### PR TITLE
Add confidence annotations and wildcard import resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Confidence annotations for `refs` output (High/Medium/Low) based on import resolution
+  - **High**: reference is in the same package or has an explicit import
+  - **Medium**: reference has a wildcard import (`import pkg._`) matching the target's package
+  - **Low**: no matching import found
+- `refs --categorize` groups by confidence level, then by category
+- `refs` (non-categorized) sorts by confidence with section headers
+- Wildcard import resolution in `imports` command — `import com.example._` now surfaces when searching for symbols in `com.example`
+
+## [1.0.0] — 2025-05-20
+
+### Added
+- Initial release
+- Symbol search, find definitions, find references, find implementations
+- Import graph (`imports` command)
+- File symbols and package listing
+- Batch mode for multiple queries
+- OID-based binary caching with bloom filters
+- Categorized references (`--categorize` flag)
+- Scala 2 and Scala 3 dialect support
+- GraalVM native image build
+- Claude Code plugin structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Scalex is a Scala code intelligence CLI for AI agents. It provides fast symbol search, find definitions, and find references — without requiring an IDE, build server, or compilation. Designed as a Claude Code plugin.
 
+## Workflow
+
+- Before planning or implementing any feature, first add it to `docs/ROADMAP.md` under the appropriate section
+- The roadmap is the source of truth for what's planned and what's done
+
 ## Build & Run
 
 ```bash
@@ -67,7 +72,8 @@ The SKILL.md contains a version-aware setup block (`EXPECTED_VERSION`) that must
 
 1. Bump `ScalexVersion` in `scalex.scala`
 2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/SKILL.md`
-3. Tag as `vX.Y.Z` and push — GitHub Actions builds native binaries for macOS ARM64, macOS x64, Linux x64 and creates a release
+3. Move `[Unreleased]` section in `CHANGELOG.md` to the new version
+4. Tag as `vX.Y.Z` and push — GitHub Actions builds native binaries for macOS ARM64, macOS x64, Linux x64 and creates a release
 
 ## Gotchas
 
@@ -77,3 +83,5 @@ The SKILL.md contains a version-aware setup block (`EXPECTED_VERSION`) that must
 - **Scalameta Tree**: `.collect` doesn't work on Tree in Scala 3 — use manual `traverse` + `visit` pattern
 - **Anonymous givens**: Only named givens are indexed; anonymous givens are skipped
 - **`refs`/`imports` use text search**: They use bloom filters to shortlist candidate files, then do word-boundary text matching. They are NOT index-based and have a 20-second timeout.
+- **Scala 3 indentation in `WorkspaceIndex`**: Deeply nested code can break method boundaries — use brace syntax for nested blocks
+- **Test fixture file counts**: Tests hardcode file counts — adding/removing fixtures requires updating all count assertions

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,6 +79,19 @@
 
 ## Future
 
+### Import-scoped confidence annotation — DONE
+- [x] Annotate `refs` results with confidence (High/Medium/Low) based on file's imports
+  - **High**: explicit import match or same package
+  - **Medium**: wildcard import (`import pkg._`/`import pkg.*`) of a package containing the symbol
+  - **Low**: no matching import (could be fully qualified, re-export, etc.)
+- [x] Resolve wildcard imports in `imports` command using existing package→symbol data
+- [x] All results kept (zero false negatives) — confidence used to sort/group, not filter
+
+### Import alias tracking
+- [ ] Detect `import X as Y` (Scala 3) and `import {X => Y}` (Scala 2) as High confidence matches
+- [ ] Follow aliases: when searching `refs X`, also search for `Y` in files that alias `X as Y`
+
+### Other
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)
 - [ ] `scalex hierarchy <class>` — show full class hierarchy (parents + children)
 - [ ] Publish plugin to Claude Code marketplace

--- a/scalex.scala
+++ b/scalex.scala
@@ -58,6 +58,9 @@ enum RefCategory:
 
 case class CategorizedRef(ref: Reference, category: RefCategory)
 
+enum Confidence:
+  case High, Medium, Low
+
 // ── Git ─────────────────────────────────────────────────────────────────────
 
 def gitLsFiles(workspace: Path): List[GitFile] =
@@ -335,6 +338,9 @@ class WorkspaceIndex(val workspace: Path):
   private var indexedFiles: List[IndexedFile] = Nil
   private var parentIndex: Map[String, List[SymbolInfo]] = Map.empty
 
+  private var packageToSymbols: Map[String, Set[String]] = Map.empty
+  private var indexedByPath: Map[String, IndexedFile] = Map.empty
+
   var fileCount: Int = 0
   var indexTimeMs: Long = 0
   var parsedCount: Int = 0
@@ -401,6 +407,8 @@ class WorkspaceIndex(val workspace: Path):
       }
     }
     parentIndex = pIdx.map((k, v) => k -> v.toList).toMap
