### PR TITLE
feat: grep improvements for AI agents (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.7.0] — 2026-03-15
+
+### Added
+- `grep -e PATTERN` flag — multi-pattern grep in one call; patterns combined with `|` (#35)
+- `grep --count` flag — output match/file count without full results for quick triage (#35)
+- Regex syntax hint — when grep returns zero results and pattern contains `\|`, `\(`, or `\)`, shows hint about Java regex syntax (#35)
+- Document `grep` support in batch mode (#35)
+
 ## [1.6.0] — 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ scalex imports UserService              # Who imports it?
 scalex file PaymentService              # Find files by name (fuzzy camelCase)
 scalex annotated deprecated             # Find all @deprecated symbols
 scalex grep "def.*process" --no-tests   # Regex search in .scala file contents
+scalex grep -e "TODO" -e "FIXME" --count # Multi-pattern count
 scalex symbols src/main/scala/App.scala # What's in this file?
 scalex packages                         # What packages exist?
 scalex def UserService --json           # Structured JSON output
@@ -249,6 +250,8 @@ scalex batch                    Run multiple queries at once    (aka: batch mode
 | `--no-tests` | Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.) |
 | `--path PREFIX` | Restrict results to files under PREFIX (e.g. `compiler/src/`) |
 | `-C N` | Show N context lines around each reference (refs, grep) |
+| `-e PATTERN` | Grep: additional pattern (repeatable); combined with `\|` |
+| `--count` | Grep: output match/file count only, no full results |
 | `--json` | Output results as JSON — structured output for programmatic parsing |
 | `--version` | Print version and exit |
 
@@ -261,7 +264,7 @@ scalex batch                    Run multiple queries at once    (aka: batch mode
 - **Fuzzy camelCase search** — `search "hms"` finds `HttpMessageService`, `file "psl"` finds `PaymentServiceLive.scala`
 - **`file`** command searches file names with the same fuzzy matching — like IntelliJ's file search
 - **`annotated`** finds symbols by annotation — `@deprecated`, `@main`, `@tailrec`, etc.
-- **`grep`** does regex content search inside `.scala` files with `--path` and `--no-tests` filtering built in
+- **`grep`** does regex content search inside `.scala` files with `--path` and `--no-tests` filtering built in; `-e` for multi-pattern, `--count` for quick triage
 - **`--json`** flag on all commands produces structured JSON output — eliminates fragile text parsing
 - **`batch`** mode loads the index once for multiple queries — 5 queries in ~1s instead of ~5s
 - **Fallback hints** on "not found" — tells the agent how many files were searched and suggests using Grep/Glob as fallback

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -148,6 +148,22 @@ Feedback from real agent usage on large codebases (scala3 compiler, 14k+ files).
 - [x] 20s timeout, sorted output, `-C N` context lines support
 - [x] Eliminates the #1 reason agents fall back to grep for Scala files
 
+### Grep improvements for AI agents (#35) — DONE
+
+Feedback from real AI agent usage — `grep` is the most-used subcommand but has the most friction.
+
+**Hint on bad regex syntax:**
+- [x] Detect common regex mistakes (`\|`, `\(`, `\)`) when grep returns zero results — emit hint: "scalex uses Java regex (use `|` not `\|` for alternation)"
+
+**Multi-pattern grep:**
+- [x] `-e` flag for multiple patterns in one call — `scalex grep -e "Ystop" -e "stopAfter" --path compiler/src/`; reduces separate process invocations during exploratory search
+
+**Grep in batch mode:**
+- [x] `grep` already works in batch mode — batch dispatches via `runCommand()` which handles all commands including grep
+
+**`--count` flag for grep:**
+- [x] `scalex grep "pattern" --count` — output match/file count without full results; lets agent triage before committing to reading all output
+
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -134,16 +134,20 @@ scalex annotated tailrec --path core/src/      # @tailrec defs in core
   def       legacyProcess (com.example) — .../Legacy.scala:45
 ```
 
-### `scalex grep <pattern> [--no-tests] [--path PREFIX] [-C N] [--limit N]` — content search
+### `scalex grep <pattern> [-e PAT]... [--count] [--no-tests] [--path PREFIX] [-C N] [--limit N]` — content search
 
 Regex search inside `.scala` file contents. This is the scalex equivalent of grep, but with integrated `--path` and `--no-tests` filtering — use it instead of the Grep tool when searching inside Scala files. Has a 20-second timeout for large codebases.
 
-The pattern is a Java regex. Use `-C N` to show context lines around each match (like `grep -C`).
+The pattern is a **Java regex** (not POSIX) — use `|` for alternation (not `\|`), `( )` for grouping (not `\( \)`). If you get zero results, check for POSIX-style escapes. Scalex will print a hint if it detects this.
+
+Use `-e` to search multiple patterns in one call — they're combined with `|`. Use `--count` to get match/file counts without full output (great for triaging before reading all results). Use `-C N` to show context lines around each match.
 
 ```bash
 scalex grep "def.*process" --no-tests          # find method-like patterns
 scalex grep "ctx\.settings" --path compiler/src/ -C 2  # with context
 scalex grep "TODO|FIXME|HACK"                  # find code markers
+scalex grep -e "Ystop" -e "stopAfter" --path compiler/src/  # multi-pattern
+scalex grep "isRunnable" --count               # count only: "31 matches across 15 files"
 ```
 ```
   src/main/scala/Service.scala:45 — def processPayment(amount: BigDecimal): Unit =
@@ -166,13 +170,13 @@ scalex packages
 
 ### `scalex batch [-w workspace]` — multiple queries, one index load
 
-Reads queries from stdin, loads index once. Use when you need several lookups — avoids re-loading the index for each command. 5 queries in ~1s instead of ~5s.
+Reads queries from stdin, loads index once. Use when you need several lookups — avoids re-loading the index for each command. 5 queries in ~1s instead of ~5s. Supports all subcommands: `def`, `impl`, `refs`, `search`, `imports`, `annotated`, `grep`, `symbols`, `packages`, `file`.
 
 The workspace is set on the `batch` subcommand, not per-query. Use `-w` or pass it as a positional arg after `batch`:
 
 ```bash
 echo -e "def UserService\nimpl UserService\nimports UserService" | scalex batch -w /path/to/project
-echo -e "def UserService\nimpl UserService" | scalex batch /path/to/project
+echo -e "def UserService\ngrep processPayment\nimpl UserService" | scalex batch /path/to/project
 ```
 
 ### `scalex index` — force reindex
@@ -191,6 +195,8 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 | `--no-tests` | Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.) |
 | `--path PREFIX` | Restrict results to files under PREFIX (e.g. `compiler/src/`) |
 | `-C N` | Show N context lines around each reference (refs, grep) |
+| `-e PATTERN` | Grep: additional pattern (repeatable); combined with `\|` |
+| `--count` | Grep: output match/file count only, no full results |
 | `--json` | Output results as JSON — structured output for programmatic parsing |
 
 ## Common workflows
@@ -218,6 +224,12 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 **"Find all deprecated APIs"** → `scalex annotated deprecated` (or any annotation: `@main`, `@tailrec`, etc.)
 
 **"Search for a pattern in Scala files"** → `scalex grep "pattern"` — prefer this over the Grep tool for `.scala` files since it integrates with `--path` and `--no-tests`
+
+**"Search for multiple patterns at once"** → `scalex grep -e "pattern1" -e "pattern2"` — combined with `|`, one process invocation
+
+**"How many files match this pattern?"** → `scalex grep "pattern" --count` — quick triage before reading all results
+
+**"I need grep + def + refs in one shot"** → use `batch`: `echo -e "grep processPayment\ndef PaymentService\nrefs PaymentService" | scalex batch -w /project`
 
 **"I need structured output for scripting"** → append `--json` to any command (e.g. `scalex def X --json`)
 

--- a/scalex.scala
+++ b/scalex.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 import com.google.common.hash.{BloomFilter, Funnels}
 
-val ScalexVersion = "1.6.0"
+val ScalexVersion = "1.7.0"
 
 // ── Data types ──────────────────────────────────────────────────────────────
 
@@ -847,6 +847,9 @@ def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String): Unit =
     println(s"  ${idx.parseFailures} files had parse errors (run `scalex index --verbose` to list them).")
   println(s"  Fallback: use Grep, Glob, or Read tools to search manually.")
 
+def hasRegexHint(pattern: String): Boolean =
+  pattern.contains("\\|") || pattern.contains("\\(") || pattern.contains("\\)")
+
 def resolveWorkspace(path: String): Path =
   val p = Path.of(path).toAbsolutePath.normalize
   if Files.isDirectory(p) then p else p.getParent
@@ -860,7 +863,8 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(Path, String)] =
 def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: Path,
                limit: Int, kindFilter: Option[String], verbose: Boolean, categorize: Boolean,
                noTests: Boolean, pathFilter: Option[String], contextLines: Int,
-               jsonOutput: Boolean): Unit =
+               jsonOutput: Boolean, grepPatterns: List[String] = Nil,
+               countOnly: Boolean = false): Unit =
   val fmt = if verbose then formatSymbolVerbose else formatSymbol
   val jRef: Reference => String =
     if contextLines > 0 then r => jsonRefWithContext(r, workspace, contextLines)
