### PR TITLE
docs: add file command to site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -486,7 +486,7 @@
 
   <!-- Commands -->
   <section class="reveal">
-    <h2>9 commands. <span class="red">Zero config.</span></h2>
+    <h2>10 commands. <span class="red">Zero config.</span></h2>
     <p class="section-sub">Point it at any git repo with Scala files. Works on Scala 2 and 3, auto-detects dialect per file.</p>
 
     <div class="cmd-grid">
@@ -513,6 +513,10 @@
       <div class="cmd-card">
         <div class="cmd-name">scalex symbols</div>
         <div class="cmd-desc">What's in this file? All classes, traits, defs, vals with signatures.</div>
+      </div>
+      <div class="cmd-card">
+        <div class="cmd-name">scalex file</div>
+        <div class="cmd-desc">Find files by name. Fuzzy camelCase matching — "hms" finds HttpMessageService.scala.</div>
       </div>
       <div class="cmd-card">
         <div class="cmd-name">scalex packages</div>


### PR DESCRIPTION
## Summary
- Update command count from 9 to 10 on the landing page
- Add `scalex file` card to the command grid with fuzzy camelCase matching description

## Test plan
- [ ] Verify site renders correctly with the new card
- [ ] Confirm command grid layout with 10 cards looks balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)