+    packageToSymbols = symbols.groupBy(_.packageName).map((k, v) => k -> v.map(_.name).toSet)
+    indexedByPath = indexedFiles.map(f => f.relativePath -> f).toMap
     indexTimeMs = (System.nanoTime() - t0) / 1_000_000
 
     IndexPersistence.save(workspace, indexedFiles)
@@ -478,6 +486,7 @@ class WorkspaceIndex(val workspace: Path):
     val deadline = System.nanoTime() + timeoutMs * 1_000_000
     timedOut = false
     val results = ConcurrentLinkedQueue[Reference]()
+    val resultPaths = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
     candidates.asJava.parallelStream().forEach { idxFile =>
       if System.nanoTime() < deadline then
         val path = workspace.resolve(idxFile.relativePath)
@@ -486,11 +495,62 @@ class WorkspaceIndex(val workspace: Path):
         lines.zipWithIndex.foreach {
           case (line, idx) if System.nanoTime() < deadline && line.trim.startsWith("import ") && containsWord(line, name) =>
             results.add(Reference(path, idx + 1, line.trim))
+            resultPaths.add(s"${idxFile.relativePath}:${idx + 1}")
           case _ =>
         }
       else timedOut = true
     }
+
+    // Also find wildcard imports that resolve to a package containing the target symbol
+    val targetPkgs = symbolsByName.getOrElse(name.toLowerCase, Nil).map(_.packageName).toSet
+    if targetPkgs.nonEmpty then
+      for idxFile <- indexedFiles if System.nanoTime() < deadline do
+        for imp <- idxFile.imports do
+          val trimmed = imp.trim.stripPrefix("import ")
+          if (trimmed.endsWith("._") || trimmed.endsWith(".*")) then
+            val pkg = trimmed.dropRight(2)
+            if targetPkgs.contains(pkg) then
+              val path = workspace.resolve(idxFile.relativePath)
+              try {
+                val lines = Files.readAllLines(path).asScala
+                lines.zipWithIndex.foreach { case (line, lineIdx) =>
+                  if line.trim == imp.trim then
+                    val key = s"${idxFile.relativePath}:${lineIdx + 1}"
+                    if !resultPaths.contains(key) then
+                      results.add(Reference(path, lineIdx + 1, line.trim))
+                      resultPaths.add(key)
+                }
+              } catch { case _: Exception => () }
+
     results.asScala.toList
+
+  private def filePackage(idxFile: IndexedFile): String =
+    idxFile.symbols.headOption.map(_.packageName).getOrElse("")
+
+  def resolveConfidence(ref: Reference, targetName: String, targetPackages: Set[String]): Confidence =
+    val relPath = workspace.relativize(ref.file).toString
+    indexedByPath.get(relPath) match
+      case None => Confidence.Low
+      case Some(idxFile) =>
+        val filePkg = filePackage(idxFile)
+        if targetPackages.contains(filePkg) then Confidence.High
+        else
+          val imports = idxFile.imports
+          val hasExplicit = imports.exists { imp =>
+            imp.contains(s".$targetName") || imp.contains(s"{$targetName") ||
+            imp.contains(s", $targetName") || imp.contains(s"$targetName,")
+          }
+          if hasExplicit then Confidence.High
+          else
+            val hasWildcard = imports.exists { imp =>
+              val trimmed = imp.trim.stripPrefix("import ")
+              (trimmed.endsWith("._") || trimmed.endsWith(".*")) && {
+                val pkg = trimmed.dropRight(2)
+                targetPackages.contains(pkg)
+              }
+            }
+            if hasWildcard then Confidence.Medium
+            else Confidence.Low
 
   private def containsWord(line: String, word: String): Boolean =
     var i = line.indexOf(word)
@@ -596,25 +656,54 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       rest.headOption match
         case None => println("Usage: scalex refs <symbol>")
         case Some(symbol) =>
+          val targetPkgs = idx.symbolsByName.getOrElse(symbol.toLowerCase, Nil).map(_.packageName).toSet
           if categorize then
             val grouped = idx.categorizeReferences(symbol)
             val total = grouped.values.map(_.size).sum
             val suffix = if idx.timedOut then " (timed out — partial results)" else ""
             println(s"References to \"$symbol\" — $total found:$suffix")
