### PR TITLE
feat: add test awareness — tests, coverage, body for test cases (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.12.0] — 2026-03-16
+
+### Added
+- `scalex tests [<pattern>] [--verbose] [--path PREFIX]` — list test cases structurally from MUnit, ScalaTest, and specs2 frameworks; optional name filter shows bodies inline (#56)
+- `scalex coverage <symbol>` — "is this symbol tested?" shorthand: refs filtered to test files only, with count and file list (#56)
+- `scalex body` now finds test cases — match `test("exact name")`, `it("name")`, `describe("name")`, `"name" in { }`, `"name" >> { }` by string literal (#56)
+- `isTestFile` detects scala-cli `*.test.scala` convention (#56)
+
 ## [1.11.0] — 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ scalex deps <symbol>            Show symbol dependencies        (aka: dependency
 scalex context <file:line>      Show enclosing scopes at line   (aka: scope chain)
 scalex diff <git-ref>           Symbol-level diff vs git ref    (aka: symbol diff)
 scalex ast-pattern              Structural AST search           (aka: pattern search)
+scalex tests                    List test cases structurally    (aka: find tests)
+scalex coverage <symbol>        Is this symbol tested?          (aka: test coverage)
 ```
 
 ### Options

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -223,6 +223,17 @@ Feedback from real-world AI-assisted exploration of the Scala 3 compiler (17.7k 
 - [x] `scalex diff [git-ref]` — changed symbols since a git ref; cheap via OID diffing of two indices (#54)
 - [ ] `scalex pattern <name>` — detect common Scala design patterns (F-bounded, typeclass, strategy via implicits) via heuristic AST matching (#53)
 
+### Test awareness (#56)
+
+Feedback from dogfooding scalex on itself — test cases (`test("name") { ... }`) are expression statements, not declarations, so they're invisible to the index. AI agents frequently need to find, list, and read test cases.
+
+**High priority:** — DONE
+- [x] `scalex tests [--verbose] [--path PREFIX]` — extract test names from common frameworks: MUnit `test("...")`, ScalaTest `"name" in { }` / `it("...") { }` / `describe("...") { }`, specs2. On-the-fly parse, heuristic pattern matching on `templ.stats` expressions. Returns test name + line + enclosing suite. Biggest gap when using scalex for test navigation.
+- [x] `scalex body` for test cases — extend body extraction to find `test("exact name") { ... }` blocks by matching the string literal in the first argument. Agent can do `body "extractBody finds method body" --in ScalexSuite` to read a specific test without opening the file.
+
+**Medium priority:** — DONE
+- [x] `scalex coverage <symbol>` — "is this function tested?" shorthand: refs filtered to test files only, with count and file list. Faster than `refs X` followed by manual test-file filtering. Shows test file names + line numbers where the symbol appears.
+
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scalex
-description: Scala code intelligence CLI for navigating Scala codebases (Scala 2 and 3). Use this skill whenever you're working in a project with .scala files and need to understand code structure — finding definitions, implementations, references, and imports; extracting bodies, members, scaladoc, and inheritance hierarchies; getting composite summaries (explain, deps, overview); or doing structural search (ast-pattern, grep, diff). Trigger on any Scala navigation task like "where is X defined", "who implements Y", "find usages of Z", "what methods does X have", "show me the body/source of X", "what's the inheritance tree", "explain this type", "what changed since last commit", "find types that extend X with method Y", or when you need to understand impact before renaming/refactoring. Also use proactively when exploring an unfamiliar Scala codebase — scalex is much faster and more structured than grep for Scala-specific queries. Supports fuzzy camelCase search (e.g. "hms" finds HttpMessageService). Always prefer scalex over grep/glob for Scala symbol and file lookups. Use `scalex grep` instead of the Grep tool for searching inside .scala files — it integrates with scalex's --path and --no-tests filters.
+description: Scala code intelligence CLI for navigating Scala codebases (Scala 2 and 3). Use this skill whenever you're working in a project with .scala files and need to understand code structure — finding where a class/trait/object is defined, who extends a trait, who uses or imports a symbol, what's in a file, what members a class has, reading scaladoc, getting a codebase overview, searching for files by name, finding annotated symbols, or searching file contents. Trigger on any Scala navigation task like "where is X defined", "who implements Y", "find usages of Z", "what methods does X have", "show me the body/source of X", "what's the inheritance tree", "explain this type", "what changed since last commit", "find types that extend X with method Y", or when you need to understand impact before renaming/refactoring. Also triggers on test navigation: "what tests exist", "is X tested", "show me the test for Y", "list test cases", "find tests that cover Z", "read that test body". Also use proactively when exploring an unfamiliar Scala codebase — scalex is much faster and more structured than grep for Scala-specific queries. Supports fuzzy camelCase search (e.g. "hms" finds HttpMessageService). Always prefer scalex over grep/glob for Scala symbol and file lookups. Use `scalex grep` instead of the Grep tool for searching inside .scala files — it integrates with scalex's --path and --no-tests filters.
 ---
 
 You have access to `scalex`, a Scala code intelligence CLI that understands Scala syntax (classes, traits, objects, enums, givens, extensions, type aliases, defs, vals). It parses source files via Scalameta — no compiler or build server needed. Works with both Scala 3 and Scala 2 files (tries Scala 3 dialect first, falls back to Scala 2.13).
@@ -228,13 +228,19 @@ Extracts the full source body of a def, val, var, type, class, trait, object, or
 
 Use `--in <owner>` to restrict to members of a specific enclosing type — essential when the same method name exists in multiple classes.
 
+**Also works with test cases** — pass the exact test name string to extract a test body. Matches `test("name")`, `it("name")`, `describe("name")`, `"name" in { }`, and `"name" >> { }` patterns. Use `--in SuiteName` to scope to a specific suite.
+
 ```bash
 scalex body findUser --in UserServiceLive    # method body in specific class
 scalex body UserService                       # full trait body
+scalex body "findUser returns None" --in UserServiceTest  # test case body
 ```
 ```
-Body of findUser — UserServiceLive — src/.../UserService.scala:9:
-  9    | def findUser(id: String): Option[User] = db.query(id)
+Body of findUser returns None — UserServiceTest — src/.../UserServiceTest.scala:4:
+  4    |   test("findUser returns None") {
+  5    |     val svc = UserServiceLive(Database.live)
+  6    |     assertEquals(svc.findUser("unknown"), None)
+  7    |   }
 ```
 
 ### `scalex hierarchy <symbol> [--up] [--down] [--no-tests] [--path PREFIX]` — type hierarchy
@@ -399,6 +405,41 @@ echo -e "def UserService\nimpl UserService\nimports UserService" | scalex batch 
 echo -e "def UserService\ngrep processPayment\nimpl UserService" | scalex batch /path/to/project
 ```
 
+### `scalex tests [<pattern>] [--verbose] [--path PREFIX] [--json]` — list test cases structurally
+
+Extract test names from common Scala test frameworks: MUnit `test("...")`, ScalaTest `it("...")` / `describe("...")` / `"name" in { }`, specs2 `"name" >> { }`. Scans test files only (including `*.test.scala`). On-the-fly parse, no bloom filters needed.
+
+Pass a `<pattern>` to filter tests by name (case-insensitive substring match). **When filtering, full test bodies are shown inline** — this is the fastest way to find and read a specific test in one command, no follow-up needed.
+
+```bash
+scalex tests                                    # List all test cases (names + lines)
+scalex tests extractBody                        # Filter + show bodies inline
+scalex tests "bloom filter"                     # Multi-word filter works too
+scalex tests --path src/test/scala/com/auth/    # Tests under a specific path
+scalex tests --verbose                          # Show body for every test (no filter needed)
+scalex tests --json                             # Structured JSON output
+```
+```
+ScalexSuite — scalex.test.scala:10:
+  test  "extractBody finds method body in a class"  :1798
+    1798 |   test("extractBody finds method body in a class") {
+    1799 |     val file = workspace.resolve("src/main/.../UserService.scala")
+    1800 |     val results = extractBody(file, "findUser", None)
+    1801 |     assert(results.nonEmpty, "Should find findUser body")
+    1802 |     ...
+    1806 |   }
+```
+
+### `scalex coverage <symbol>` — is this symbol tested?
+
+Shorthand for "find references in test files only". Shows how many test files reference the symbol and where. Faster than `refs X` followed by manual test-file filtering.
+
+```bash
+scalex coverage UserService                     # Is UserService tested?
+scalex coverage extractBody -w .                # Is extractBody tested?
+scalex coverage UserService --json              # JSON: testFileCount, referenceCount, references
+```
+
 ### `scalex index` — force reindex
 
 Normally not needed — every command auto-reindexes changed files. Use after major branch switches or large merges to get a clean reindex.
@@ -497,6 +538,14 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 **"Show me inherited members too"** → `scalex members MyClass --inherited` (own + parent members)
 
 **"Show architecture"** → `scalex overview --architecture` (package deps + hub types)
+
+**"What tests exist?"** → `scalex tests` (lists all test cases with suite + line)
+
+**"Find tests for X / show me tests about X"** → `scalex tests extractBody` (filter by name + show bodies inline — one command, no follow-up)
+
+**"Is this function tested?"** → `scalex coverage extractBody` (refs in test files only, with count + locations)
+
+**"Show me a specific test"** → `scalex body "exact test name" --in MySuite` (when you know the exact name)
 
 ## Fallback
 

--- a/scalex.scala
+++ b/scalex.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 import com.google.common.hash.{BloomFilter, Funnels}
 
-val ScalexVersion = "1.11.0"
+val ScalexVersion = "1.12.0"
 
 // ── Data types ──────────────────────────────────────────────────────────────
 
@@ -263,6 +263,9 @@ case class ScopeInfo(name: String, kind: String, line: Int)
 
 case class DiffSymbol(name: String, kind: SymbolKind, file: String, line: Int, packageName: String, signature: String)
 
+case class TestCaseInfo(name: String, line: Int, suiteName: String, suiteFile: Path)
+case class TestSuiteInfo(name: String, file: Path, line: Int, tests: List[TestCaseInfo])
+
 def extractMembers(file: Path, symbolName: String): List[MemberInfo] =
   parseFile(file) match
     case None => Nil
@@ -358,6 +361,65 @@ def extractScaladoc(file: Path, targetLine: Int): Option[String] =
     Some(lines(endLine))
   else None
 
+// ── Test extraction ─────────────────────────────────────────────────────
+
+private val testFnNames = Set("test", "it", "describe")
+
+private def extractTestName(t: Tree): Option[(String, Int)] =
+  t match
+    case app: Term.Apply =>
+      app.fun match
+        case innerApp: Term.Apply =>
+          innerApp.fun match
+            case fn: Term.Name if testFnNames.contains(fn.value) =>
+              innerApp.argClause.values.collectFirst { case lit: Lit.String => (lit.value, app.pos.startLine + 1) }
+            case _ => None
+        case _ => None
+    case infix: Term.ApplyInfix =>
+      if infix.op.value == "in" || infix.op.value == ">>" then
+        infix.lhs match
+          case lit: Lit.String => Some((lit.value, infix.pos.startLine + 1))
+          case _ => None
+      else None
+    case _ => None
+
+def extractTests(file: Path): List[TestSuiteInfo] = {
+  parseFile(file) match
+    case None => Nil
+    case Some(tree) =>
+      val suites = mutable.ListBuffer.empty[TestSuiteInfo]
+
+      def collectTests(stats: List[Tree], suiteName: String): List[TestCaseInfo] = {
+        val tests = mutable.ListBuffer.empty[TestCaseInfo]
+        def visit(t: Tree): Unit = {
+          extractTestName(t) match
+            case Some((name, line)) =>
+              tests += TestCaseInfo(name, line, suiteName, file)
+            case None =>
+          t.children.foreach(visit)
+        }
+        stats.foreach(visit)
+        tests.toList
+      }
+
+      def findSuites(t: Tree): Unit = {
+        t match
+          case d: Defn.Class =>
+            val tests = collectTests(d.templ.stats, d.name.value)
+            if tests.nonEmpty then
+              suites += TestSuiteInfo(d.name.value, file, d.pos.startLine + 1, tests)
+          case d: Defn.Object =>
+            val tests = collectTests(d.templ.stats, d.name.value)
+            if tests.nonEmpty then
+              suites += TestSuiteInfo(d.name.value, file, d.pos.startLine + 1, tests)
+          case _ =>
+        t.children.foreach(findSuites)
+      }
+
+      findSuites(tree)
+      suites.toList
+}
+
 // ── Body extraction ─────────────────────────────────────────────────────────
 
 def extractBody(file: Path, symbolName: String, ownerName: Option[String]): List[BodyInfo] = {
@@ -430,6 +492,26 @@ def extractBody(file: Path, symbolName: String, ownerName: Option[String]): List
               val body = (sl to el).map(lines(_)).mkString("\n")
               buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
             d.templ.stats.foreach(s => extractFromTree(s, d.name.value))
+          case app: Term.Apply =>
+            extractTestName(app) match
+              case Some((name, _)) if name == symbolName =>
+                if ownerName.isEmpty || ownerName.contains(currentOwner) then
+                  val sl = app.pos.startLine
+                  val el = app.pos.endLine
+                  val body = (sl to el).map(lines(_)).mkString("\n")
+                  buf += BodyInfo(currentOwner, name, body, sl + 1, el + 1)
+              case _ =>
+            app.children.foreach(c => extractFromTree(c, currentOwner))
+          case infix: Term.ApplyInfix =>
+            extractTestName(infix) match
+              case Some((name, _)) if name == symbolName =>
+                if ownerName.isEmpty || ownerName.contains(currentOwner) then
+                  val sl = infix.pos.startLine
+                  val el = infix.pos.endLine
+                  val body = (sl to el).map(lines(_)).mkString("\n")
+                  buf += BodyInfo(currentOwner, name, body, sl + 1, el + 1)
+              case _ =>
+            infix.children.foreach(c => extractFromTree(c, currentOwner))
           case p: Pkg =>
             p.stats.foreach(s => extractFromTree(s, currentOwner))
           case _ =>
@@ -1304,7 +1386,8 @@ def isTestFile(path: Path, workspace: Path): Boolean =
   val rel = workspace.relativize(path).toString
   rel.contains("/test/") || rel.contains("/tests/") || rel.contains("/testing/") ||
   rel.startsWith("bench-") || rel.contains("/bench-") ||
-  rel.endsWith("Test.scala") || rel.endsWith("Spec.scala") || rel.endsWith("Suite.scala")
+  rel.endsWith("Test.scala") || rel.endsWith("Spec.scala") || rel.endsWith("Suite.scala") ||
+  rel.endsWith(".test.scala")
 
 def matchesPath(file: Path, prefix: String, workspace: Path): Boolean =
   val rel = workspace.relativize(file).toString
@@ -1993,6 +2076,85 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
                 println()
               }
 
+    case "tests" =>
+      val nameFilter = rest.headOption
+      var filesToScan = idx.gitFiles.map(_.path).filter(f => isTestFile(f, workspace))
+      pathFilter.foreach { p => filesToScan = filesToScan.filter(f => matchesPath(f, p, workspace)) }
+      val allSuites = filesToScan.flatMap(extractTests).map { suite =>
+        nameFilter match
+          case Some(pattern) =>
+            val lower = pattern.toLowerCase
+            val filtered = suite.tests.filter(_.name.toLowerCase.contains(lower))
+            suite.copy(tests = filtered)
+          case None => suite
+      }.filter(_.tests.nonEmpty)
+      val showBody = nameFilter.isDefined
+      if jsonOutput then
+        val arr = allSuites.take(limit).map { suite =>
+          val rel = jsonEscape(workspace.relativize(suite.file).toString)
+          val fileLines = if showBody then
+            try Files.readAllLines(suite.file).asScala.toArray catch case _: Exception => Array.empty[String]
+          else Array.empty[String]
+          val testsJson = suite.tests.map { tc =>
+            val bodyField = if showBody then {
+              val bodies = extractBody(suite.file, tc.name, Some(suite.name))
+              bodies.headOption.map(b => s""","body":"${jsonEscape(b.sourceText)}"""").getOrElse("")
+            } else ""
+            s"""{"name":"${jsonEscape(tc.name)}","line":${tc.line}$bodyField}"""
+          }.mkString("[", ",", "]")
+          s"""{"suite":"${jsonEscape(suite.name)}","file":"$rel","line":${suite.line},"tests":$testsJson}"""
+        }.mkString("[", ",", "]")
+        println(arr)
+      else
+        if allSuites.isEmpty then
+          if nameFilter.isDefined then println(s"No tests matching \"${nameFilter.get}\"")
+          else println("No test suites found")
+        else
+          allSuites.take(limit).foreach { suite =>
+            val rel = workspace.relativize(suite.file)
+            println(s"${suite.name} — $rel:${suite.line}:")
+            suite.tests.foreach { tc =>
+              println(s"  test  \"${tc.name}\"  :${tc.line}")
+              if showBody || verbose then
+                val bodies = extractBody(suite.file, tc.name, Some(suite.name))
+                bodies.headOption.foreach { b =>
+                  val bodyLines = b.sourceText.split("\n")
+                  bodyLines.zipWithIndex.foreach { case (line, i) =>
+                    println(s"    ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
+                  }
+                  println()
+                }
+            }
+            if !showBody && !verbose then println()
+          }
+
+    case "coverage" =>
+      rest.headOption match
+        case None => println("Usage: scalex coverage <symbol>")
+        case Some(symbol) =>
+          val refs = idx.findReferences(symbol)
+          val testRefs = refs.filter(r => isTestFile(r.file, workspace))
+          val testFiles = testRefs.map(r => workspace.relativize(r.file).toString).distinct
+          if jsonOutput then
+            val refsJson = testRefs.take(limit).map(r => jRef(r)).mkString("[", ",", "]")
+            println(s"""{"symbol":"${jsonEscape(symbol)}","testFileCount":${testFiles.size},"referenceCount":${testRefs.size},"references":$refsJson}""")
+          else
+            if testRefs.isEmpty then
+              if refs.isEmpty then
+                println(s"""Coverage of "$symbol" — no references found""")
+                printNotFoundHint(symbol, idx, "coverage", batchMode)
+              else
+                println(s"""Coverage of "$symbol" — ${refs.size} refs but 0 in test files""")
+            else
+              println(s"""Coverage of "$symbol" — ${testRefs.size} refs in ${testFiles.size} test files:""")
+              testFiles.sorted.foreach { f =>
+                val fileRefs = testRefs.filter(r => workspace.relativize(r.file).toString == f)
+                println(s"  $f")
+                fileRefs.take(limit).foreach { r =>
+                  println(s"    :${r.line}  ${r.contextLine}")
+                }
+              }
+
     case "hierarchy" =>
       rest.headOption match
         case None => println("Usage: scalex hierarchy <symbol> [--up] [--down]")
@@ -2411,6 +2573,8 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
         |  scalex context <file:line>      Show enclosing scopes at line   (aka: scope chain)
         |  scalex diff <git-ref>           Symbol-level diff vs git ref    (aka: symbol diff)
         |  scalex ast-pattern              Structural AST search           (aka: pattern search)
+        |  scalex tests                    List test cases structurally    (aka: find tests)
+        |  scalex coverage <symbol>        Is this symbol tested?          (aka: test coverage)
         |
         |Options:
         |  -w, --workspace PATH  Set workspace path (default: current directory)
@@ -2477,7 +2641,7 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
                 case ws :: arg :: tail => (resolveWorkspace(ws), arg :: tail)
                 case Nil => (resolveWorkspace("."), Nil)
 
-      val bloomCmds = Set("refs", "imports")
+      val bloomCmds = Set("refs", "imports", "coverage")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))
       idx.index()
       runCommand(cmd, cmdRest, idx, workspace, limit, kindFilter, verbose, categorize, noTests, pathFilter, contextLines, jsonOutput, grepPatterns, countOnly, searchMode = searchMode, definitionsOnly = definitionsOnly, categoryFilter = categoryFilter,

--- a/scalex.test.scala
+++ b/scalex.test.scala
@@ -160,6 +160,23 @@ class ScalexSuite extends FunSuite:
         |}
         |""".stripMargin)
 
+    writeFile("src/test/scala/com/example/UserServiceTest.scala",
+      """package com.example
+        |
+        |class UserServiceTest extends munit.FunSuite {
+        |  test("findUser returns None for unknown id") {
+        |    val svc = UserServiceLive(Database.live)
+        |    assertEquals(svc.findUser("unknown"), None)
+        |  }
+        |
+        |  test("createUser returns new user") {
+        |    val svc = UserServiceLive(Database.live)
+        |    val user = svc.createUser("Alice")
+        |    assertEquals(user.name, "Alice")
+        |  }
+        |}
+        |""".stripMargin)
+
     // Initialize git repo
     run("git", "init")
     run("git", "add", ".")
@@ -191,7 +208,7 @@ class ScalexSuite extends FunSuite:
 
   test("gitLsFiles finds all .scala files") {
     val files = gitLsFiles(workspace)
-    assertEquals(files.size, 11)
+    assertEquals(files.size, 12)
     assert(files.exists(_.path.toString.contains("UserService.scala")))
     assert(files.exists(_.path.toString.contains("Model.scala")))
     assert(files.exists(_.path.toString.contains("Database.scala")))
@@ -305,7 +322,7 @@ class ScalexSuite extends FunSuite:
     val idx = WorkspaceIndex(workspace)
     idx.index()
 
-    assert(idx.fileCount == 11)
+    assert(idx.fileCount == 12)
     assert(idx.symbols.size > 10)
     assert(idx.packages.contains("com.example"))
     assert(idx.packages.contains("com.other"))
@@ -448,13 +465,13 @@ class ScalexSuite extends FunSuite:
     // First index — cold
     val idx1 = WorkspaceIndex(workspace)
     idx1.index()
-    assert(idx1.parsedCount == 11, s"Cold index should parse all 11 files, got ${idx1.parsedCount}")
+    assert(idx1.parsedCount == 12, s"Cold index should parse all 12 files, got ${idx1.parsedCount}")
 
     // Second index — warm (all cached)
     val idx2 = WorkspaceIndex(workspace)
     idx2.index()
     assert(idx2.cachedLoad, "Second index should load from cache")
-    assert(idx2.skippedCount == 11, s"Warm index should skip all 11 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 12, s"Warm index should skip all 12 files, got ${idx2.skippedCount}")
     assert(idx2.parsedCount == 0, s"Warm index should parse 0 files, got ${idx2.parsedCount}")
 
     // Symbols should be identical
@@ -478,7 +495,7 @@ class ScalexSuite extends FunSuite:
     idx2.index()
     assert(idx2.cachedLoad)
     assert(idx2.parsedCount == 1, s"Should re-parse 1 file, got ${idx2.parsedCount}")
-    assert(idx2.skippedCount == 10, s"Should skip 10 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 11, s"Should skip 11 files, got ${idx2.skippedCount}")
   }
 
   // ── Binary format ─────────────────────────────────────────────────────
@@ -1032,6 +1049,12 @@ class ScalexSuite extends FunSuite:
     assert(isTestFile(workspace.resolve("src/bench-run/Foo.scala"), workspace))
   }
 
+  test("isTestFile detects scala-cli .test.scala convention") {
+    assert(isTestFile(workspace.resolve("scalex.test.scala"), workspace))
+    assert(isTestFile(workspace.resolve("src/foo.test.scala"), workspace))
+    assert(!isTestFile(workspace.resolve("src/foo.scala"), workspace))
+  }
+
   // ── --kind on def ──────────────────────────────────────────────────
 
   test("def --kind filters by symbol kind") {
@@ -1392,7 +1415,7 @@ class ScalexSuite extends FunSuite:
     }
     val output = out.toString
     assert(output.contains("User"), s"Should find exact match 'User': $output")
-    assert(!output.contains("UserService"), s"Should NOT find 'UserService' (not exact): $output")
+    assert(!output.contains("UserService ("), s"Should NOT find 'UserService' as symbol (not exact): $output")
   }
 
   test("search --prefix returns exact + prefix matches only") {
@@ -2103,4 +2126,93 @@ class ScalexSuite extends FunSuite:
     assert(output.startsWith("{"), s"JSON should start with brace: $output")
     assert(output.contains("\"packageDependencies\""), s"JSON should contain packageDependencies: $output")
     assert(output.contains("\"hubTypes\""), s"JSON should contain hubTypes: $output")
+  }
+
+  // ── Test awareness: extractTests ────────────────────────────────────────
+
+  test("extractTests finds test cases in MUnit suite") {
+    val file = workspace.resolve("src/test/scala/com/example/UserServiceTest.scala")
+    val suites = extractTests(file)
+    assert(suites.nonEmpty, "Should find at least one suite")
+    val suite = suites.find(_.name == "UserServiceTest").get
+    assertEquals(suite.tests.size, 2)
+    val testNames = suite.tests.map(_.name)
+    assert(testNames.contains("findUser returns None for unknown id"), s"Test names: $testNames")
+    assert(testNames.contains("createUser returns new user"), s"Test names: $testNames")
+  }
+
+  test("extractTests returns empty for non-test file") {
+    val file = workspace.resolve("src/main/scala/com/example/Model.scala")
+    val suites = extractTests(file)
+    assert(suites.isEmpty, s"Non-test file should have no suites: ${suites.map(_.name)}")
+  }
+
+  test("tests command --json output") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      runCommand("tests", Nil, idx, workspace, 20, None, false, false, false, None, 0, true)
+    }
+    val output = out.toString.trim
+    assert(output.startsWith("["), s"JSON should start with [: $output")
+    assert(output.contains("\"suite\":\"UserServiceTest\""), s"Should contain suite name: $output")
+    assert(output.contains("\"name\":\"findUser returns None for unknown id\""), s"Should contain test name: $output")
+  }
+
+  // ── Test awareness: body for test cases ──────────────────────────────────
+
+  test("extractBody finds test case body by exact name") {
+    val file = workspace.resolve("src/test/scala/com/example/UserServiceTest.scala")
+    val results = extractBody(file, "findUser returns None for unknown id", None)
+    assert(results.nonEmpty, "Should find test body")
+    val body = results.head
+    assert(body.sourceText.contains("findUser"), s"Body should contain test code: ${body.sourceText}")
+    assert(body.ownerName == "UserServiceTest", s"Owner should be UserServiceTest: ${body.ownerName}")
+  }
+
+  test("extractBody finds test body with --in owner") {
+    val file = workspace.resolve("src/test/scala/com/example/UserServiceTest.scala")
+    val results = extractBody(file, "createUser returns new user", Some("UserServiceTest"))
+    assert(results.nonEmpty, "Should find test body with owner filter")
+    val body = results.head
+    assert(body.sourceText.contains("createUser"), s"Body should contain test code: ${body.sourceText}")
+  }
+
+  // ── Test awareness: coverage ─────────────────────────────────────────────
+
+  test("coverage finds refs only in test files") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      runCommand("coverage", List("UserService"), idx, workspace, 20, None, false, false, false, None, 0, false)
+    }
+    val output = out.toString
+    assert(output.contains("Coverage of"), s"Should show coverage header: $output")
+    assert(output.contains("test"), s"Should mention test files: $output")
+  }
+
+  test("coverage excludes non-test file refs") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val refs = idx.findReferences("UserService")
+    val allFiles = refs.map(r => workspace.relativize(r.file).toString).distinct
+    val testFiles = refs.filter(r => isTestFile(r.file, workspace)).map(r => workspace.relativize(r.file).toString).distinct
+    // There should be refs in non-test files too
+    assert(allFiles.size > testFiles.size, s"Should have non-test refs too: all=$allFiles test=$testFiles")
+  }
+
+  test("coverage --json output") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      runCommand("coverage", List("UserService"), idx, workspace, 20, None, false, false, false, None, 0, true)
+    }
+    val output = out.toString.trim
+    assert(output.startsWith("{"), s"JSON should start with brace: $output")
+    assert(output.contains("\"symbol\":\"UserService\""), s"Should contain symbol: $output")
+    assert(output.contains("\"testFileCount\""), s"Should contain testFileCount: $output")
+    assert(output.contains("\"referenceCount\""), s"Should contain referenceCount: $output")
   }

--- a/site/index.html
+++ b/site/index.html
@@ -486,7 +486,7 @@
 
   <!-- Commands -->
   <section class="reveal">
-    <h2>23 commands. <span class="red">Zero config.</span></h2>
+    <h2>25 commands. <span class="red">Zero config.</span></h2>
     <p class="section-sub">Point it at any git repo with Scala files. Works on Scala 2 and 3, auto-detects dialect per file.</p>
 
     <div class="cmd-grid">
@@ -581,6 +581,14 @@
       <div class="cmd-card">
         <div class="cmd-name">scalex ast-pattern</div>
         <div class="cmd-desc">Structural AST search — find types by extends, methods, or body content.</div>
+      </div>
+      <div class="cmd-card">
+        <div class="cmd-name">scalex tests</div>
+        <div class="cmd-desc">List test cases structurally — MUnit, ScalaTest, specs2. Suite name + test name + line.</div>
+      </div>
+      <div class="cmd-card">
+        <div class="cmd-name">scalex coverage</div>
+        <div class="cmd-desc">Is this symbol tested? Refs filtered to test files only, with count and file list.</div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- **`scalex tests [<pattern>]`** — list test cases structurally from MUnit, ScalaTest FunSuite/FunSpec/WordSpec, and specs2. Optional name filter shows full test bodies inline — one command to find and read tests.
- **`scalex coverage <symbol>`** — "is this symbol tested?" shorthand: refs filtered to test files only, with count and file list.
- **`scalex body` for test cases** — `body "test name" --in Suite` now matches `test("name")`, `it("name")`, `describe("name")`, `"name" in { }`, `"name" >> { }` by string literal.
- **`isTestFile` improvement** — detects scala-cli `*.test.scala` convention (caught by dogfooding on scalex itself).

## Test plan
- [x] 173 tests pass (`scala-cli test scalex.scala scalex.test.scala`)
- [x] Dogfooded: `scalex tests -w .` lists all 173 ScalexSuite tests
- [x] Dogfooded: `scalex tests extractBody -w .` filters + shows bodies inline
- [x] Dogfooded: `scalex body "extractTests finds test cases in MUnit suite" --in ScalexSuite -w .`
- [x] Dogfooded: `scalex coverage isTestFile -w .` → 25 refs in 1 test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)