### PR TITLE
feat: show parse error files in index --verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `scalex index --verbose` now lists files that had parse errors
+- Not-found hint directs users to `scalex index --verbose` to see failed files
+
 ## [1.2.0] — 2026-03-15
 
 ### Performance

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,6 +104,11 @@
 - [x] Adaptive bloom filter capacity — `max(500, source.length / 15)` scales bloom size with file size
 - [x] Single-pass post-index map building — 2 passes instead of 7 separate passes over 200K+ symbols
 
+### Parse error diagnostics — DONE
+- [x] Track which files had parse errors (not just the count)
+- [x] `scalex index --verbose` lists the files with parse errors
+- [x] Not-found hint directs users to `scalex index --verbose` to see failed files
+
 ### Other
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)
 - [ ] `scalex hierarchy <class>` — show full class hierarchy (parents + children)

--- a/scalex.scala
+++ b/scalex.scala
@@ -378,6 +378,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   var parsedCount: Int = 0
   var skippedCount: Int = 0
   var parseFailures: Int = 0
+  var parseFailedFiles: List[String] = Nil
   var cachedLoad: Boolean = false
 
   def index(): Unit =
@@ -423,10 +424,13 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
         parsedCount = gitFiles.size
 
     indexedFiles = result.toList
-    parseFailures = indexedFiles.count(f => f.symbols.isEmpty && {
-      val p = workspace.resolve(f.relativePath)
-      try Files.size(p) > 0 catch case _: Exception => false
-    })
+    parseFailedFiles = indexedFiles.collect {
+      case f if f.symbols.isEmpty && {
+        val p = workspace.resolve(f.relativePath)
+        try Files.size(p) > 0 catch case _: Exception => false
+      } => f.relativePath
+    }
+    parseFailures = parseFailedFiles.size
     // Single-pass over symbols: build all symbol-level indexes
     val allSyms = mutable.ListBuffer.empty[SymbolInfo]
     val byPath = mutable.HashMap.empty[Path, mutable.ListBuffer[SymbolInfo]]
@@ -671,7 +675,7 @@ def formatRef(r: Reference, workspace: Path): String =
 def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String): Unit =
   println(s"  Hint: scalex indexes ${idx.fileCount} git-tracked .scala files.")
   if idx.parseFailures > 0 then
-    println(s"  ${idx.parseFailures} files had parse errors and may be missing symbols.")
+    println(s"  ${idx.parseFailures} files had parse errors (run `scalex index --verbose` to list them).")
   println(s"  Fallback: use Grep, Glob, or Read tools to search manually.")
 
 def resolveWorkspace(path: String): Path =
@@ -699,6 +703,12 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size).foreach { (kind, syms) =>
         println(s"  ${kind.toString.padTo(10, ' ')} ${syms.size}")
       }
+      if idx.parseFailures > 0 then
+        println(s"\n${idx.parseFailures} files had parse errors:")
+        if verbose then
+          idx.parseFailedFiles.sorted.foreach(f => println(s"  $f"))
+        else
+          println("  Run with --verbose to see the list.")
 
     case "search" =>
       rest.headOption match


### PR DESCRIPTION
## Summary

- Track which files had parse errors (file paths, not just count)
- `scalex index --verbose` lists the files with parse errors
- Not-found hint now directs users to `scalex index --verbose` to see failed files

## Test plan

- [x] All 60 tests pass
- [x] Verified on stargazer (13,970 files) — correctly lists 5 files with parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)