-            val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
-                             RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
-            order.foreach { cat =>
-              grouped.get(cat).filter(_.nonEmpty).foreach { refs =>
-                println(s"\n  ${cat.toString}:")
-                refs.take(limit).foreach(r => println(s"  ${formatRef(r, workspace)}"))
-                if refs.size > limit then println(s"    ... and ${refs.size - limit} more")
-              }
+            val confidenceOrder = List(Confidence.High, Confidence.Medium, Confidence.Low)
+            confidenceOrder.foreach { conf =>
+              val catRefs = grouped.flatMap { (cat, refs) =>
+                refs.map(r => (cat, r, idx.resolveConfidence(r, symbol, targetPkgs)))
+              }.filter(_._3 == conf).toList
+              if catRefs.nonEmpty then
+                val label = conf match
+                  case Confidence.High   => "High confidence (import-matched)"
+                  case Confidence.Medium => "Medium confidence (wildcard import)"
+                  case Confidence.Low    => "Low confidence (no matching import)"
+                println(s"\n  $label:")
+                val byCat = catRefs.groupBy(_._1)
+                val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
+                                 RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
+                order.foreach { cat =>
+                  byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
+                    println(s"\n    ${cat.toString}:")
+                    entries.take(limit).foreach((_, r, _) => println(s"    ${formatRef(r, workspace)}"))
+                    if entries.size > limit then println(s"      ... and ${entries.size - limit} more")
+                  }
+                }
             }
           else
             val results = idx.findReferences(symbol)
             val suffix = if idx.timedOut then " (timed out — partial results)" else ""
             println(s"References to \"$symbol\" — ${results.size} found:$suffix")
-            results.take(limit).foreach(r => println(formatRef(r, workspace)))
+            val annotated = results.map(r => (r, idx.resolveConfidence(r, symbol, targetPkgs)))
+            val sorted = annotated.sortBy { case (_, c) => c.ordinal }
+            var lastConf: Option[Confidence] = None
+            var shown = 0
+            sorted.foreach { case (r, conf) =>
+              if shown < limit then
+                if !lastConf.contains(conf) then
+                  val label = conf match
+                    case Confidence.High   => "High confidence"
+                    case Confidence.Medium => "Medium confidence"
+                    case Confidence.Low    => "Low confidence"
+                  println(s"\n  [$label]")
+                  lastConf = Some(conf)
+                println(formatRef(r, workspace))
+                shown += 1
+            }
             if results.size > limit then println(s"  ... and ${results.size - limit} more")
 
     case "imports" =>

