### PR TITLE
fix: zsh compat + workspace flag + path hint (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.4.0] — 2026-03-15
+
+### Added
+- `-w` / `--workspace` flag — named flag for setting workspace path, avoids ambiguity with positional args
+- Path-as-symbol hint — when a symbol looks like a filesystem path, suggests correct arg order
+
+### Fixed
+- zsh compatibility — bash re-exec guard in `scalex-cli` bootstrap script fixes `(eval):1: permission denied:` when zsh eval's the script (#22)
+
 ## [1.3.0] — 2026-03-15
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,6 +113,11 @@
 - [x] Support camelCase abbreviation matching in `search` — e.g. "hms" matches `HttpMessageService` by matching initials of each camelCase segment
 - [x] Rank fuzzy results below exact/prefix/substring matches
 
+### zsh compat + UX improvements (#22) — DONE
+- [x] Bash re-exec guard in `scalex-cli` — fixes `(eval):1: permission denied:` when zsh eval's the script
+- [x] `-w` / `--workspace` flag — named flag for workspace, avoids ambiguity with positional args
+- [x] Path-as-symbol hint — detect when symbol looks like a path and suggest correct arg order
+
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -27,7 +27,7 @@ The `refs`, `imports`, and `categorize` features work differently — they do te
 
 ## Commands
 
-All commands default to current directory. You can pass an explicit workspace path as the first argument after the command (e.g., `scalex def /path/to/project MyTrait`). Every command auto-indexes on first run.
+All commands default to current directory. You can set the workspace with `-w` / `--workspace` (e.g., `scalex def -w /path/to/project MyTrait`) or as a positional argument (e.g., `scalex def /path/to/project MyTrait`). The `-w` flag is preferred — it avoids ambiguity between workspace and symbol. Every command auto-indexes on first run.
 
 ### `scalex def <symbol> [--verbose]` — find definition
 
@@ -119,12 +119,15 @@ scalex symbols src/main/scala/com/example/Service.scala --verbose
 scalex packages
 ```
 
-### `scalex batch` — multiple queries, one index load
+### `scalex batch [-w workspace]` — multiple queries, one index load
 
 Reads queries from stdin, loads index once. Use when you need several lookups — avoids re-loading the index for each command. 5 queries in ~1s instead of ~5s.
 
+The workspace is set on the `batch` subcommand, not per-query. Use `-w` or pass it as a positional arg after `batch`:
+
 ```bash
