### PR TITLE
feat: add benchmark skill and update benchmark docs

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: benchmark
+description: Run scalex performance benchmarks using hyperfine against the scala3 repo. Use this skill whenever the user asks to benchmark scalex, measure performance, profile index/query times, compare before/after performance of a change, or mentions "benchmark", "perf", "how fast", "timing", "hyperfine". Also use after implementing performance improvements to verify the gains.
+---
+
+## Overview
+
+This skill runs reproducible performance benchmarks for scalex using [hyperfine](https://github.com/sharkdp/hyperfine) against the Scala 3 compiler repo (~17.7K files, ~203K symbols). It measures:
+
+- **Cold index**: no cache, full parse of all files
+- **Warm index**: fully cached, OID comparison only
+- **Query commands**: each command with warm cache (includes index deserialization)
+
+## Prerequisites
+
+- `hyperfine` installed (`brew install hyperfine`)
+- Native scalex binary built (`./build-native.sh`)
+- The scala3 repo is cloned automatically on first run
+
+## Running benchmarks
+
+Use the bundled script. From the scalex project root:
+
+```bash
+.claude/skills/benchmark/scripts/bench.sh
+```
+
+### Options
+
+```bash
+# Full suite (default)
+./scripts/bench.sh
+
+# Only cold index
+./scripts/bench.sh cold
+
+# Only warm index
+./scripts/bench.sh warm
+
+# Only query benchmarks
+./scripts/bench.sh query
+
+# Custom scalex binary path
+SCALEX_BIN=./target/scalex ./scripts/bench.sh
+
+# Custom number of runs
+BENCH_RUNS=10 ./scripts/bench.sh
+
+# Export JSON results (for comparison)
+BENCH_EXPORT=benchmark-results/before.json ./scripts/bench.sh
+```
+
+### Comparing before/after
+
+When benchmarking a performance change:
+
+1. Build the native binary from main: `./build-native.sh`
+2. Run: `BENCH_EXPORT=benchmark-results/before.json .claude/skills/benchmark/scripts/bench.sh`
+3. Apply changes, rebuild: `./build-native.sh`
+4. Run: `BENCH_EXPORT=benchmark-results/after.json .claude/skills/benchmark/scripts/bench.sh`
+5. Compare the JSON files or use `hyperfine`'s `--export-markdown` for side-by-side
+
+### Interpreting results
+
+From prior benchmarks on Apple M3 Max:
+
+| Metric | Typical range | What dominates |
+|---|---|---|
+| Cold index | 3-5s | Scalameta parsing (CPU-bound, parallel) |
+| Warm index | 0.8-1.0s | OID comparison + index save |
+| Query (any) | 1.2-1.5s | Index deserialization from disk |
+
+If warm index is slow, check if `IndexPersistence.save` is running unnecessarily.
+If all queries have similar times, the bottleneck is deserialization, not query logic.
+
+## Updating BENCHMARK.md
+
+After running benchmarks, update `docs/BENCHMARK.md` with the new numbers if they've changed significantly. Include the hardware, date, and both project sizes.

--- a/.claude/skills/benchmark/scripts/bench.sh
+++ b/.claude/skills/benchmark/scripts/bench.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+SCALEX_BIN="${SCALEX_BIN:-$PROJECT_ROOT/scalex}"
+SCALA3_DIR="$PROJECT_ROOT/scala3"
+BENCH_RUNS="${BENCH_RUNS:-5}"
+BENCH_EXPORT="${BENCH_EXPORT:-}"
+MODE="${1:-all}"
+
+# ── Validate prerequisites ──────────────────────────────────────────────────
+
+if ! command -v hyperfine &>/dev/null; then
+  echo "Error: hyperfine not found. Install with: brew install hyperfine"
+  exit 1
+fi
+
+if [ ! -x "$SCALEX_BIN" ]; then
+  echo "Error: scalex binary not found at $SCALEX_BIN"
+  echo "Build it with: ./build-native.sh"
+  exit 1
+fi
+
+# ── Clone scala3 repo if needed ─────────────────────────────────────────────
+
+if [ ! -d "$SCALA3_DIR" ]; then
+  echo "Cloning scala3 repo (depth=1)..."
+  git clone --depth=1 https://github.com/scala/scala3.git "$SCALA3_DIR"
+  echo ""
+fi
+
+FILE_COUNT=$(git -C "$SCALA3_DIR" ls-files '*.scala' | wc -l | tr -d ' ')
+echo "scala3 repo: $FILE_COUNT .scala files"
+echo "scalex binary: $SCALEX_BIN"
+echo "runs per benchmark: $BENCH_RUNS"
+echo ""
+
+# ── Hyperfine export flags ──────────────────────────────────────────────────
+
+EXPORT_FLAGS=()
+if [ -n "$BENCH_EXPORT" ]; then
+  mkdir -p "$(dirname "$BENCH_EXPORT")"
+  EXPORT_FLAGS=(--export-json "$BENCH_EXPORT")
+fi
+
+# ── Cold index ──────────────────────────────────────────────────────────────
+
+run_cold() {
+  echo "=== Cold Index (no cache) ==="
+  echo ""
+  hyperfine \
+    --warmup 0 \
+    --runs "$BENCH_RUNS" \
+    --prepare "rm -rf $SCALA3_DIR/.scalex" \
+    "$SCALEX_BIN index $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Warm index ──────────────────────────────────────────────────────────────
+
+run_warm() {
+  echo "=== Warm Index (fully cached) ==="
+  echo ""
+  # Ensure cache exists
+  "$SCALEX_BIN" index "$SCALA3_DIR" >/dev/null 2>&1
+  hyperfine \
+    --warmup 1 \
+    --runs "$BENCH_RUNS" \
+    "$SCALEX_BIN index $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Query benchmarks ────────────────────────────────────────────────────────
+
+run_query() {
+  echo "=== Query Performance (warm cache) ==="
+  echo ""
+  # Ensure cache exists
+  "$SCALEX_BIN" index "$SCALA3_DIR" >/dev/null 2>&1
+  hyperfine \
+    --warmup 1 \
+    --runs "$BENCH_RUNS" \
+    --command-name "def" "$SCALEX_BIN def $SCALA3_DIR Compiler" \
+    --command-name "search" "$SCALEX_BIN search $SCALA3_DIR Compiler" \
+    --command-name "impl" "$SCALEX_BIN impl $SCALA3_DIR Compiler" \
+    --command-name "refs" "$SCALEX_BIN refs $SCALA3_DIR Compiler" \
+    --command-name "imports" "$SCALEX_BIN imports $SCALA3_DIR Compiler" \
+    --command-name "packages" "$SCALEX_BIN packages $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Run selected benchmarks ─────────────────────────────────────────────────
+
+case "$MODE" in
+  cold)  run_cold ;;
+  warm)  run_warm ;;
+  query) run_query ;;
+  all)
+    run_cold
+    run_warm
+    run_query
+    ;;
+  *)
+    echo "Usage: $0 [cold|warm|query|all]"
+    exit 1
+    ;;
+esac
+
+echo "Done."

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ out
 .scala-build
 .scalex/
 scalex-workspace/
