### PR TITLE
fix: filter stdlib types from overview --architecture hub types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `overview --architecture` "Most extended" and "Hub types" no longer dominated by stdlib/framework types (`None`, `AnyVal`, `Object`, etc.) — both lists now filter to types defined in the indexed codebase (#64)
+
 ## [1.13.0] — 2026-03-16
 
 ### Fixed

--- a/scalex.scala
+++ b/scalex.scala
@@ -1962,7 +1962,9 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
     case "overview" =>
       val symbolsByKind = idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size)
       val topPackages = idx.packageToSymbols.toList.sortBy(-_._2.size).take(limit)
-      val mostExtended = idx.parentIndex.toList.sortBy(-_._2.size).take(limit)
+      val mostExtended = idx.parentIndex.toList
+        .filter((name, _) => idx.symbolsByName.contains(name))
+        .sortBy(-_._2.size).take(limit)
 
       // Architecture: compute package dependency graph from imports
       val archPkgDeps: Map[String, Set[String]] = if architecture then {
@@ -1994,7 +1996,8 @@ def runCommand(cmd: String, rest: List[String], idx: WorkspaceIndex, workspace: 
       val hubTypes: List[(String, Int)] = if architecture then {
         val refCounts = mutable.HashMap.empty[String, Int]
         idx.parentIndex.foreach { (name, impls) =>
-          refCounts(name) = refCounts.getOrElse(name, 0) + impls.size
+          if idx.symbolsByName.contains(name) then
+            refCounts(name) = refCounts.getOrElse(name, 0) + impls.size
         }
         refCounts.toList.sortBy(-_._2).take(limit)
       } else Nil


### PR DESCRIPTION
## Summary
- Filter `mostExtended` and `hubTypes` in `overview --architecture` to only include types defined in the indexed codebase
- Stdlib/framework types like `None`, `AnyVal`, `Object` no longer dominate the output
- Uses existing `symbolsByName` index — no schema changes, no perf impact

Closes #64

## Test plan
- [x] All 176 existing tests pass
- [ ] Run `scalex overview --architecture` on a real project and confirm stdlib types no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)