### PR TITLE
docs: add performance improvement items to roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,6 +96,14 @@
 - [x] Alias annotation in output: show `[via alias Y]` when a reference was found through alias tracking
 - ~~Reverse alias lookup~~: deliberately skipped — agent can do 2-step lookup (`def TextAlignE` → see alias → `refs TextAlign`), and reverse lookup risks worse-than-grep perf on large codebases
 
+### Performance improvements
+- [ ] Eliminate double file read in `extractSymbols` — `buildBloomFilter` and `extractSymbols` both call `Files.readString`; read once, pass source to both
+- [ ] Skip `IndexPersistence.save` when nothing changed — avoid rewriting 22-28MB index when `parsedCount == 0`
+- [ ] Lazy bloom filter deserialization — `def`/`search`/`impl`/`symbols`/`packages` don't need blooms; skip deserializing them to cut ~40-50% off load time
+- [ ] Pre-compute search deduplication — `search` runs `distinctBy` over all 200K+ symbols on every call; compute once at index time
+- [ ] Adaptive bloom filter capacity — hardcoded at 500 expected insertions; large files exceed this, raising false positive rate for `refs`/`imports`
+- [ ] Single-pass post-index map building — build `filesByPath`, `symbolsByName`, `parentIndex`, etc. in one loop instead of 7 separate passes
+
 ### Other
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)
 - [ ] `scalex hierarchy <class>` — show full class hierarchy (parents + children)


### PR DESCRIPTION
## Summary
- Add 6 performance improvement items to the roadmap under a new "Performance improvements" section
- Items cover: double file read elimination, conditional index save, lazy bloom deserialization, pre-computed search dedup, adaptive bloom capacity, single-pass map building
- Ordered by estimated impact based on code review and benchmark analysis

## Test plan
- [x] Verify ROADMAP.md renders correctly with new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)