### PR TITLE
feat: AI-agent ergonomics — noise reduction and richer output (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.5.0] — 2026-03-15
+
+### Added
+- `--kind` filter now works on `def` and `impl` commands — `scalex def Driver --kind class` filters by symbol kind (#29)
+- `--no-tests` global flag — excludes test files (`test/`, `tests/`, `testing/`, `bench-*`, `*Spec.scala`, `*Test.scala`, `*Suite.scala`) from results; works on `def`, `search`, `impl`, `refs`, `imports` (#29)
+- `--path PREFIX` filter — restricts results to files under a path prefix, e.g. `scalex def Driver --path compiler/src/`; works on all query commands (#29)
+- `refs -C N` context lines — shows N lines before/after each reference with line numbers and `>` marker, like `grep -C` (#29)
+- Smarter `def` ranking — results sorted by: class/trait/object/enum first, then type/given, then def/val/var; non-test before test; shorter paths first (#29)
+
 ## [1.4.0] — 2026-03-15
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,8 +118,24 @@
 - [x] `-w` / `--workspace` flag — named flag for workspace, avoids ambiguity with positional args
 - [x] Path-as-symbol hint — detect when symbol looks like a path and suggest correct arg order
 
+### AI-agent ergonomics (#29)
+
+Feedback from real agent usage on large codebases (scala3 compiler, 14k+ files).
+
+**High priority — noise reduction:** — DONE
+- [x] `--kind` filter on `def` command — `def` ignores `--kind` today; `scalex def Driver --kind class` should filter by symbol kind (search already supports it)
+- [x] `--exclude-tests` / `--no-tests` global flag — skip common test dirs (`tests/`, `**/test/**`, `bench-*`, `**/testing/**`); ~50% noise reduction on large repos
+- [x] `--path` filter — restrict results to a subtree, e.g. `scalex def Driver --path compiler/src/`; essential for monorepos
+
+**Medium priority — richer output:** — DONE
+- [x] `refs -C N` context lines — show N lines before/after each reference (like `grep -C`); reduces follow-up Read calls
+- [x] Smarter `def` ranking — rank class/trait/object above val/def, main source above test files, shorter package paths first
+
+**Lower priority — new capabilities:**
+- [ ] Override search — `scalex overrides Phase.isRunnable` finds methods overriding a specific def; combines impl lookup with method-level filtering
+- [ ] `scalex hierarchy <class>` — show full inheritance chain (parents + children)
+
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)
-- [ ] `scalex hierarchy <class>` — show full class hierarchy (parents + children)
 - [ ] Publish plugin to Claude Code marketplace

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -37,12 +37,14 @@ The `refs`, `imports`, and `categorize` features work differently — they do te
 
 All commands default to current directory. You can set the workspace with `-w` / `--workspace` (e.g., `scalex def -w /path/to/project MyTrait`) or as a positional argument (e.g., `scalex def /path/to/project MyTrait`). The `-w` flag is preferred — it avoids ambiguity between workspace and symbol. Every command auto-indexes on first run.
 
-### `scalex def <symbol> [--verbose]` — find definition
+### `scalex def <symbol> [--verbose] [--kind K] [--no-tests] [--path PREFIX]` — find definition
 
-Returns where a symbol is defined, including given instances that grep would miss. Use `--verbose` to see the full signature inline — saves a follow-up Read call.
+Returns where a symbol is defined, including given instances that grep would miss. Use `--verbose` to see the full signature inline — saves a follow-up Read call. Results are ranked: class/trait/object/enum first, non-test before test, shorter paths first.
 
 ```bash
 scalex def PaymentService --verbose
+scalex def Driver --kind class              # only class definitions
+scalex def Driver --no-tests --path compiler/src/  # exclude tests, restrict to subtree
 ```
 ```
   trait     PaymentService (com.example.payment) — .../PaymentService.scala:16
@@ -51,26 +53,29 @@ scalex def PaymentService --verbose
              given paymentService: PaymentService
 ```
 
-### `scalex impl <trait> [--verbose] [--limit N]` — find implementations
+### `scalex impl <trait> [--verbose] [--kind K] [--no-tests] [--path PREFIX] [--limit N]` — find implementations
 
 Finds all classes/objects/enums that extend or mix in a trait. Uses the index directly — much faster and more targeted than `refs` when you specifically need concrete implementations.
 
 ```bash
 scalex impl PaymentService --verbose
+scalex impl PaymentService --no-tests --path core/src/
 ```
 ```
   class     PaymentServiceLive — .../PaymentServiceLive.scala:43
              class PaymentServiceLive extends PaymentService
 ```
 
-### `scalex refs <symbol> [--categorize] [--limit N]` — find references
+### `scalex refs <symbol> [--categorize] [--no-tests] [--path PREFIX] [-C N] [--limit N]` — find references
 
 Finds all usages of a symbol using word-boundary text matching. Uses bloom filters to skip files that definitely don't contain the symbol, then reads candidate files. Has a 20-second timeout — on very large codebases with a common symbol, output may say "(timed out — partial results)".
 
-Use `--categorize` before refactoring — it groups results into Definition, ExtendedBy, ImportedBy, UsedAsType, Usage, and Comment so you can understand impact at a glance.
+Use `--categorize` before refactoring — it groups results into Definition, ExtendedBy, ImportedBy, UsedAsType, Usage, and Comment so you can understand impact at a glance. Use `-C N` to show N lines of context around each reference (like `grep -C`) — reduces follow-up Read calls.
 
 ```bash
 scalex refs PaymentService --categorize
+scalex refs PaymentService --no-tests --path core/src/
+scalex refs PaymentService -C 3          # show 3 lines of context around each ref
 ```
 ```
   Definition:
@@ -87,12 +92,13 @@ scalex refs PaymentService --categorize
 
 Without `--categorize`, returns a flat list (faster for simple lookups).
 
-### `scalex imports <symbol> [--limit N]` — import graph
+### `scalex imports <symbol> [--no-tests] [--path PREFIX] [--limit N]` — import graph
 
 Returns only import statements for a symbol. Use when you need to know which files depend on something — cleaner than `refs` for dependency analysis. Also has a 20-second timeout.
 
 ```bash
 scalex imports PaymentService
+scalex imports PaymentService --no-tests
 ```
 
 ### `scalex search <query> [--kind K] [--verbose] [--limit N]` — search symbols
@@ -150,7 +156,10 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 | `--verbose` | Show signatures, extends clauses, param types |
 | `--categorize` | Group refs into Definition/ExtendedBy/ImportedBy/UsedAsType/Comment/Usage |
 | `--limit N` | Max results (default: 20) |
-| `--kind K` | Filter search: class, trait, object, def, val, type, enum, given, extension |
+| `--kind K` | Filter by kind: class, trait, object, def, val, type, enum, given, extension |
+| `--no-tests` | Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.) |
+| `--path PREFIX` | Restrict results to files under PREFIX (e.g. `compiler/src/`) |
+| `-C N` | Show N context lines around each reference (refs only) |
 
 ## Common workflows
 
@@ -169,6 +178,10 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 **"What's in this file?"** → `scalex symbols path/to/File.scala --verbose`
 
 **"I need to look up 3+ symbols"** → use `batch` to avoid repeated index loads
+
+**"Too many results / noisy output"** → `--no-tests` and/or `--path compiler/src/` to filter
+
+**"I want to see the code around each reference"** → `scalex refs X -C 3` shows 3 lines of context
 
 ## Fallback
 

--- a/scalex.scala
+++ b/scalex.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 import com.google.common.hash.{BloomFilter, Funnels}
 
-val ScalexVersion = "1.4.0"
+val ScalexVersion = "1.5.0"
 
 // ── Data types ──────────────────────────────────────────────────────────────
 
@@ -691,6 +691,18 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       i = line.indexOf(word, i + 1)
     false
 
+// ── Filtering helpers ────────────────────────────────────────────────────────
+
+def isTestFile(path: Path, workspace: Path): Boolean =
+  val rel = workspace.relativize(path).toString
+  rel.contains("/test/") || rel.contains("/tests/") || rel.contains("/testing/") ||
+  rel.startsWith("bench-") || rel.contains("/bench-") ||
+  rel.endsWith("Test.scala") || rel.endsWith("Spec.scala") || rel.endsWith("Suite.scala")
+
+def matchesPath(file: Path, prefix: String, workspace: Path): Boolean =
+  val rel = workspace.relativize(file).toString
+  rel.startsWith(prefix)
+
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 def formatSymbol(s: SymbolInfo, workspace: Path): String =
@@ -708,6 +720,25 @@ def formatRef(r: Reference, workspace: Path): String =
   val rel = workspace.relativize(r.file)
   val alias = r.aliasInfo.map(a => s" [$a]").getOrElse("")
   s"  $rel:${r.line} — ${r.contextLine}$alias"
+
+def formatRefWithContext(r: Reference, workspace: Path, contextN: Int): String =
+  val rel = workspace.relativize(r.file)
+  val alias = r.aliasInfo.map(a => s" [$a]").getOrElse("")
+  val header = s"  $rel:${r.line}$alias"
+  val lines = try java.nio.file.Files.readAllLines(r.file).asScala catch
+    case _: Exception => return s"$header\n    > ${r.contextLine}"
+  val total = lines.size
+  val startLine = math.max(1, r.line - contextN)
+  val endLine = math.min(total, r.line + contextN)
+  val buf = new StringBuilder(header)
+  var i = startLine
+  while i <= endLine do
+    val lineContent = lines(i - 1)
+    val marker = if i == r.line then ">" else " "
+    val lineNum = i.toString.reverse.padTo(4, ' ').reverse
+    buf.append(s"\n    $marker $lineNum | $lineContent")
+    i += 1
+  buf.toString
 
 def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String): Unit =
   if symbol.contains("/") || symbol.startsWith(".") then
@@ -728,7 +759,8 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(Path, String)] =
     case _ => None
 
 def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: Path,
-               limit: Int, kindFilter: Option[String], verbose: Boolean, categorize: Boolean): Unit =
+               limit: Int, kindFilter: Option[String], verbose: Boolean, categorize: Boolean,
+               noTests: Boolean, pathFilter: Option[String], contextLines: Int): Unit =
   val fmt = if verbose then formatSymbolVerbose else formatSymbol
   cmd match
     case "index" =>
@@ -758,6 +790,8 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
             val kk = k.toLowerCase
             results = results.filter(_.kind.toString.toLowerCase == kk)
           }
+          if noTests then results = results.filter(s => !isTestFile(s.file, workspace))
+          pathFilter.foreach { p => results = results.filter(s => matchesPath(s.file, p, workspace)) }
           if results.isEmpty then
             println(s"Found 0 symbols matching \"$query\"")
             printNotFoundHint(query, idx, "search")
@@ -770,19 +804,42 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       rest.headOption match
         case None => println("Usage: scalex def <symbol>")
         case Some(symbol) =>
-          val results = idx.findDefinition(symbol)
+          var results = idx.findDefinition(symbol)
+          kindFilter.foreach { k =>
+            val kk = k.toLowerCase
+            results = results.filter(_.kind.toString.toLowerCase == kk)
+          }
+          if noTests then results = results.filter(s => !isTestFile(s.file, workspace))
+          pathFilter.foreach { p => results = results.filter(s => matchesPath(s.file, p, workspace)) }
+          // Rank: class/trait/object/enum > type/given > def/val/var, non-test > test, shorter path first
+          results = results.sortBy { s =>
+            val kindRank = s.kind match
+              case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+              case SymbolKind.Type | SymbolKind.Given => 1
+              case _ => 2
+            val testRank = if isTestFile(s.file, workspace) then 1 else 0
+            val pathLen = workspace.relativize(s.file).toString.length
+            (kindRank, testRank, pathLen)
+          }
           if results.isEmpty then
             println(s"Definition of \"$symbol\": not found")
             printNotFoundHint(symbol, idx, "def")
           else
             println(s"Definition of \"$symbol\":")
-            results.foreach(s => println(fmt(s, workspace)))
+            results.take(limit).foreach(s => println(fmt(s, workspace)))
+            if results.size > limit then println(s"  ... and ${results.size - limit} more")
 
     case "impl" =>
       rest.headOption match
         case None => println("Usage: scalex impl <trait>")
         case Some(symbol) =>
-          val results = idx.findImplementations(symbol)
+          var results = idx.findImplementations(symbol)
+          kindFilter.foreach { k =>
+            val kk = k.toLowerCase
+            results = results.filter(_.kind.toString.toLowerCase == kk)
+          }
+          if noTests then results = results.filter(s => !isTestFile(s.file, workspace))
+          pathFilter.foreach { p => results = results.filter(s => matchesPath(s.file, p, workspace)) }
           if results.isEmpty then
             println(s"No implementations of \"$symbol\" found")
             printNotFoundHint(symbol, idx, "impl")
@@ -795,9 +852,17 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       rest.headOption match
         case None => println("Usage: scalex refs <symbol>")
         case Some(symbol) =>
+          val fmtRef: Reference => String =
+            if contextLines > 0 then r => formatRefWithContext(r, workspace, contextLines)
+            else r => formatRef(r, workspace)
           val targetPkgs = idx.symbolsByName.getOrElse(symbol.toLowerCase, Nil).map(_.packageName).toSet
+          def filterRefs(refs: List[Reference]): List[Reference] =
+            var r = refs
+            if noTests then r = r.filter(ref => !isTestFile(ref.file, workspace))
+            pathFilter.foreach { p => r = r.filter(ref => matchesPath(ref.file, p, workspace)) }
+            r
           if categorize then
-            val grouped = idx.categorizeReferences(symbol)
+            val grouped = idx.categorizeReferences(symbol).map((cat, refs) => (cat, filterRefs(refs)))
             val total = grouped.values.map(_.size).sum
             val suffix = if idx.timedOut then " (timed out — partial results)" else ""
             println(s"References to \"$symbol\" — $total found:$suffix")
@@ -818,13 +883,13 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
                 order.foreach { cat =>
                   byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
                     println(s"\n    ${cat.toString}:")
-                    entries.take(limit).foreach((_, r, _) => println(s"    ${formatRef(r, workspace)}"))
+                    entries.take(limit).foreach((_, r, _) => println(s"    ${fmtRef(r)}"))
                     if entries.size > limit then println(s"      ... and ${entries.size - limit} more")
                   }
                 }
             }
           else
-            val results = idx.findReferences(symbol)
+            val results = filterRefs(idx.findReferences(symbol))
             val suffix = if idx.timedOut then " (timed out — partial results)" else ""
             println(s"References to \"$symbol\" — ${results.size} found:$suffix")
             val annotated = results.map(r => (r, idx.resolveConfidence(r, symbol, targetPkgs)))
@@ -840,7 +905,7 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
                     case Confidence.Low    => "Low confidence"
                   println(s"\n  [$label]")
                   lastConf = Some(conf)
-                println(formatRef(r, workspace))
+                println(fmtRef(r))
                 shown += 1
             }
             if results.size > limit then println(s"  ... and ${results.size - limit} more")
@@ -849,7 +914,9 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       rest.headOption match
         case None => println("Usage: scalex imports <symbol>")
         case Some(symbol) =>
-          val results = idx.findImports(symbol)
+          var results = idx.findImports(symbol)
+          if noTests then results = results.filter(r => !isTestFile(r.file, workspace))
+          pathFilter.foreach { p => results = results.filter(r => matchesPath(r.file, p, workspace)) }
           if results.isEmpty then
             println(s"No imports of \"$symbol\" found")
             printNotFoundHint(symbol, idx, "imports")
@@ -904,14 +971,21 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
     case i => argList.lift(i + 1)
   val verbose = argList.contains("--verbose")
   val categorize = argList.contains("--categorize")
+  val noTests = argList.contains("--no-tests")
+  val pathFilter: Option[String] = argList.indexOf("--path") match
+    case -1 => None
+    case i => argList.lift(i + 1).map(p => p.stripPrefix("/"))
+  val contextLines: Int = argList.indexOf("-C") match
+    case -1 => 0
+    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
   val explicitWorkspace: Option[String] =
     val longIdx = argList.indexOf("--workspace")
     val shortIdx = argList.indexOf("-w")
     val idx = if longIdx >= 0 then longIdx else shortIdx
     if idx >= 0 then argList.lift(idx + 1) else None
 
-  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w")
-  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || {
+  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "-C")
+  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || {
     val prev = argList.indexOf(a) - 1
     prev >= 0 && flagsWithArgs.contains(argList(prev))
   })
@@ -938,6 +1012,9 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
         |  --kind K              Filter by kind: class, trait, object, def, val, type, enum, given, extension
         |  --verbose             Show signatures and extends clauses
         |  --categorize          Group refs by: definition, extends, import, type usage, comment
+        |  --no-tests            Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.)
+        |  --path PREFIX         Restrict results to files under PREFIX (e.g. compiler/src/)
+        |  -C N                  Show N context lines around each reference (refs only)
         |  --version             Print version and exit
         |
         |All commands accept an optional [workspace] positional arg or -w flag (default: current directory).
@@ -956,7 +1033,7 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
           val batchCmd = parts.head
           val batchRest = parts.tail
           println(s">>> $line")
-          runCommand(batchCmd, batchRest, idx, workspace, limit, kindFilter, verbose, categorize)
+          runCommand(batchCmd, batchRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines)
           println()
         line = reader.readLine()
 
@@ -977,4 +1054,4 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       val bloomCmds = Set("refs", "imports")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))
       idx.index()
-      runCommand(cmd, cmdRest, idx, workspace, limit, kindFilter, verbose, categorize)
+      runCommand(cmd, cmdRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines)

--- a/scalex.test.scala
+++ b/scalex.test.scala
@@ -976,3 +976,172 @@ class ScalexSuite extends FunSuite:
     val results = idx.searchFiles("ZxQwNonexistent")
     assert(results.isEmpty)
   }
+
+  // ── isTestFile helper ──────────────────────────────────────────────
+
+  test("isTestFile detects test directories") {
+    assert(isTestFile(workspace.resolve("src/test/scala/Foo.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/tests/scala/Foo.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/testing/scala/Foo.scala"), workspace))
+    assert(!isTestFile(workspace.resolve("src/main/scala/Foo.scala"), workspace))
+  }
+
+  test("isTestFile detects test file suffixes") {
+    assert(isTestFile(workspace.resolve("src/main/FooTest.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/main/FooSpec.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/main/FooSuite.scala"), workspace))
+    assert(!isTestFile(workspace.resolve("src/main/Foo.scala"), workspace))
+  }
+
+  test("isTestFile detects bench dirs") {
+    assert(isTestFile(workspace.resolve("bench-run/Foo.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/bench-run/Foo.scala"), workspace))
+  }
+
+  // ── --kind on def ──────────────────────────────────────────────────
+
+  test("def --kind filters by symbol kind") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val all = idx.findDefinition("UserService")
+    assert(all.exists(_.kind == SymbolKind.Trait), "Should have trait")
+    assert(all.exists(_.kind == SymbolKind.Object), "Should have object")
+
+    // Filter to trait only
+    var filtered = all
+    val kk = "trait"
+    filtered = filtered.filter(_.kind.toString.toLowerCase == kk)
+    assert(filtered.forall(_.kind == SymbolKind.Trait))
+    assert(filtered.nonEmpty)
+  }
+
+  // ── --no-tests filtering ───────────────────────────────────────────
+
+  test("--no-tests excludes test file results from def") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // UserServiceSpec is in test dir
+    val all = idx.findDefinition("UserServiceSpec")
+    assert(all.nonEmpty, "Should find UserServiceSpec")
+    val filtered = all.filter(s => !isTestFile(s.file, workspace))
+    assert(filtered.isEmpty, "Should exclude test files")
+  }
+
+  test("--no-tests excludes test file results from refs") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val all = idx.findReferences("UserService")
+    val allFiles = all.map(r => workspace.relativize(r.file).toString).distinct
+    assert(allFiles.exists(_.contains("UserServiceSpec")), "Should have test file in unfiltered")
+    val filtered = all.filter(r => !isTestFile(r.file, workspace))
+    val filteredFiles = filtered.map(r => workspace.relativize(r.file).toString).distinct
+    assert(!filteredFiles.exists(_.contains("UserServiceSpec")), "Should exclude test file")
+  }
+
+  // ── --path filtering ───────────────────────────────────────────────
+
+  test("matchesPath filters by path prefix") {
+    assert(matchesPath(workspace.resolve("src/main/scala/Foo.scala"), "src/main", workspace))
+    assert(!matchesPath(workspace.resolve("src/test/scala/Foo.scala"), "src/main", workspace))
+  }
+
+  test("--path filters def results to subtree") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val all = idx.findDefinition("UserService")
+    assert(all.nonEmpty)
+    val filtered = all.filter(s => matchesPath(s.file, "src/main", workspace))
+    assert(filtered.nonEmpty, "Should have results in src/main")
+    filtered.foreach { s =>
+      assert(workspace.relativize(s.file).toString.startsWith("src/main"),
+        s"All results should be in src/main: ${workspace.relativize(s.file)}")
+    }
+  }
+
+  test("--path strips leading slash") {
+    // The pathFilter parsing strips leading /, so "/src/main" becomes "src/main"
+    val prefix = "/src/main".stripPrefix("/")
+    assert(matchesPath(workspace.resolve("src/main/scala/Foo.scala"), prefix, workspace))
+  }
+
+  // ── Smarter def ranking ────────────────────────────────────────────
+
+  test("def ranking puts class/trait/object before def/val") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // findUser is both a def. UserService has trait, object.
+    // Create a scenario: search for something with mixed kinds
+    val results = idx.findDefinition("UserService")
+    // Sort using the ranking logic
+    val ranked = results.sortBy { s =>
+      val kindRank = s.kind match
+        case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+        case SymbolKind.Type | SymbolKind.Given => 1
+        case _ => 2
+      val testRank = if isTestFile(s.file, workspace) then 1 else 0
+      val pathLen = workspace.relativize(s.file).toString.length
+      (kindRank, testRank, pathLen)
+    }
+    // Trait and Object should come before any def/val
+    val traitIdx = ranked.indexWhere(_.kind == SymbolKind.Trait)
+    val objIdx = ranked.indexWhere(_.kind == SymbolKind.Object)
+    assert(traitIdx >= 0 && objIdx >= 0)
+    // Both should be in the first positions
+    assert(traitIdx < 2 && objIdx < 2)
+  }
+
+  test("def ranking puts non-test before test files") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // UserServiceSpec is in test dir, UserService is in main
+    val all = idx.findDefinition("UserService") ++ idx.findDefinition("UserServiceSpec")
+    val ranked = all.sortBy { s =>
+      val kindRank = s.kind match
+        case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+        case SymbolKind.Type | SymbolKind.Given => 1
+        case _ => 2
+      val testRank = if isTestFile(s.file, workspace) then 1 else 0
+      val pathLen = workspace.relativize(s.file).toString.length
+      (kindRank, testRank, pathLen)
+    }
+    // Non-test files should come first
+    val firstTestIdx = ranked.indexWhere(s => isTestFile(s.file, workspace))
+    if firstTestIdx >= 0 then
+      ranked.take(firstTestIdx).foreach { s =>
+        assert(!isTestFile(s.file, workspace), "Non-test should come before test")
+      }
+  }
+
+  // ── refs -C N context lines ────────────────────────────────────────
+
+  test("formatRefWithContext shows context lines") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val ref = refs.find(r => workspace.relativize(r.file).toString.contains("UserService.scala")).get
+    val output = formatRefWithContext(ref, workspace, 1)
+    // Should have the header line and context lines
+    assert(output.contains("UserService.scala:"), s"Should have file header: $output")
+    assert(output.contains(">"), s"Should have > marker on match line: $output")
+    // Count non-empty lines (header + up to 3 context lines)
+    val lines = output.split("\n")
+    assert(lines.size >= 2, s"Should have header + at least 1 context line: ${lines.size}")
+  }
+
+  test("formatRefWithContext with 0 context falls back to formatRef") {
+    val ref = Reference(workspace.resolve("src/main/scala/com/example/UserService.scala"), 3, "trait UserService {")
+    val withCtx = formatRefWithContext(ref, workspace, 0)
+    // With 0 context, should only show the match line
+    val lines = withCtx.split("\n").filter(_.nonEmpty)
+    assert(lines.size == 2, s"0 context: header + 1 line, got ${lines.size}: $withCtx")
+  }
+
+  test("formatRefWithContext handles edge of file") {
+    // Line 1 with context 3 — should not go below line 0
+    val ref = Reference(workspace.resolve("src/main/scala/com/example/Model.scala"), 1, "package com.example")
+    val output = formatRefWithContext(ref, workspace, 3)
+    assert(output.contains(">"), s"Should have marker: $output")
+    // Should not crash and should show lines from 1 to 4
+    val contentLines = output.split("\n").tail // skip header
+    assert(contentLines.size >= 1 && contentLines.size <= 4, s"Lines: ${contentLines.size}")
+  }


### PR DESCRIPTION
## Summary
- **`--kind` on `def`/`impl`** — filter by symbol kind (e.g. `scalex def Driver --kind class`)
- **`--no-tests`** — exclude test files (`test/`, `tests/`, `testing/`, `bench-*`, `*Spec.scala`, `*Test.scala`, `*Suite.scala`) from `def`, `search`, `impl`, `refs`, `imports`
- **`--path PREFIX`** — restrict results to a subtree (e.g. `--path compiler/src/`)
- **Smarter `def` ranking** — class/trait/object/enum first, non-test before test, shorter paths first
- **`refs -C N`** — show N context lines around each reference with line numbers and `>` marker
- Version bumped to 1.5.0

Closes #29

## Test plan
- [x] All 84 tests pass (70 existing + 14 new)
- [ ] Manual smoke test on scala3 compiler repo with `--no-tests` and `--path`
- [ ] Verify `-C N` context output readability on large codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)