### PR TITLE
Import alias tracking: confidence fix + annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - `refs X` also finds usages of alias `Y` in files that rename the import
   - Alias imports are classified as High confidence
   - Aliases survive binary cache roundtrip (index format bumped to v4)
+- Alias-aware confidence: `resolveConfidence` now checks alias mappings — searching by alias name (e.g. `refs TextAlignE`) returns High confidence instead of Low
+- Alias annotation in output: references found via alias show `[via alias Y]` suffix (e.g. `AliasClient.scala:6 — val svc: US = ??? [via alias US]`)
 
 ## [1.0.0] — 2025-05-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ git ls-files --stage → Scalameta parse → in-memory index → query
 - **Scalameta, not presentation compiler**: Scala 3's PC requires compiled `.class`/`.tasty` on classpath, which reintroduces build server dependency. Scalameta parses source directly.
 - **Git OIDs for caching**: Available free from `git ls-files --stage`, no disk reads needed to detect changes.
 - **No build server**: AI agents can run `./mill __.compile` directly for error checking.
+- **Feature gate question**: "Is this better than grep, or does it introduce a worst case that grep never has?" If a feature risks being slower or less reliable than grep in any scenario, don't add it. The agent can always fall back to grep — scalex must never be the worse option.
 
 ### Dependencies
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -91,6 +91,11 @@
 - [x] Detect `import X as Y` (Scala 3) and `import {X => Y}` (Scala 2) as High confidence matches
 - [x] Follow aliases: when searching `refs X`, also search for `Y` in files that alias `X as Y`
 
+### Alias tracking improvements
+- [x] Confidence for alias refs: refs found via alias are now High confidence (`resolveConfidence` checks alias names)
+- [x] Alias annotation in output: show `[via alias Y]` when a reference was found through alias tracking
+- ~~Reverse alias lookup~~: deliberately skipped — agent can do 2-step lookup (`def TextAlignE` → see alias → `refs TextAlign`), and reverse lookup risks worse-than-grep perf on large codebases
+
 ### Other
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)
 - [ ] `scalex hierarchy <class>` — show full class hierarchy (parents + children)

--- a/scalex.scala
+++ b/scalex.scala
@@ -42,7 +42,7 @@ case class SymbolInfo(
     signature: String = ""
 )
 
-case class Reference(file: Path, line: Int, contextLine: String)
+case class Reference(file: Path, line: Int, contextLine: String, aliasInfo: Option[String] = None)
 case class GitFile(path: Path, oid: String)
 
 case class IndexedFile(
@@ -501,7 +501,7 @@ class WorkspaceIndex(val workspace: Path):
               results.add(Reference(path, idx + 1, line.trim))
             else aliasName match
               case Some(alias) if containsWord(line, alias) && seen.add(key) =>
-                results.add(Reference(path, idx + 1, line.trim))
+                results.add(Reference(path, idx + 1, line.trim, Some(s"via alias $alias")))
               case _ =>
           case _ =>
         }
@@ -589,7 +589,10 @@ class WorkspaceIndex(val workspace: Path):
             imp.contains(s".$targetName") || imp.contains(s"{$targetName") ||
             imp.contains(s", $targetName") || imp.contains(s"$targetName,")
           }
-          if hasExplicit then Confidence.High
+          val hasAliasMatch = idxFile.aliases.exists { (orig, alias) =>
+            alias == targetName || orig == targetName
+          }
+          if hasExplicit || hasAliasMatch then Confidence.High
           else
             val hasWildcard = imports.exists { imp =>
               val trimmed = imp.trim.stripPrefix("import ")
@@ -625,7 +628,8 @@ def formatSymbolVerbose(s: SymbolInfo, workspace: Path): String =
 
 def formatRef(r: Reference, workspace: Path): String =
   val rel = workspace.relativize(r.file)
-  s"  $rel:${r.line} — ${r.contextLine}"
+  val alias = r.aliasInfo.map(a => s" [$a]").getOrElse("")
+  s"  $rel:${r.line} — ${r.contextLine}$alias"
 
 def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String): Unit =
   println(s"  Hint: scalex indexes ${idx.fileCount} git-tracked .scala files.")

--- a/scalex.test.scala
+++ b/scalex.test.scala
@@ -832,6 +832,38 @@ class ScalexSuite extends FunSuite:
     assertEquals(conf, Confidence.High)
   }
 
+  test("resolveConfidence returns High when searching by alias name") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // Search for "US" which is an alias for UserService — refs found in AliasClient.scala
+    // should be High confidence because the file has an alias mapping for UserService
+    val ref = Reference(
+      workspace.resolve("src/main/scala/com/client/AliasClient.scala"),
+      6, "val svc: US = ???"
+    )
+    val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
+    val conf = idx.resolveConfidence(ref, "US", targetPkgs)
+    assertEquals(conf, Confidence.High)
+  }
+
+  test("findReferences annotates aliasInfo for alias matches") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val aliasRef = refs.find { r =>
+      workspace.relativize(r.file).toString.contains("AliasClient.scala") &&
+      r.contextLine.contains("US") && !r.contextLine.contains("UserService")
+    }
+    assert(aliasRef.isDefined, s"Should find alias ref with US: ${refs.map(r => (workspace.relativize(r.file).toString, r.contextLine))}")
+    assertEquals(aliasRef.get.aliasInfo, Some("via alias US"))
+  }
+
+  test("formatRef shows alias annotation") {
+    val r = Reference(workspace.resolve("Foo.scala"), 10, "val x: US = ???", Some("via alias US"))
+    val result = formatRef(r, workspace)
+    assert(result.contains("[via alias US]"), s"Should contain alias annotation: $result")
+  }
+
   test("binary roundtrip preserves aliases") {
     val cacheDir = workspace.resolve(".scalex")
     if Files.exists(cacheDir) then


### PR DESCRIPTION
## Summary
- **Alias-aware confidence**: `resolveConfidence` checks alias mappings — searching by alias name (e.g. `refs TextAlignE`) now returns High confidence instead of Low
- **Alias annotation**: references found via alias show `[via alias Y]` suffix in output
- Reverse alias lookup deliberately skipped (agent can do 2-step lookup; avoids worse-than-grep perf risk)

## Test plan
- [x] 60 tests pass (3 new: alias confidence, aliasInfo population, formatRef annotation)
- [ ] Manual: `scala-cli run scalex.scala -- refs /path/to/project TextAlignE` → High confidence
- [ ] Manual: `scala-cli run scalex.scala -- refs /path/to/project UserService` → alias lines show `[via alias ...]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)