+scala3/
+benchmark-results/

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -2,41 +2,50 @@
 
 Native GraalVM binary, Macbook Pro, Apple Silicon M3 Max, measured March 2026.
 
+Reproducible via `.claude/skills/benchmark/scripts/bench.sh` using [hyperfine](https://github.com/sharkdp/hyperfine) against the [Scala 3 compiler repo](https://github.com/scala/scala3) (17,733 files, cloned with `--depth=1`).
+
 ## Test projects
 
-| | **Project A** | **Project B** |
+| | **Scala 3 compiler** | **Enterprise monorepo** |
 |---|---|---|
-| Description | Compiler / language toolchain | Large enterprise monorepo |
-| Scala files | 17,731 | 13,970 |
+| Scala files | 17,733 | 13,970 |
 | Symbols indexed | 202,916 | 214,154 |
 | Cache size (`.scalex/index.bin`) | 22 MB | 28 MB |
 
-## Indexing
+## Indexing (hyperfine, 5 runs)
 
-| | Project A (17.7K files) | Project B (14K files) |
+| | Scala 3 (17.7K files) | Enterprise (14K files) |
 |---|---|---|
-| **Cold index** (no cache) | 3.4s | 4.6s |
-| **Warm index** (fully cached) | 0.8s | 1.0s |
+| **Cold index** (no cache) | 3.618s ± 0.071s | 4.6s |
+| **Warm index** (fully cached) | 1.360s ± 0.027s | 1.0s |
 
-Cold index time correlates with symbol count, not file count — Project B has fewer files but more symbols (214K vs 203K) and takes longer.
+Cold index time correlates with symbol count, not file count — the enterprise repo has fewer files but more symbols (214K vs 203K) and takes longer.
 
-## Query performance (warm cache)
+## Query performance — Scala 3 compiler (hyperfine, 5 runs, warm cache)
 
-| Command | Project A | Project B |
+| Command | Mean ± σ | Range |
 |---|---|---|
-| `search` | ~1.4s | ~1.8s |
-| `def` | ~1.3s | ~1.5s |
-| `impl` | ~1.1s | ~1.5s |
-| `refs` | ~1.3s | ~1.5s |
-| `imports` | ~1.3s | ~1.5s |
-| `symbols` | ~1.3s | ~1.5s |
-| `packages` | ~1.3s | ~1.5s |
+| `def Compiler` | 1.299s ± 0.007s | 1.288–1.304s |
+| `impl Compiler` | 1.292s ± 0.003s | 1.287–1.294s |
+| `packages` | 1.300s ± 0.008s | 1.292–1.310s |
+| `refs Compiler` | 1.316s ± 0.010s | 1.304–1.327s |
+| `imports Compiler` | 1.341s ± 0.005s | 1.333–1.347s |
+| `search Compiler` | 1.353s ± 0.048s | 1.269–1.382s |
 
-All query times include index deserialization from disk. Actual query logic runs in single-digit milliseconds — the ~1.2–1.5s baseline is entirely cache loading overhead.
+All query times include full index deserialization from disk. Actual query logic runs in single-digit milliseconds.
 
 ## Observations
 
-- **Index loading dominates**: Every command pays the same ~1.2–1.5s cost to deserialize the binary cache. Query execution itself is negligible.
-- **Bloom filters work**: `refs Symbol` across 17.7K files returns 4,551 matches in 1.3s — bloom filters skip files that don't contain the symbol.
-- **Cold indexing scales linearly**: ~3–5s for 14K–18K files. Parallel Scalameta parsing saturates available cores (327–418% CPU).
-- **Cache hit is cheap**: Warm index compares git OIDs only — no file reads, no parsing. Sub-second for both projects.
+- **Index deserialization dominates**: All 6 query commands cluster within 1.29–1.35s. The query logic itself is negligible — the entire cost is loading and deserializing the ~22MB binary cache with bloom filters.
+- **Warm index pays an unnecessary save cost**: Warm index (1.36s) is ~60ms slower than the fastest query (1.29s). The difference is `IndexPersistence.save` writing 22MB back to disk even when nothing changed (all files hit OID cache).
+- **Bloom filters work**: `refs Compiler` and `imports Compiler` add only ~20–40ms over non-bloom commands (`def`, `impl`, `packages`), despite scanning bloom filters across 17.7K files.
+- **Cold indexing parallelizes well**: 3.6s wall-clock with 10.5s user time = ~290% CPU utilization across Scalameta parsing.
+
+## Improvement opportunities
+
+These are ordered by estimated impact (see `docs/ROADMAP.md` for tracking):
+
+1. **Lazy bloom filter deserialization** — `def`, `search`, `impl`, `symbols`, `packages` never use bloom filters, yet every command deserializes all ~17.7K of them. Skipping bloom deserialization for non-refs/imports commands could cut the 1.3s baseline by 40–50%.
+2. **Skip save when nothing changed** — When `parsedCount == 0` (all files cached), skip the 22MB write. Would bring warm index time closer to query time (~1.3s → ~1.29s).
+3. **Eliminate double file read** — During cold index, `buildBloomFilter` and `extractSymbols` both call `Files.readString` on the same file. Reading once and sharing the source string would cut I/O in half for cold indexing.
+4. **Adaptive bloom filter capacity** — Bloom filters are created with 500 expected insertions. Large files with 2000+ identifiers exceed this, raising false positive rates and causing `refs`/`imports` to read more files than necessary.


### PR DESCRIPTION
## Summary
- Add `.claude/skills/benchmark/` with a `bench.sh` script that runs reproducible hyperfine benchmarks against the scala3 repo (cloned `--depth=1`, gitignored)
- Supports `cold`/`warm`/`query`/`all` modes, configurable runs, and JSON export for before/after comparison
- Update `docs/BENCHMARK.md` with precise hyperfine measurements (mean ± σ), observations, and improvement opportunities

## Test plan
- [x] Run full benchmark suite: `.claude/skills/benchmark/scripts/bench.sh`
- [x] Verify scala3 repo auto-clones on first run
- [x] Verify `.gitignore` excludes `scala3/` and `benchmark-results/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)