### PR TITLE
Add import alias tracking for refs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - `refs --categorize` groups by confidence level, then by category
 - `refs` (non-categorized) sorts by confidence with section headers
 - Wildcard import resolution in `imports` command — `import com.example._` now surfaces when searching for symbols in `com.example`
+- Import alias tracking — `import X as Y` (Scala 3) and `import {X => Y}` (Scala 2) are now detected and followed
+  - `refs X` also finds usages of alias `Y` in files that rename the import
+  - Alias imports are classified as High confidence
+  - Aliases survive binary cache roundtrip (index format bumped to v4)
 
 ## [1.0.0] — 2025-05-20
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,7 +58,7 @@
 
 ## Phase 8: Testing — DONE
 
-- [x] 46 MUnit tests covering all features
+- [x] 57 MUnit tests covering all features
 - [x] Scala 3 symbol extraction (class, trait, object, def, val, type, enum, given, extension)
 - [x] Scala 2 fallback (procedure syntax, implicit class, mixed projects)
 - [x] Binary persistence roundtrip (parents, signatures survive save/load)
@@ -87,9 +87,9 @@
 - [x] Resolve wildcard imports in `imports` command using existing package→symbol data
 - [x] All results kept (zero false negatives) — confidence used to sort/group, not filter
 
-### Import alias tracking
-- [ ] Detect `import X as Y` (Scala 3) and `import {X => Y}` (Scala 2) as High confidence matches
-- [ ] Follow aliases: when searching `refs X`, also search for `Y` in files that alias `X as Y`
+### Import alias tracking — DONE
+- [x] Detect `import X as Y` (Scala 3) and `import {X => Y}` (Scala 2) as High confidence matches
+- [x] Follow aliases: when searching `refs X`, also search for `Y` in files that alias `X as Y`
 
 ### Other
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)

--- a/scalex.scala
+++ b/scalex.scala
@@ -50,7 +50,8 @@ case class IndexedFile(
     oid: String,
     symbols: List[SymbolInfo],
     identifierBloom: BloomFilter[CharSequence],
-    imports: List[String] = Nil
+    imports: List[String] = Nil,
+    aliases: Map[String, String] = Map.empty
 )
 
 enum RefCategory:
@@ -115,21 +116,29 @@ private def buildSignature(name: String, kind: String, parents: List[String], tp
   val ext = if parents.nonEmpty then s" extends ${parents.mkString(" with ")}" else ""
   s"$kind $name$tps$ext"
 
-private def extractImports(tree: Tree): List[String] =
+private def extractImports(tree: Tree): (List[String], Map[String, String]) =
   val buf = mutable.ListBuffer.empty[String]
+  val aliases = mutable.Map.empty[String, String]
   def visit(t: Tree): Unit =
     t match
-      case i: Import => buf += i.toString()
+      case i: Import =>
+        buf += i.toString()
+        i.importers.foreach { importer =>
+          importer.importees.foreach {
+            case r: Importee.Rename => aliases(r.name.value) = r.rename.value
+            case _ =>
+          }
+        }
       case _ =>
     t.children.foreach(visit)
   visit(tree)
-  buf.toList
+  (buf.toList, aliases.toMap)
 
-def extractSymbols(file: Path): (List[SymbolInfo], BloomFilter[CharSequence], List[String]) =
+def extractSymbols(file: Path): (List[SymbolInfo], BloomFilter[CharSequence], List[String], Map[String, String]) =
   val bloom = buildBloomFilter(file)
 
   val source = try Files.readString(file) catch
-    case _: Exception => return (Nil, bloom, Nil)
+    case _: Exception => return (Nil, bloom, Nil, Map.empty)
 
   val input = Input.VirtualFile(file.toString, source)
   val tree = try
@@ -141,10 +150,10 @@ def extractSymbols(file: Path): (List[SymbolInfo], BloomFilter[CharSequence], Li
         given scala.meta.Dialect = scala.meta.dialects.Scala213
         input.parse[Source].get
       catch
-        case _: Exception => return (Nil, bloom, Nil)
+        case _: Exception => return (Nil, bloom, Nil, Map.empty)
 
   val pkg = tree.children.collectFirst { case p: Pkg => p.ref.toString() }.getOrElse("")
-  val imports = extractImports(tree)
+  val (imports, aliases) = extractImports(tree)
   val buf = mutable.ListBuffer.empty[SymbolInfo]
 
   def visit(t: Tree): Unit = t match
@@ -201,13 +210,13 @@ def extractSymbols(file: Path): (List[SymbolInfo], BloomFilter[CharSequence], Li
     t.children.foreach(traverse)
 
   traverse(tree)
-  (buf.toList, bloom, imports)
+  (buf.toList, bloom, imports, aliases)
 
 // ── Binary persistence ──────────────────────────────────────────────────────
 
 object IndexPersistence:
   private val MAGIC = 0x53584458
-  private val VERSION: Byte = 3
+  private val VERSION: Byte = 4
 
   def indexPath(workspace: Path): Path = workspace.resolve(".scalex").resolve("index.bin")
 
@@ -229,6 +238,7 @@ object IndexPersistence:
         s.parents.foreach(intern)
       }
       f.imports.foreach(intern)
+      f.aliases.foreach { (k, v) => intern(k); intern(v) }
     }
 
     val out = DataOutputStream(BufferedOutputStream(Files.newOutputStream(indexPath(workspace)), 1 << 16))
@@ -259,6 +269,13 @@ object IndexPersistence:
         // Imports
         out.writeShort(f.imports.size)
         f.imports.foreach(i => out.writeInt(intern(i)))
+
+        // Aliases
+        out.writeShort(f.aliases.size)
+        f.aliases.foreach { (k, v) =>
+          out.writeInt(intern(k))
+          out.writeInt(intern(v))
+        }
 
         // Bloom filter
         val bloomBytes = java.io.ByteArrayOutputStream()
@@ -310,6 +327,14 @@ object IndexPersistence:
           val importCount = in.readShort()
           val imports = (0 until importCount).map(_ => strings(in.readInt())).toList
 
+          // Aliases
+          val aliasCount = in.readShort()
+          val aliases = (0 until aliasCount).map { _ =>
+            val k = strings(in.readInt())
+            val v = strings(in.readInt())
+            k -> v
+          }.toMap
+
           // Bloom filter
           val bloomLen = in.readInt()
           val bloomBytes = new Array[Byte](bloomLen)
@@ -319,7 +344,7 @@ object IndexPersistence:
             Funnels.unencodedCharsFunnel()
           )
 
-          result(relPath) = IndexedFile(relPath, oid, syms.result(), bloom, imports)
+          result(relPath) = IndexedFile(relPath, oid, syms.result(), bloom, imports, aliases)
           fi += 1
 
         Some(result.toMap)
@@ -340,6 +365,7 @@ class WorkspaceIndex(val workspace: Path):
 
   private var packageToSymbols: Map[String, Set[String]] = Map.empty
   private var indexedByPath: Map[String, IndexedFile] = Map.empty
+  private var aliasIndex: Map[String, List[(IndexedFile, String)]] = Map.empty
 
   var fileCount: Int = 0
   var indexTimeMs: Long = 0
@@ -374,8 +400,8 @@ class WorkspaceIndex(val workspace: Path):
 
         toParse.asJava.parallelStream().forEach { gf =>
           val rel = workspace.relativize(gf.path).toString
-          val (syms, bloom, imports) = extractSymbols(gf.path)
-          toParseQueue.add(IndexedFile(rel, gf.oid, syms, bloom, imports))
+          val (syms, bloom, imports, aliases) = extractSymbols(gf.path)
+          toParseQueue.add(IndexedFile(rel, gf.oid, syms, bloom, imports, aliases))
         }
         result ++= toParseQueue.asScala
         parsedCount = toParse.size