--- a/scalex.test.scala
+++ b/scalex.test.scala
@@ -87,6 +87,34 @@ class ScalexSuite extends FunSuite:
         |}
         |""".stripMargin)
 
+    writeFile("src/main/scala/com/client/ExplicitClient.scala",
+      """package com.client
+        |
+        |import com.example.UserService
+        |
+        |class ExplicitClient {
+        |  val svc: UserService = ???
+        |}
+        |""".stripMargin)
+
+    writeFile("src/main/scala/com/client/WildcardClient.scala",
+      """package com.client
+        |
+        |import com.example._
+        |
+        |class WildcardClient {
+        |  val svc: UserService = ???
+        |}
+        |""".stripMargin)
+
+    writeFile("src/main/scala/com/unrelated/NoImportClient.scala",
+      """package com.unrelated
+        |
+        |class NoImportClient {
+        |  val svc: UserService = ???
+        |}
+        |""".stripMargin)
+
     // Initialize git repo
     run("git", "init")
     run("git", "add", ".")
@@ -118,12 +146,15 @@ class ScalexSuite extends FunSuite:
 
   test("gitLsFiles finds all .scala files") {
     val files = gitLsFiles(workspace)
-    assertEquals(files.size, 5)
+    assertEquals(files.size, 8)
     assert(files.exists(_.path.toString.contains("UserService.scala")))
     assert(files.exists(_.path.toString.contains("Model.scala")))
     assert(files.exists(_.path.toString.contains("Database.scala")))
     assert(files.exists(_.path.toString.contains("Helper.scala")))
     assert(files.exists(_.path.toString.contains("UserServiceSpec.scala")))
+    assert(files.exists(_.path.toString.contains("ExplicitClient.scala")))
+    assert(files.exists(_.path.toString.contains("WildcardClient.scala")))
+    assert(files.exists(_.path.toString.contains("NoImportClient.scala")))
   }
 
   test("gitLsFiles returns valid OIDs") {
@@ -227,7 +258,7 @@ class ScalexSuite extends FunSuite:
     val idx = WorkspaceIndex(workspace)
     idx.index()
 
-    assert(idx.fileCount == 5)
+    assert(idx.fileCount == 8)
     assert(idx.symbols.size > 10)
     assert(idx.packages.contains("com.example"))
     assert(idx.packages.contains("com.other"))
@@ -370,13 +401,13 @@ class ScalexSuite extends FunSuite:
     // First index — cold
     val idx1 = WorkspaceIndex(workspace)
     idx1.index()
-    assert(idx1.parsedCount == 5, s"Cold index should parse all 5 files, got ${idx1.parsedCount}")
+    assert(idx1.parsedCount == 8, s"Cold index should parse all 8 files, got ${idx1.parsedCount}")
 
     // Second index — warm (all cached)
     val idx2 = WorkspaceIndex(workspace)
     idx2.index()
     assert(idx2.cachedLoad, "Second index should load from cache")
-    assert(idx2.skippedCount == 5, s"Warm index should skip all 5 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 8, s"Warm index should skip all 8 files, got ${idx2.skippedCount}")
     assert(idx2.parsedCount == 0, s"Warm index should parse 0 files, got ${idx2.parsedCount}")
 
     // Symbols should be identical
@@ -400,7 +431,7 @@ class ScalexSuite extends FunSuite:
     idx2.index()
     assert(idx2.cachedLoad)
     assert(idx2.parsedCount == 1, s"Should re-parse 1 file, got ${idx2.parsedCount}")
-    assert(idx2.skippedCount == 4, s"Should skip 4 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 7, s"Should skip 7 files, got ${idx2.skippedCount}")
   }
 
   // ── Binary format ─────────────────────────────────────────────────────
@@ -671,4 +702,75 @@ class ScalexSuite extends FunSuite:
     Files.delete(scala2File)
     run("git", "add", ".")
     run("git", "commit", "-m", "remove legacy")
+  }
+
+  // ── Confidence annotation ────────────────────────────────────────────
+
+  test("resolveConfidence returns High for same-package references") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // UserServiceSpec is in com.example, same as UserService definition
+    val refs = idx.findReferences("UserService")
+    val specRef = refs.find(r => workspace.relativize(r.file).toString.contains("UserServiceSpec.scala"))
+    assert(specRef.isDefined, "Should find ref in UserServiceSpec")
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(specRef.get, "UserService", targetPkgs)
+    assertEquals(conf, Confidence.High)
+  }
+
+  test("resolveConfidence returns High for explicit import") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val clientRef = refs.find(r => workspace.relativize(r.file).toString.contains("ExplicitClient.scala"))
+    assert(clientRef.isDefined, "Should find ref in ExplicitClient")
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(clientRef.get, "UserService", targetPkgs)
+    assertEquals(conf, Confidence.High)
+  }
+
+  test("resolveConfidence returns Medium for wildcard import") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val wcRef = refs.find(r => workspace.relativize(r.file).toString.contains("WildcardClient.scala"))
+    assert(wcRef.isDefined, "Should find ref in WildcardClient")
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(wcRef.get, "UserService", targetPkgs)
+    assertEquals(conf, Confidence.Medium)
+  }
+
+  test("resolveConfidence returns Low for no matching import") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val noImpRef = refs.find(r => workspace.relativize(r.file).toString.contains("NoImportClient.scala"))
+    assert(noImpRef.isDefined, "Should find ref in NoImportClient")
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(noImpRef.get, "UserService", targetPkgs)
+    assertEquals(conf, Confidence.Low)
+  }
+
+  // ── Wildcard import resolution ───────────────────────────────────────
+
+  test("findImports finds wildcard imports that match target package") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val results = idx.findImports("UserService")
+    // Should find explicit import in ExplicitClient AND wildcard import in WildcardClient
+    val files = results.map(r => workspace.relativize(r.file).toString)
+    assert(files.exists(_.contains("ExplicitClient.scala")),
+      s"Should find explicit import: $files")
+    assert(files.exists(_.contains("WildcardClient.scala")),
+      s"Should find wildcard import: ${files}")
+  }
+
+  test("findImports wildcard result contains the wildcard import line") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val results = idx.findImports("UserService")
+    val wcResult = results.find(r => workspace.relativize(r.file).toString.contains("WildcardClient.scala"))
+    assert(wcResult.isDefined, "Should find wildcard import result")
+    assert(wcResult.get.contextLine.contains("import com.example._"),
+      s"Should contain wildcard import line: ${wcResult.get.contextLine}")
   }


### PR DESCRIPTION
## Summary
- Annotate `refs` output with **High/Medium/Low confidence** based on import resolution (same package, explicit import, wildcard import, or no match)
- Resolve **wildcard imports** (`import pkg._`) in the `imports` command using indexed package→symbol data
- All results kept (zero false negatives) — confidence is used to sort/group, not filter
- Add `CHANGELOG.md` with `[Unreleased]` workflow
- Update `CLAUDE.md` with workflow rules and new gotchas
- Update `docs/ROADMAP.md` — mark confidence annotation items as done

## Test plan
- [x] All 52 tests pass (`scala-cli test scalex.scala scalex.test.scala`)
- [x] 6 new tests: confidence High (same-package, explicit import), Medium (wildcard), Low (no import), wildcard import discovery
- [x] Manual test: `scalex refs WorkspaceIndex` shows `[High confidence]` grouping
- [x] Manual test: `scalex refs SymbolKind --categorize` shows confidence → category hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)