@@ -1126,17 +1130,28 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
               if results.size > limit then println(s"  ... and ${results.size - limit} more")
 
     case "grep" =>
-      rest.headOption match
+      val patternOpt = if grepPatterns.nonEmpty then Some(grepPatterns.mkString("|"))
+                       else rest.headOption
+      patternOpt match
         case None => println("Usage: scalex grep <pattern>")
         case Some(pattern) =>
           val (results, grepTimedOut) = idx.grepFiles(pattern, noTests, pathFilter)
-          if jsonOutput then
+          if countOnly then
+            val fileCount = results.map(_.file).distinct.size
+            if jsonOutput then println(s"""{"matches":${results.size},"files":$fileCount,"timedOut":$grepTimedOut}""")
+            else
+              val suffix = if grepTimedOut then " (timed out — partial results)" else ""
+              println(s"${results.size} matches across $fileCount files$suffix")
+          else if jsonOutput then
             val arr = results.take(limit).map(jRef).mkString("[", ",", "]")
-            println(s"""{"results":$arr,"timedOut":$grepTimedOut}""")
+            val hint = if results.isEmpty && hasRegexHint(pattern) then ",\"hint\":\"scalex uses Java regex — use | not \\\\| for alternation, ( ) not \\\\( \\\\)\"" else ""
+            println(s"""{"results":$arr,"timedOut":$grepTimedOut$hint}""")
           else
             val suffix = if grepTimedOut then " (timed out — partial results)" else ""
             if results.isEmpty then
               println(s"No matches for \"$pattern\"$suffix")
