### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.1.0] — 2026-03-14
 
 ### Added
 - Confidence annotations for `refs` output (High/Medium/Low) based on import resolution

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -12,7 +12,7 @@ First run on a project indexes all git-tracked `.scala` files (~3s for 14k files
 Before first use, check if scalex is installed and at the expected version:
 
 ```bash
-EXPECTED_VERSION="1.0.0"
+EXPECTED_VERSION="1.1.0"
 INSTALLED_VERSION=$(scalex --version 2>/dev/null || echo "none")
 echo "Expected: $EXPECTED_VERSION, Installed: $INSTALLED_VERSION"
 ```

--- a/scalex.scala
+++ b/scalex.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 import com.google.common.hash.{BloomFilter, Funnels}
 
-val ScalexVersion = "1.0.0"
+val ScalexVersion = "1.1.0"
 
 // ── Data types ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` in `scalex.scala` to `1.1.0`
- Bump `EXPECTED_VERSION` in `plugin/skills/scalex/SKILL.md` to `1.1.0`
- Move changelog `[Unreleased]` section to `[1.1.0] — 2026-03-14`

## Test plan
- [ ] `scala-cli run scalex.scala -- --version` prints `1.1.0`
- [ ] Tag as `v1.1.0` after merge to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)