### PR TITLE
chore: update CI actions to Node.js 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:
@@ -24,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: graalvm/setup-graalvm@v1
         with:
@@ -56,7 +59,7 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |
@@ -67,9 +70,9 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4 → v6 (Node 24 native)
- Upgrade `actions/upload-artifact` v4 → v7 (Node 24 native)
- Upgrade `actions/download-artifact` v4 → v8 (Node 24 native)
- Upgrade `actions/checkout` in pages workflow v4 → v6
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env for actions that don't have Node 24 major versions yet (`graalvm/setup-graalvm@v1`, `VirtusLab/scala-cli-setup@v1`, `softprops/action-gh-release@v2`)

Fixes the "Node.js 20 actions are deprecated" warnings from v1.7.0 release workflow.

## Test plan
- [ ] Merge and verify next release workflow runs without Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)