+              if hasRegexHint(pattern) then
+                println("  Hint: scalex uses Java regex — use | not \\| for alternation, ( ) not \\( \\)")
             else
               val fmtRef: Reference => String =
                 if contextLines > 0 then r => formatRefWithContext(r, workspace, contextLines)
@@ -1171,14 +1186,18 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
     case -1 => 0
     case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
   val jsonOutput = argList.contains("--json")
+  val countOnly = argList.contains("--count")
+  val grepPatterns: List[String] = argList.zipWithIndex.collect {
+    case ("-e", i) if argList.lift(i + 1).exists(a => !a.startsWith("-")) => argList(i + 1)
+  }
   val explicitWorkspace: Option[String] =
     val longIdx = argList.indexOf("--workspace")
     val shortIdx = argList.indexOf("-w")
     val idx = if longIdx >= 0 then longIdx else shortIdx
     if idx >= 0 then argList.lift(idx + 1) else None
 
-  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "-C")
-  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || {
+  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "-C", "-e")
+  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || a == "-e" || {
     val prev = argList.indexOf(a) - 1
     prev >= 0 && flagsWithArgs.contains(argList(prev))
   })
@@ -1210,6 +1229,8 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
         |  --no-tests            Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.)
         |  --path PREFIX         Restrict results to files under PREFIX (e.g. compiler/src/)
         |  -C N                  Show N context lines around each reference (refs, grep)
+        |  -e PATTERN            Grep: additional pattern (combine multiple with |); repeatable
+        |  --count               Grep: show match/file count only, no full results
         |  --json                Output results as JSON (structured output for programmatic use)
         |  --version             Print version and exit
         |
@@ -1229,7 +1250,7 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
           val batchCmd = parts.head
           val batchRest = parts.tail
           println(s">>> $line")
-          runCommand(batchCmd, batchRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines, jsonOutput)
+          runCommand(batchCmd, batchRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines, jsonOutput, grepPatterns, countOnly)
           println()
         line = reader.readLine()
 
@@ -1250,4 +1271,4 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       val bloomCmds = Set("refs", "imports")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))
       idx.index()
-      runCommand(cmd, cmdRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines, jsonOutput)
+      runCommand(cmd, cmdRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines, jsonOutput, grepPatterns, countOnly)


### PR DESCRIPTION
## Summary
- **`-e` flag** for multi-pattern grep — `scalex grep -e "Ystop" -e "stopAfter"`; patterns combined with `|`, one process invocation
- **`--count` flag** — `scalex grep "pattern" --count` outputs `"31 matches across 15 files"` for quick triage
- **Regex syntax hint** — when grep returns zero results and pattern contains `\|`, `\(`, or `\)`, emits hint about Java regex syntax (text + JSON modes)
- **Batch grep docs** — grep already works in batch mode; updated SKILL.md to document this

## Test plan
- [x] All 103 existing tests pass
- [x] `scalex grep '\|foo'` → shows regex hint
- [x] `scalex grep -e "def" -e "val" --count` → multi-pattern + count
- [x] `scalex grep "SymbolInfo" --count` → count only
- [x] `echo "grep SymbolInfo" | scalex batch` → batch grep works
- [x] JSON output with hint and count verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)