@@ -384,8 +410,8 @@ class WorkspaceIndex(val workspace: Path):
         val queue = ConcurrentLinkedQueue[IndexedFile]()
         gitFiles.asJava.parallelStream().forEach { gf =>
           val rel = workspace.relativize(gf.path).toString
-          val (syms, bloom, imports) = extractSymbols(gf.path)
-          queue.add(IndexedFile(rel, gf.oid, syms, bloom, imports))
+          val (syms, bloom, imports, aliases) = extractSymbols(gf.path)
+          queue.add(IndexedFile(rel, gf.oid, syms, bloom, imports, aliases))
         }
         result ++= queue.asScala
         parsedCount = gitFiles.size
@@ -409,6 +435,13 @@ class WorkspaceIndex(val workspace: Path):
     parentIndex = pIdx.map((k, v) => k -> v.toList).toMap
     packageToSymbols = symbols.groupBy(_.packageName).map((k, v) => k -> v.map(_.name).toSet)
     indexedByPath = indexedFiles.map(f => f.relativePath -> f).toMap
+    val aIdx = mutable.HashMap.empty[String, mutable.ListBuffer[(IndexedFile, String)]]
+    indexedFiles.foreach { f =>
+      f.aliases.foreach { (orig, alias) =>
+        aIdx.getOrElseUpdate(orig, mutable.ListBuffer.empty) += ((f, alias))
+      }
+    }
+    aliasIndex = aIdx.map((k, v) => k -> v.toList).toMap
     indexTimeMs = (System.nanoTime() - t0) / 1_000_000
 
     IndexPersistence.save(workspace, indexedFiles)
@@ -443,17 +476,33 @@ class WorkspaceIndex(val workspace: Path):
 
   def findReferences(name: String, timeoutMs: Long = defaultTimeoutMs): List[Reference] =
     val candidates = indexedFiles.filter(_.identifierBloom.mightContain(name))
+    val aliasFiles = aliasIndex.getOrElse(name, Nil)
+    val candidateSet = candidates.map(_.relativePath).toSet
+    val extraFiles = aliasFiles.collect {
+      case (f, _) if !candidateSet.contains(f.relativePath) => f
+    }
+    val allCandidates = candidates ++ extraFiles
+    val fileAliasMap = aliasFiles.map((f, alias) => f.relativePath -> alias).toMap
+
     val deadline = System.nanoTime() + timeoutMs * 1_000_000
     timedOut = false
     val results = ConcurrentLinkedQueue[Reference]()