-echo -e "def UserService\nimpl UserService\nimports UserService" | scalex batch
+echo -e "def UserService\nimpl UserService\nimports UserService" | scalex batch -w /path/to/project
+echo -e "def UserService\nimpl UserService" | scalex batch /path/to/project
 ```
 
 ### `scalex index` — force reindex
@@ -135,6 +138,7 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 
 | Flag | Effect |
 |---|---|
+| `-w`, `--workspace PATH` | Set workspace path (default: current directory) |
 | `--verbose` | Show signatures, extends clauses, param types |
 | `--categorize` | Group refs into Definition/ExtendedBy/ImportedBy/UsedAsType/Comment/Usage |
 | `--limit N` | Max results (default: 20) |

--- a/plugin/skills/scalex/scripts/scalex-cli
+++ b/plugin/skills/scalex/scripts/scalex-cli
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# If executed by a non-bash shell, re-exec with bash.
+# When eval'd (e.g. zsh eval), $0 is the shell binary — fall through
+# since the script is POSIX-compatible.
+if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
+  exec bash "$0" "$@"
+fi
 set -euo pipefail
 
 EXPECTED_VERSION="1.3.0"

--- a/scalex.scala
+++ b/scalex.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 import com.google.common.hash.{BloomFilter, Funnels}
 
-val ScalexVersion = "1.3.0"
+val ScalexVersion = "1.4.0"
 
 // ── Data types ──────────────────────────────────────────────────────────────
 
@@ -710,6 +710,8 @@ def formatRef(r: Reference, workspace: Path): String =
   s"  $rel:${r.line} — ${r.contextLine}$alias"
 
 def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String): Unit =
+  if symbol.contains("/") || symbol.startsWith(".") then
+    println(s"  Note: \"$symbol\" looks like a path. Did you mean: scalex $cmd -w <workspace> $symbol?")
   println(s"  Hint: scalex indexes ${idx.fileCount} git-tracked .scala files.")
   if idx.parseFailures > 0 then
     println(s"  ${idx.parseFailures} files had parse errors (run `scalex index --verbose` to list them).")
@@ -902,10 +904,16 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
     case i => argList.lift(i + 1)
   val verbose = argList.contains("--verbose")
   val categorize = argList.contains("--categorize")
+  val explicitWorkspace: Option[String] =
+    val longIdx = argList.indexOf("--workspace")
+    val shortIdx = argList.indexOf("-w")
+    val idx = if longIdx >= 0 then longIdx else shortIdx
+    if idx >= 0 then argList.lift(idx + 1) else None
 
-  val cleanArgs = argList.filterNot(a => a.startsWith("--") || {
+  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w")
+  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || {
     val prev = argList.indexOf(a) - 1
-    prev >= 0 && (argList(prev) == "--limit" || argList(prev) == "--kind")
+    prev >= 0 && flagsWithArgs.contains(argList(prev))
   })
 
   cleanArgs match
@@ -925,18 +933,19 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
         |  scalex batch                    Run multiple queries at once    (aka: batch mode)
         |
         |Options:
-        |  --limit N       Max results (default: 20)
-        |  --kind K        Filter by kind: class, trait, object, def, val, type, enum, given, extension
-        |  --verbose       Show signatures and extends clauses
-        |  --categorize    Group refs by: definition, extends, import, type usage, comment
-        |  --version       Print version and exit
+        |  -w, --workspace PATH  Set workspace path (default: current directory)
+        |  --limit N             Max results (default: 20)
+        |  --kind K              Filter by kind: class, trait, object, def, val, type, enum, given, extension
+        |  --verbose             Show signatures and extends clauses
+        |  --categorize          Group refs by: definition, extends, import, type usage, comment
+        |  --version             Print version and exit
         |
-        |All commands accept an optional [workspace] path (default: current directory).
+        |All commands accept an optional [workspace] positional arg or -w flag (default: current directory).
         |First run indexes the project (~3s for 14k files). Subsequent runs use cache (~300ms).
         |""".stripMargin)
 
     case "batch" :: rest =>
-      val workspace = resolveWorkspace(rest.headOption.getOrElse("."))
+      val workspace = resolveWorkspace(explicitWorkspace.orElse(rest.headOption).getOrElse("."))
       val idx = WorkspaceIndex(workspace, needBlooms = true)
       idx.index()
       val reader = BufferedReader(InputStreamReader(System.in))
@@ -952,14 +961,18 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
         line = reader.readLine()
 
     case cmd :: rest =>
-      val (workspace, cmdRest) = cmd match
-        case "index" | "packages" =>
-          (resolveWorkspace(rest.headOption.getOrElse(".")), rest)
-        case _ =>
-          rest match
-            case arg :: Nil => (resolveWorkspace("."), List(arg))
-            case ws :: arg :: tail => (resolveWorkspace(ws), arg :: tail)
-            case Nil => (resolveWorkspace("."), Nil)
+      val (workspace, cmdRest) = explicitWorkspace match
+        case Some(ws) =>
+          (resolveWorkspace(ws), rest)
+        case None =>
+          cmd match
+            case "index" | "packages" =>
+              (resolveWorkspace(rest.headOption.getOrElse(".")), rest)
+            case _ =>
+              rest match
+                case arg :: Nil => (resolveWorkspace("."), List(arg))
+                case ws :: arg :: tail => (resolveWorkspace(ws), arg :: tail)
+                case Nil => (resolveWorkspace("."), Nil)
 
       val bloomCmds = Set("refs", "imports")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))


### PR DESCRIPTION
## Summary
- Adds bash re-exec guard in `scalex-cli` bootstrap script to fix `(eval):1: permission denied:` under zsh
- Adds `-w` / `--workspace` named flag for setting workspace path, avoiding ambiguity with positional args
- Detects path-like symbols (e.g. `scalex def /some/path`) and suggests correct arg order
- Bumps version to 1.4.0

Closes #22

## Test plan
- [x] 70/70 existing tests pass
- [x] `zsh plugin/skills/scalex/scripts/scalex-cli --version` → re-execs with bash, prints version
- [x] `zsh -c 'eval "$(cat scalex-cli)"'` → falls through (POSIX-compatible), executes binary
- [x] `bash scalex-cli --version` → unchanged behavior
- [x] `scalex def /nonexistent/path` → shows path hint
- [x] `scalex def -w . WorkspaceIndex` → resolves workspace from flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)