### PR TITLE
docs: use direct path invocation, drop shell variables (#27)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "scalex",
       "source": "./plugin",
       "description": "Scala code intelligence for AI agents — search symbols, find definitions, find implementations, find references, explore imports. Works on Scala 2 and 3 codebases without a compiler or build server.",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -11,24 +11,20 @@ First run on a project indexes all git-tracked `.scala` files (~3s for 14k files
 
 A bootstrap script at `scripts/scalex-cli` (next to this SKILL.md) handles everything automatically — platform detection, downloading the correct native binary from GitHub releases, and caching at `~/.cache/scalex/`. It auto-upgrades when the skill version changes.
 
-Set `$SCALEX` to the absolute path of the bootstrap script, and always invoke with `bash "$SCALEX"` — this is shell-agnostic and works under zsh, dash, or any sandbox:
+**Invocation pattern** — use the absolute path to `scalex-cli` directly in every command. Do NOT use shell variables (`$SCALEX`) — AI agent shells are non-persistent, so variables are lost between commands.
 
 ```bash
-# Set once per session
-SCALEX="/absolute/path/to/skills/scalex/scripts/scalex-cli"
-
-# All commands use: bash "$SCALEX" <command> [args] -w <workspace>
-bash "$SCALEX" def MyTrait --verbose -w /path/to/project
-echo -e "def Foo\nimpl Foo\nrefs Foo" | bash "$SCALEX" batch -w /path/to/project
+# Pattern: bash "<path-to-scripts>/scalex-cli" <command> [args] -w <workspace>
+bash "/absolute/path/to/skills/scalex/scripts/scalex-cli" def MyTrait --verbose -w /project
+bash "/absolute/path/to/skills/scalex/scripts/scalex-cli" impl MyTrait -w /project
+echo -e "def Foo\nimpl Foo\nrefs Foo" | bash "/absolute/path/to/skills/scalex/scripts/scalex-cli" batch -w /project
 ```
 
-Replace `/absolute/path/to/skills/scalex` with the absolute path to the directory containing this SKILL.md.
-
-**IMPORTANT:** Never assign `SCALEX="bash /path/to/scalex-cli"` — putting `bash` inside the variable breaks zsh word splitting. Use `bash "$SCALEX"` (two separate words) instead.
+Replace `/absolute/path/to/skills/scalex` with the absolute path to the directory containing this SKILL.md. Remember this path and substitute it directly into every command.
 
 ## Troubleshooting
 
-- **`permission denied`**: Run `chmod +x "$SCALEX"` once, then retry.
+- **`permission denied`**: Run `chmod +x /path/to/scalex-cli` once, then retry.
 - **macOS quarantine**: `xattr -d com.apple.quarantine ~/.cache/scalex/*`
 
 ## What scalex indexes


### PR DESCRIPTION
## Summary
- Drop the `$SCALEX` variable pattern — AI agent shells are non-persistent, so variables are lost between commands
- Use literal path directly in every command: `bash "/path/to/scalex-cli" <command> [args]`
- Explicitly tell agents to remember the path and substitute it directly
- Bump plugin version to 1.4.3

Closes #27

## Test plan
- [x] SKILL.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)