-    candidates.asJava.parallelStream().forEach { idxFile =>
+    val seen = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
+    allCandidates.asJava.parallelStream().forEach { idxFile =>
       if System.nanoTime() < deadline then
         val path = workspace.resolve(idxFile.relativePath)
         val lines = try Files.readAllLines(path).asScala catch
           case _: Exception => Seq.empty
+        val aliasName = fileAliasMap.get(idxFile.relativePath)
         lines.zipWithIndex.foreach {
-          case (line, idx) if System.nanoTime() < deadline && containsWord(line, name) =>
-            results.add(Reference(path, idx + 1, line.trim))
+          case (line, idx) if System.nanoTime() < deadline =>
+            val key = s"${idxFile.relativePath}:${idx + 1}"
+            if containsWord(line, name) && seen.add(key) then
+              results.add(Reference(path, idx + 1, line.trim))
+            else aliasName match
+              case Some(alias) if containsWord(line, alias) && seen.add(key) =>
+                results.add(Reference(path, idx + 1, line.trim))
+              case _ =>
           case _ =>
         }
       else timedOut = true

--- a/scalex.test.scala
+++ b/scalex.test.scala
@@ -115,6 +115,18 @@ class ScalexSuite extends FunSuite:
         |}
         |""".stripMargin)
 
+    writeFile("src/main/scala/com/client/AliasClient.scala",
+      """package com.client
+        |
+        |import com.example.UserService as US
+        |import com.example.{Database as DB}
+        |
+        |class AliasClient {
+        |  val svc: US = ???
+        |  val db: DB = ???
+        |}
+        |""".stripMargin)
+
     // Initialize git repo
     run("git", "init")
     run("git", "add", ".")
@@ -146,7 +158,7 @@ class ScalexSuite extends FunSuite:
 
   test("gitLsFiles finds all .scala files") {
     val files = gitLsFiles(workspace)
-    assertEquals(files.size, 8)
+    assertEquals(files.size, 9)
     assert(files.exists(_.path.toString.contains("UserService.scala")))
     assert(files.exists(_.path.toString.contains("Model.scala")))
     assert(files.exists(_.path.toString.contains("Database.scala")))
@@ -155,6 +167,7 @@ class ScalexSuite extends FunSuite:
     assert(files.exists(_.path.toString.contains("ExplicitClient.scala")))
     assert(files.exists(_.path.toString.contains("WildcardClient.scala")))
     assert(files.exists(_.path.toString.contains("NoImportClient.scala")))
+    assert(files.exists(_.path.toString.contains("AliasClient.scala")))
   }
 
   test("gitLsFiles returns valid OIDs") {
@@ -169,7 +182,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols finds classes, traits, objects") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     val names = syms.map(s => (s.name, s.kind))
 
     assert(names.contains(("UserService", SymbolKind.Trait)))
@@ -179,7 +192,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols finds defs") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     val defs = syms.filter(_.kind == SymbolKind.Def).map(_.name)
 
     assert(defs.contains("findUser"))
@@ -188,37 +201,37 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols finds enums") {
     val file = workspace.resolve("src/main/scala/com/example/Model.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     assert(syms.exists(s => s.name == "Role" && s.kind == SymbolKind.Enum))
   }
 
   test("extractSymbols finds type aliases") {
     val file = workspace.resolve("src/main/scala/com/example/Model.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     assert(syms.exists(s => s.name == "UserId" && s.kind == SymbolKind.Type))
   }
 
   test("extractSymbols finds givens") {
     val file = workspace.resolve("src/main/scala/com/example/Model.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     assert(syms.exists(s => s.kind == SymbolKind.Given))
   }
 
   test("extractSymbols finds extensions") {
     val file = workspace.resolve("src/main/scala/com/other/Helper.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     assert(syms.exists(s => s.kind == SymbolKind.Extension))
   }
 
   test("extractSymbols captures package name") {
     val file = workspace.resolve("src/main/scala/com/example/Model.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     assert(syms.forall(_.packageName == "com.example"))
   }
 
   test("extractSymbols captures line numbers") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     val traitSym = syms.find(s => s.name == "UserService" && s.kind == SymbolKind.Trait).get
     assert(traitSym.line > 0)
   }
@@ -226,7 +239,7 @@ class ScalexSuite extends FunSuite:
   test("extractSymbols handles unparseable files gracefully") {
     val bad = workspace.resolve("bad.scala")
     Files.writeString(bad, "this is not valid scala {{{")
-    val (syms, _, _) = extractSymbols(bad)
+    val (syms, _, _, _) = extractSymbols(bad)
     assertEquals(syms, Nil)
     Files.delete(bad)
   }
@@ -235,7 +248,7 @@ class ScalexSuite extends FunSuite:
 
   test("bloom filter contains identifiers from file") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (_, bloom, _) = extractSymbols(file)
+    val (_, bloom, _, _) = extractSymbols(file)
 
     assert(bloom.mightContain("UserService"))
     assert(bloom.mightContain("findUser"))
@@ -245,7 +258,7 @@ class ScalexSuite extends FunSuite:
 
   test("bloom filter rejects absent identifiers") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (_, bloom, _) = extractSymbols(file)
+    val (_, bloom, _, _) = extractSymbols(file)
 
     // These should almost certainly not be in the bloom filter
     assert(!bloom.mightContain("ZxQwVeryUnlikelyIdentifier"))
@@ -258,7 +271,7 @@ class ScalexSuite extends FunSuite:
     val idx = WorkspaceIndex(workspace)
     idx.index()
 
-    assert(idx.fileCount == 8)
+    assert(idx.fileCount == 9)
     assert(idx.symbols.size > 10)
     assert(idx.packages.contains("com.example"))
     assert(idx.packages.contains("com.other"))
@@ -401,13 +414,13 @@ class ScalexSuite extends FunSuite:
     // First index — cold
     val idx1 = WorkspaceIndex(workspace)
     idx1.index()
-    assert(idx1.parsedCount == 8, s"Cold index should parse all 8 files, got ${idx1.parsedCount}")
+    assert(idx1.parsedCount == 9, s"Cold index should parse all 9 files, got ${idx1.parsedCount}")
 
     // Second index — warm (all cached)
     val idx2 = WorkspaceIndex(workspace)
     idx2.index()
     assert(idx2.cachedLoad, "Second index should load from cache")
-    assert(idx2.skippedCount == 8, s"Warm index should skip all 8 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 9, s"Warm index should skip all 9 files, got ${idx2.skippedCount}")
     assert(idx2.parsedCount == 0, s"Warm index should parse 0 files, got ${idx2.parsedCount}")
 
     // Symbols should be identical
@@ -431,7 +444,7 @@ class ScalexSuite extends FunSuite:
     idx2.index()
     assert(idx2.cachedLoad)
     assert(idx2.parsedCount == 1, s"Should re-parse 1 file, got ${idx2.parsedCount}")
-    assert(idx2.skippedCount == 7, s"Should skip 7 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 8, s"Should skip 8 files, got ${idx2.skippedCount}")
   }
 
   // ── Binary format ─────────────────────────────────────────────────────
@@ -479,7 +492,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols captures signatures") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
 
     val traitSym = syms.find(s => s.name == "UserService" && s.kind == SymbolKind.Trait).get
     assert(traitSym.signature.nonEmpty, "Trait should have a signature")
@@ -488,7 +501,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols captures extends parents") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
 
     val classSym = syms.find(s => s.name == "UserServiceLive" && s.kind == SymbolKind.Class).get
     assert(classSym.parents.contains("UserService"), s"Parents: ${classSym.parents}")
@@ -496,7 +509,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols captures def signatures with params") {
     val file = workspace.resolve("src/main/scala/com/example/UserService.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
 
     val defSym = syms.find(s => s.name == "findUser" && s.kind == SymbolKind.Def).get
     assert(defSym.signature.contains("def findUser"), s"Sig: ${defSym.signature}")
@@ -505,7 +518,7 @@ class ScalexSuite extends FunSuite:
 
   test("extractSymbols captures given alias signatures") {
     val file = workspace.resolve("src/main/scala/com/example/Model.scala")
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
 
     val givenSym = syms.find(s => s.kind == SymbolKind.Given).get
     assert(givenSym.signature.contains("given"), s"Sig: ${givenSym.signature}")
@@ -515,7 +528,7 @@ class ScalexSuite extends FunSuite:
   test("extractSymbols captures imports") {
     // UserServiceSpec imports UserService
     val file = workspace.resolve("src/test/scala/com/example/UserServiceSpec.scala")
-    val (_, _, imports) = extractSymbols(file)
+    val (_, _, imports, _) = extractSymbols(file)
     // This file doesn't have imports in our test data, but the function should return empty list not crash
     assert(imports != null)
   }
@@ -639,7 +652,7 @@ class ScalexSuite extends FunSuite:
         |}
         |""".stripMargin)
 
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     val names = syms.map(_.name)
     assert(names.contains("OldService"), s"Should find OldService class: $names")
     assert(syms.exists(s => s.name == "OldService" && s.kind == SymbolKind.Class))
@@ -663,7 +676,7 @@ class ScalexSuite extends FunSuite:
         |}
         |""".stripMargin)
 
-    val (syms, _, _) = extractSymbols(file)
+    val (syms, _, _, _) = extractSymbols(file)
     val names = syms.map(_.name)
     assert(names.contains("Implicits"), s"Should find Implicits object: $names")
     assert(names.contains("RichString"), s"Should find RichString class: $names")
@@ -773,4 +786,65 @@ class ScalexSuite extends FunSuite:
     assert(wcResult.isDefined, "Should find wildcard import result")
     assert(wcResult.get.contextLine.contains("import com.example._"),
       s"Should contain wildcard import line: ${wcResult.get.contextLine}")
+  }
+
+  // ── Import alias tracking ──────────────────────────────────────────
+
+  test("extractSymbols extracts import aliases") {
+    val file = workspace.resolve("src/main/scala/com/client/AliasClient.scala")
+    val (_, _, _, aliases) = extractSymbols(file)
+    assertEquals(aliases.get("UserService"), Some("US"))
+    assertEquals(aliases.get("Database"), Some("DB"))
+  }
+
+  test("findReferences follows aliases") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val aliasRefs = refs.filter(r =>
+      workspace.relativize(r.file).toString.contains("AliasClient.scala"))
+    // Should find import line (contains "UserService") AND usage lines (contain "US")
+    assert(aliasRefs.exists(_.contextLine.contains("US")),
+      s"Should find alias usage 'US': ${aliasRefs.map(_.contextLine)}")
+  }
+
+  test("findReferences follows aliases for Database") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("Database")
+    val aliasRefs = refs.filter(r =>
+      workspace.relativize(r.file).toString.contains("AliasClient.scala"))
+    assert(aliasRefs.exists(_.contextLine.contains("DB")),
+      s"Should find alias usage 'DB': ${aliasRefs.map(_.contextLine)}")
+  }
+
+  test("resolveConfidence returns High for alias imports") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val aliasRef = refs.find { r =>
+      val rel = workspace.relativize(r.file).toString
+      rel.contains("AliasClient.scala") && r.contextLine.contains("US")
+    }
+    assert(aliasRef.isDefined, "Should find alias ref")
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(aliasRef.get, "UserService", targetPkgs)
+    assertEquals(conf, Confidence.High)
+  }
+
+  test("binary roundtrip preserves aliases") {
+    val cacheDir = workspace.resolve(".scalex")
+    if Files.exists(cacheDir) then
+      Files.list(cacheDir).iterator().asScala.foreach(Files.delete)
+
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+
+    val loaded = IndexPersistence.load(workspace)
+    assert(loaded.isDefined, "Should load from cache")
+
+    val cachedFiles = loaded.get
+    val aliasFile = cachedFiles.values.find(_.relativePath.contains("AliasClient.scala")).get
+    assertEquals(aliasFile.aliases.get("UserService"), Some("US"))
+    assertEquals(aliasFile.aliases.get("Database"), Some("DB"))
   }


### PR DESCRIPTION
## Summary

- `refs X` now also finds usages of alias `Y` in files with `import X as Y` (Scala 3) or `import {X => Y}` (Scala 2)
- Aliases extracted from Scalameta `Importee.Rename` AST nodes, persisted in binary index (format bumped v3→v4), and followed during reference search via a new `aliasIndex`
- Alias imports resolve as High confidence; 5 new tests + fixture (`AliasClient.scala`)

## Test plan

- [x] All 57 tests pass (`scala-cli test scalex.scala scalex.test.scala`)
- [ ] Verify alias detection on a real codebase with renamed imports
- [ ] Confirm old v3 caches auto-rebuild on first run (version mismatch → full reparse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)