### PR TITLE
refactor: extract CmdResult enum — commands return data, render at boundary

### DIFF
--- a/src/cli.test.scala
+++ b/src/cli.test.scala
@@ -290,26 +290,26 @@ class CliSuite extends ScalexTestBase:
 
   // ── condensed not-found in batch mode ──────────────────────────────────
 
-  test("printNotFoundHint in batch mode prints single line") {
+  test("not-found hint in batch mode is condensed") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
     val out = new java.io.ByteArrayOutputStream()
     Console.withOut(out) {
-      printNotFoundHint("NonExistent", idx, "def", batchMode = true)
+      runCommand("def", List("NonExistent"), CommandContext(idx = idx, workspace = workspace, batchMode = true))
     }
-    val output = out.toString.trim
-    assert(output.startsWith("not found"), s"Batch not-found should be single line: $output")
+    val output = out.toString
+    assert(output.contains("not found"), s"Should contain not found: $output")
     assert(output.contains("files"), s"Should mention file count: $output")
     assert(!output.contains("Hint:"), s"Should NOT contain verbose hints: $output")
     assert(!output.contains("Fallback:"), s"Should NOT contain fallback: $output")
   }
 
-  test("printNotFoundHint in normal mode prints full hints") {
+  test("not-found hint in normal mode has full hints") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
     val out = new java.io.ByteArrayOutputStream()
     Console.withOut(out) {
-      printNotFoundHint("NonExistent", idx, "def", batchMode = false)
+      runCommand("def", List("NonExistent"), CommandContext(idx = idx, workspace = workspace, batchMode = false))
     }
     val output = out.toString
     assert(output.contains("Hint:"), s"Normal mode should contain Hint: $output")

--- a/src/commands.scala
+++ b/src/commands.scala
@@ -4,17 +4,6 @@ import scala.jdk.CollectionConverters.*
 
 // ── Command helpers ─────────────────────────────────────────────────────────
 
-def printNotFoundHint(symbol: String, idx: WorkspaceIndex, cmd: String, batchMode: Boolean = false): Unit =
-  if batchMode then
-    println(s"  not found (0 matches in ${idx.fileCount} files)")
-  else
-    if symbol.contains("/") || symbol.startsWith(".") then
-      println(s"  Note: \"$symbol\" looks like a path. Did you mean: scalex $cmd -w <workspace> $symbol?")
-    println(s"  Hint: scalex indexes ${idx.fileCount} git-tracked .scala files.")
-    if idx.parseFailures > 0 then
-      println(s"  ${idx.parseFailures} files had parse errors (run `scalex index --verbose` to list them).")
-    println(s"  Fallback: use Grep, Glob, or Read tools to search manually.")
-
 def hasRegexHint(pattern: String): Boolean =
   pattern.contains("\\|") || pattern.contains("\\(") || pattern.contains("\\)")
 
@@ -42,32 +31,24 @@ def filterRefs(refs: List[Reference], ctx: CommandContext): List[Reference] =
 
 // ── Command implementations ─────────────────────────────────────────────────
 
-def cmdIndex(args: List[String], ctx: CommandContext): Unit =
-  if ctx.jsonOutput then
-    val byKind = ctx.idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size)
-      .map((k, v) => s""""${k.toString.toLowerCase}":${v.size}""").mkString(",")
-    println(s"""{"fileCount":${ctx.idx.fileCount},"symbolCount":${ctx.idx.symbols.size},"packageCount":${ctx.idx.packages.size},"symbolsByKind":{$byKind},"indexTimeMs":${ctx.idx.indexTimeMs},"cachedLoad":${ctx.idx.cachedLoad},"parsedCount":${ctx.idx.parsedCount},"skippedCount":${ctx.idx.skippedCount},"parseFailures":${ctx.idx.parseFailures}}""")
-  else
-    if ctx.idx.cachedLoad then
-      println(s"Indexed ${ctx.idx.fileCount} files (${ctx.idx.skippedCount} cached, ${ctx.idx.parsedCount} parsed) in ${ctx.idx.indexTimeMs}ms")
-    else
-      println(s"Indexed ${ctx.idx.fileCount} files, ${ctx.idx.symbols.size} symbols in ${ctx.idx.indexTimeMs}ms")
-    println(s"Packages: ${ctx.idx.packages.size}")
-    println()
-    println("Symbols by kind:")
-    ctx.idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size).foreach { (kind, syms) =>
-      println(s"  ${kind.toString.padTo(10, ' ')} ${syms.size}")
-    }
-    if ctx.idx.parseFailures > 0 then
-      println(s"\n${ctx.idx.parseFailures} files had parse errors:")
-      if ctx.verbose then
-        ctx.idx.parseFailedFiles.sorted.foreach(f => println(s"  $f"))
-      else
-        println("  Run with --verbose to see the list.")
+def cmdIndex(args: List[String], ctx: CommandContext): CmdResult =
+  val byKind = ctx.idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size).map((k, v) => (kind = k, count = v.size))
+  CmdResult.IndexStats(
+    fileCount = ctx.idx.fileCount,
+    symbolCount = ctx.idx.symbols.size,
+    packageCount = ctx.idx.packages.size,
+    symbolsByKind = byKind,
+    indexTimeMs = ctx.idx.indexTimeMs,
+    cachedLoad = ctx.idx.cachedLoad,
+    parsedCount = ctx.idx.parsedCount,
+    skippedCount = ctx.idx.skippedCount,
+    parseFailures = ctx.idx.parseFailures,
+    parseFailedFiles = ctx.idx.parseFailedFiles
+  )
 
-def cmdSearch(args: List[String], ctx: CommandContext): Unit =
+def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex search <query>")
+    case None => CmdResult.UsageError("Usage: scalex search <query>")
     case Some(query) =>
       var results = ctx.idx.search(query)
       ctx.searchMode.foreach {
@@ -83,21 +64,19 @@ def cmdSearch(args: List[String], ctx: CommandContext): Unit =
         val defKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
         results = results.filter(s => defKinds.contains(s.kind))
       results = filterSymbols(results, ctx)
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-        println(arr)
+      if results.isEmpty then
+        CmdResult.NotFound(
+          s"""Found 0 symbols matching "$query"""",
+          NotFoundHint(query, ctx.idx.fileCount, ctx.idx.parseFailures, "search", ctx.batchMode, query.contains("/") || query.startsWith(".")))
       else
-        if results.isEmpty then
-          println(s"Found 0 symbols matching \"$query\"")
-          printNotFoundHint(query, ctx.idx, "search", ctx.batchMode)
-        else
-          println(s"Found ${results.size} symbols matching \"$query\":")
-          results.take(ctx.limit).foreach(s => println(ctx.fmt(s, ctx.workspace)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        CmdResult.SymbolList(
+          header = s"""Found ${results.size} symbols matching "$query":""",
+          symbols = results,
+          total = results.size)
 
-def cmdDef(args: List[String], ctx: CommandContext): Unit =
+def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex def <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex def <symbol>")
     case Some(symbol) =>
       var results = filterSymbols(ctx.idx.findDefinition(symbol), ctx)
       // Rank: class/trait/object/enum > type/given > def/val/var, non-test > test, shorter path first
@@ -110,231 +89,146 @@ def cmdDef(args: List[String], ctx: CommandContext): Unit =
         val pathLen = ctx.workspace.relativize(s.file).toString.length
         (kindRank, testRank, pathLen)
       }
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-        println(arr)
+      if results.isEmpty then
+        CmdResult.NotFound(
+          s"""Definition of "$symbol": not found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "def", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if results.isEmpty then
-          println(s"Definition of \"$symbol\": not found")
-          printNotFoundHint(symbol, ctx.idx, "def", ctx.batchMode)
-        else
-          println(s"Definition of \"$symbol\":")
-          results.take(ctx.limit).foreach(s => println(ctx.fmt(s, ctx.workspace)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        CmdResult.SymbolList(
+          header = s"""Definition of "$symbol":""",
+          symbols = results,
+          total = results.size)
 
-def cmdImpl(args: List[String], ctx: CommandContext): Unit =
+def cmdImpl(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex impl <trait>")
+    case None => CmdResult.UsageError("Usage: scalex impl <trait>")
     case Some(symbol) =>
       val results = filterSymbols(ctx.idx.findImplementations(symbol), ctx)
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-        println(arr)
+      if results.isEmpty then
+        CmdResult.NotFound(
+          s"""No implementations of "$symbol" found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "impl", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if results.isEmpty then
-          println(s"No implementations of \"$symbol\" found")
-          printNotFoundHint(symbol, ctx.idx, "impl", ctx.batchMode)
-        else
-          println(s"Implementations of \"$symbol\" — ${results.size} found:")
-          results.take(ctx.limit).foreach(s => println(ctx.fmt(s, ctx.workspace)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        CmdResult.SymbolList(
+          header = s"""Implementations of "$symbol" — ${results.size} found:""",
+          symbols = results,
+          total = results.size)
 
-def cmdRefs(args: List[String], ctx: CommandContext): Unit =
+def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex refs <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex refs <symbol>")
     case Some(symbol) =>
       val targetPkgs = ctx.idx.symbolsByName.getOrElse(symbol.toLowerCase, Nil).map(_.packageName).toSet
-      def filterByCategory(grouped: Map[RefCategory, List[Reference]]): Map[RefCategory, List[Reference]] =
+      def filterByCategory(grouped: Map[RefCategory, List[Reference]]): (filtered: Map[RefCategory, List[Reference]], stderrHint: Option[String]) =
         ctx.categoryFilter match
           case Some(catName) =>
             val validCats = RefCategory.values.map(_.toString.toLowerCase).toSet
             val lower = catName.toLowerCase
             if !validCats.contains(lower) then
-              System.err.println(s"Unknown category: $catName. Valid: ${RefCategory.values.map(_.toString).mkString(", ")}")
-              Map.empty
+              (Map.empty, Some(s"Unknown category: $catName. Valid: ${RefCategory.values.map(_.toString).mkString(", ")}"))
             else
-              grouped.filter((cat, _) => cat.toString.toLowerCase == lower)
-          case None => grouped
-      if ctx.jsonOutput then
-        if ctx.categorize then
-          val grouped = filterByCategory(ctx.idx.categorizeReferences(symbol).map((cat, refs) => (cat, filterRefs(refs, ctx))))
-          val entries = grouped.map { (cat, refs) =>
-            val arr = refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-            s""""${cat.toString}":$arr"""
-          }.mkString(",")
-          println(s"""{"categories":{$entries},"timedOut":${ctx.idx.timedOut}}""")
-        else
-          val results = filterRefs(ctx.idx.findReferences(symbol), ctx)
-          val arr = results.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-          println(s"""{"results":$arr,"timedOut":${ctx.idx.timedOut}}""")
+              (grouped.filter((cat, _) => cat.toString.toLowerCase == lower), None)
+          case None => (grouped, None)
+      if ctx.categorize then
+        val rawGrouped = ctx.idx.categorizeReferences(symbol).map((cat, refs) => (cat, filterRefs(refs, ctx)))
+        val (grouped, stderrHint) = filterByCategory(rawGrouped)
+        CmdResult.CategorizedRefs(symbol, grouped, targetPkgs, ctx.idx.timedOut, stderrHint)
       else
-        if ctx.categorize then
-          val grouped = filterByCategory(ctx.idx.categorizeReferences(symbol).map((cat, refs) => (cat, filterRefs(refs, ctx))))
-          val total = grouped.values.map(_.size).sum
-          val suffix = if ctx.idx.timedOut then " (timed out — partial results)" else ""
-          println(s"References to \"$symbol\" — $total found:$suffix")
-          val confidenceOrder = List(Confidence.High, Confidence.Medium, Confidence.Low)
-          confidenceOrder.foreach { conf =>
-            val catRefs = grouped.flatMap { (cat, refs) =>
-              refs.map(r => (cat, r, ctx.idx.resolveConfidence(r, symbol, targetPkgs)))
-            }.filter(_._3 == conf).toList
-            if catRefs.nonEmpty then
-              val label = conf match
-                case Confidence.High   => "High confidence (import-matched)"
-                case Confidence.Medium => "Medium confidence (wildcard import)"
-                case Confidence.Low    => "Low confidence (no matching import)"
-              println(s"\n  $label:")
-              val byCat = catRefs.groupBy(_._1)
-              val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
-                               RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
-              order.foreach { cat =>
-                byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
-                  println(s"\n    ${cat.toString}:")
-                  entries.take(ctx.limit).foreach((_, r, _) => println(s"    ${ctx.fmtRef(r)}"))
-                  if entries.size > ctx.limit then println(s"      ... and ${entries.size - ctx.limit} more")
-                }
-              }
-          }
-        else
-          val results = filterRefs(ctx.idx.findReferences(symbol), ctx)
-          val suffix = if ctx.idx.timedOut then " (timed out — partial results)" else ""
-          println(s"References to \"$symbol\" — ${results.size} found:$suffix")
-          val annotated = results.map(r => (r, ctx.idx.resolveConfidence(r, symbol, targetPkgs)))
-          val sorted = annotated.sortBy { case (_, c) => c.ordinal }
-          var lastConf: Option[Confidence] = None
-          var shown = 0
-          sorted.foreach { case (r, conf) =>
-            if shown < ctx.limit then
-              if !lastConf.contains(conf) then
-                val label = conf match
-                  case Confidence.High   => "High confidence"
-                  case Confidence.Medium => "Medium confidence"
-                  case Confidence.Low    => "Low confidence"
-                println(s"\n  [$label]")
-                lastConf = Some(conf)
-              println(ctx.fmtRef(r))
-              shown += 1
-          }
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        val results = filterRefs(ctx.idx.findReferences(symbol), ctx)
+        CmdResult.FlatRefs(symbol, results, targetPkgs, ctx.idx.timedOut)
 
-def cmdImports(args: List[String], ctx: CommandContext): Unit =
+def cmdImports(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex imports <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex imports <symbol>")
     case Some(symbol) =>
       val results = filterRefs(ctx.idx.findImports(symbol), ctx)
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(r => jsonRef(r, ctx.workspace)).mkString("[", ",", "]")
-        println(s"""{"results":$arr,"timedOut":${ctx.idx.timedOut}}""")
+      if results.isEmpty then
+        CmdResult.NotFound(
+          s"""No imports of "$symbol" found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "imports", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if results.isEmpty then
-          println(s"No imports of \"$symbol\" found")
-          printNotFoundHint(symbol, ctx.idx, "imports", ctx.batchMode)
-        else
-          val suffix = if ctx.idx.timedOut then " (timed out — partial results)" else ""
-          println(s"Imports of \"$symbol\" — ${results.size} found:$suffix")
-          results.take(ctx.limit).foreach(r => println(formatRef(r, ctx.workspace)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        val suffix = if ctx.idx.timedOut then " (timed out — partial results)" else ""
+        CmdResult.RefList(
+          header = s"""Imports of "$symbol" — ${results.size} found:$suffix""",
+          refs = results,
+          timedOut = ctx.idx.timedOut,
+          useContext = false)
 
-def cmdSymbols(args: List[String], ctx: CommandContext): Unit =
+def cmdSymbols(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex symbols <file>")
+    case None => CmdResult.UsageError("Usage: scalex symbols <file>")
     case Some(file) =>
       val results = ctx.idx.fileSymbols(file)
-      if ctx.jsonOutput then
-        val arr = results.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-        println(arr)
-      else
-        if results.isEmpty then println(s"No symbols found in $file")
-        else
-          println(s"Symbols in $file:")
-          results.foreach(s => println(ctx.fmt(s, ctx.workspace)))
+      CmdResult.SymbolList(
+        header = s"Symbols in $file:",
+        symbols = results,
+        total = results.size,
+        emptyMessage = s"No symbols found in $file",
+        truncate = false)
 
-def cmdFile(args: List[String], ctx: CommandContext): Unit =
+def cmdFile(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex file <query>")
+    case None => CmdResult.UsageError("Usage: scalex file <query>")
     case Some(query) =>
       val results = ctx.idx.searchFiles(query)
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(f => s""""${jsonEscape(f)}"""").mkString("[", ",", "]")
-        println(arr)
-      else
-        if results.isEmpty then
-          println(s"Found 0 files matching \"$query\"")
-          println(s"  Hint: scalex indexes ${ctx.idx.fileCount} git-tracked .scala files.")
-        else
-          println(s"Found ${results.size} files matching \"$query\":")
-          results.take(ctx.limit).foreach(f => println(s"  $f"))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+      CmdResult.StringList(
+        header = s"""Found ${results.size} files matching "$query":""",
+        items = results,
+        total = results.size,
+        emptyMessage = s"""Found 0 files matching "$query"\n  Hint: scalex indexes ${ctx.idx.fileCount} git-tracked .scala files.""")
 
-def cmdPackages(args: List[String], ctx: CommandContext): Unit =
-  if ctx.jsonOutput then
-    val arr = ctx.idx.packages.toList.sorted.map(p => s""""${jsonEscape(p)}"""").mkString("[", ",", "]")
-    println(arr)
-  else
-    println(s"Packages (${ctx.idx.packages.size}):")
-    ctx.idx.packages.toList.sorted.foreach(p => println(s"  $p"))
+def cmdPackages(args: List[String], ctx: CommandContext): CmdResult =
+  CmdResult.Packages(ctx.idx.packages.toList.sorted)
 
-def cmdAnnotated(args: List[String], ctx: CommandContext): Unit =
+def cmdAnnotated(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex annotated <annotation>")
+    case None => CmdResult.UsageError("Usage: scalex annotated <annotation>")
     case Some(query) =>
       val annot = query.stripPrefix("@")
       val results = filterSymbols(ctx.idx.findAnnotated(annot), ctx)
-      if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-        println(arr)
-      else
-        if results.isEmpty then
-          println(s"No symbols with @$annot annotation found")
-        else
-          println(s"Symbols annotated with @$annot — ${results.size} found:")
-          results.take(ctx.limit).foreach(s => println(ctx.fmt(s, ctx.workspace)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+      CmdResult.SymbolList(
+        header = s"Symbols annotated with @$annot — ${results.size} found:",
+        symbols = results,
+        total = results.size,
+        emptyMessage = s"No symbols with @$annot annotation found")
 
-def cmdGrep(args: List[String], ctx: CommandContext): Unit =
+def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
   val patternOpt = if ctx.grepPatterns.nonEmpty then Some(ctx.grepPatterns.mkString("|"))
                    else args.headOption
   patternOpt match
-    case None => println("Usage: scalex grep <pattern>")
+    case None => CmdResult.UsageError("Usage: scalex grep <pattern>")
     case Some(rawPattern) =>
       val (pattern, wasFixed) = fixPosixRegex(rawPattern)
-      if wasFixed then
-        System.err.println(s"  Note: auto-corrected POSIX regex to Java regex: \"$rawPattern\" → \"$pattern\"")
+      val stderrHint = if wasFixed then Some(s"""  Note: auto-corrected POSIX regex to Java regex: "$rawPattern" → "$pattern"""") else None
+      val hint = if wasFixed then Some(s""","corrected":"$pattern"""") else None
       val (results, grepTimedOut) = ctx.idx.grepFiles(pattern, ctx.noTests, ctx.pathFilter)
       if ctx.countOnly then
         val fileCount = results.map(_.file).distinct.size
-        val hint = if wasFixed then s""","corrected":"$pattern"""" else ""
-        if ctx.jsonOutput then println(s"""{"matches":${results.size},"files":$fileCount,"timedOut":$grepTimedOut$hint}""")
-        else
-          val suffix = if grepTimedOut then " (timed out — partial results)" else ""
-          println(s"${results.size} matches across $fileCount files$suffix")
-      else if ctx.jsonOutput then
-        val arr = results.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-        val hint = if wasFixed then s""","corrected":"$pattern"""" else ""
-        println(s"""{"results":$arr,"timedOut":$grepTimedOut$hint}""")
+        CmdResult.GrepCount(results.size, fileCount, grepTimedOut, hint, stderrHint)
       else
         val suffix = if grepTimedOut then " (timed out — partial results)" else ""
-        if results.isEmpty then
-          println(s"No matches for \"$pattern\"$suffix")
-        else
-          println(s"Matches for \"$pattern\" — ${results.size} found:$suffix")
-          results.take(ctx.limit).foreach(r => println(ctx.fmtRef(r)))
-          if results.size > ctx.limit then println(s"  ... and ${results.size - ctx.limit} more")
+        CmdResult.RefList(
+          header = s"""Matches for "$pattern" — ${results.size} found:$suffix""",
+          refs = results,
+          timedOut = grepTimedOut,
+          hint = hint,
+          emptyMessage = s"""No matches for "$pattern"$suffix""",
+          stderrHint = stderrHint)
 
-def cmdMembers(args: List[String], ctx: CommandContext): Unit =
+def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex members <Symbol>")
+    case None => CmdResult.UsageError("Usage: scalex members <Symbol>")
     case Some(symbol) =>
       val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
       val defs = filterSymbols(ctx.idx.findDefinition(symbol).filter(s => typeKinds.contains(s.kind)), ctx)
 
       // Collect inherited members if --inherited is set
-      def collectInherited(sym: SymbolInfo): List[(parentName: String, members: List[MemberInfo])] = {
+      def collectInherited(sym: SymbolInfo): List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])] = {
         if !ctx.inherited then return Nil
         val visited = mutable.HashSet.empty[String]
         visited += sym.name.toLowerCase
         val ownMembers = extractMembers(sym.file, sym.name).map(m => (m.name, m.kind)).toSet
-        val result = mutable.ListBuffer.empty[(String, List[MemberInfo])]
+        val result = mutable.ListBuffer.empty[(String, Option[Path], String, List[MemberInfo])]
 
         def walk(parentNames: List[String]): Unit = {
           parentNames.foreach { pName =>
@@ -344,7 +238,7 @@ def cmdMembers(args: List[String], ctx: CommandContext): Unit =
               parentDefs.headOption.foreach { pd =>
                 val parentMembers = extractMembers(pd.file, pd.name)
                 val filtered = parentMembers.filterNot(m => ownMembers.contains((m.name, m.kind)))
-                if filtered.nonEmpty then result += ((pd.name, filtered))
+                if filtered.nonEmpty then result += ((pd.name, Some(pd.file), pd.packageName, filtered))
                 walk(pd.parents)
               }
             }
@@ -355,83 +249,41 @@ def cmdMembers(args: List[String], ctx: CommandContext): Unit =
         result.toList
       }
 
-      if ctx.jsonOutput then
-        val allMembers = defs.flatMap { s =>
-          val ownMembers = extractMembers(s.file, symbol).map { m =>
-            val rel = jsonEscape(ctx.workspace.relativize(s.file).toString)
-            s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(symbol)}","ownerKind":"${s.kind.toString.toLowerCase}","package":"${jsonEscape(s.packageName)}","inherited":false}"""
-          }
-          val inheritedMembers = collectInherited(s).flatMap { case (parentName, members) =>
-            val parentDef = ctx.idx.findDefinition(parentName).headOption
-            members.map { m =>
-              val rel = parentDef.map(pd => jsonEscape(ctx.workspace.relativize(pd.file).toString)).getOrElse("")
-              s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(parentName)}","ownerKind":"inherited","package":"${parentDef.map(_.packageName).getOrElse("")}","inherited":true}"""
-            }
-          }
-          ownMembers ++ inheritedMembers
-        }
-        println(allMembers.take(ctx.limit).mkString("[", ",", "]"))
+      if defs.isEmpty then
+        CmdResult.NotFound(
+          s"""No class/trait/object/enum "$symbol" found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "members", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if defs.isEmpty then
-          println(s"No class/trait/object/enum \"$symbol\" found")
-          printNotFoundHint(symbol, ctx.idx, "members", ctx.batchMode)
-        else
-          defs.foreach { s =>
-            val rel = ctx.workspace.relativize(s.file)
-            val pkg = if s.packageName.nonEmpty then s" (${s.packageName})" else ""
-            val members = extractMembers(s.file, symbol)
-            println(s"Members of ${s.kind.toString.toLowerCase} $symbol$pkg — $rel:${s.line}:")
-            if members.isEmpty then println("  (no members)")
-            else
-              println(s"  Defined in $symbol:")
-              members.take(ctx.limit).foreach { m =>
-                if ctx.verbose then
-                  println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
-                else
-                  println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
-              }
-              if members.size > ctx.limit then println(s"    ... and ${members.size - ctx.limit} more")
-            val inheritedGroups = collectInherited(s)
-            inheritedGroups.foreach { case (parentName, pMembers) =>
-              println(s"  Inherited from $parentName:")
-              pMembers.take(ctx.limit).foreach { m =>
-                if ctx.verbose then
-                  println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
-                else
-                  println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
-              }
-              if pMembers.size > ctx.limit then println(s"    ... and ${pMembers.size - ctx.limit} more")
-            }
-          }
+        val sections = defs.map { s =>
+          val members = extractMembers(s.file, symbol)
+          val inherited = collectInherited(s)
+          MemberSectionData(
+            file = s.file,
+            ownerKind = s.kind,
+            packageName = s.packageName,
+            line = s.line,
+            ownMembers = members,
+            inherited = inherited
+          )
+        }
+        CmdResult.MemberSections(symbol, sections)
 
-def cmdDoc(args: List[String], ctx: CommandContext): Unit =
+def cmdDoc(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex doc <Symbol>")
+    case None => CmdResult.UsageError("Usage: scalex doc <Symbol>")
     case Some(symbol) =>
       val defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx)
-      if ctx.jsonOutput then
-        val entries = defs.take(ctx.limit).map { s =>
-          val rel = jsonEscape(ctx.workspace.relativize(s.file).toString)
-          val doc = extractScaladoc(s.file, s.line).map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
-          s"""{"name":"${jsonEscape(s.name)}","kind":"${s.kind.toString.toLowerCase}","file":"$rel","line":${s.line},"package":"${jsonEscape(s.packageName)}","doc":$doc}"""
-        }
-        println(entries.mkString("[", ",", "]"))
+      if defs.isEmpty then
+        CmdResult.NotFound(
+          s"""Definition of "$symbol": not found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "doc", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if defs.isEmpty then
-          println(s"Definition of \"$symbol\": not found")
-          printNotFoundHint(symbol, ctx.idx, "doc", ctx.batchMode)
-        else
-          defs.take(ctx.limit).foreach { s =>
-            val rel = ctx.workspace.relativize(s.file)
-            val pkg = if s.packageName.nonEmpty then s" (${s.packageName})" else ""
-            println(s"${s.kind.toString.toLowerCase} $symbol$pkg — $rel:${s.line}:")
-            extractScaladoc(s.file, s.line) match
-              case Some(doc) => println(doc)
-              case None => println("  (no scaladoc)")
-            println()
-          }
+        val entries = defs.map { s =>
+          DocEntryData(s, extractScaladoc(s.file, s.line))
+        }
+        CmdResult.DocEntries(symbol, entries)
 
-def cmdOverview(args: List[String], ctx: CommandContext): Unit =
+def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
   val symbolsByKind = ctx.idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size)
   val topPackages = ctx.idx.packageToSymbols.toList.sortBy(-_._2.size).take(ctx.limit)
   val mostExtended = ctx.idx.parentIndex.toList
@@ -474,48 +326,21 @@ def cmdOverview(args: List[String], ctx: CommandContext): Unit =
     refCounts.toList.sortBy(-_._2).take(ctx.limit)
   } else Nil
 
-  if ctx.jsonOutput then
-    val kindJson = symbolsByKind.map((k, v) => s""""${k.toString.toLowerCase}":${v.size}""").mkString("{", ",", "}")
-    val pkgJson = topPackages.map((p, s) => s"""{"package":"${jsonEscape(p)}","count":${s.size}}""").mkString("[", ",", "]")
-    val extJson = mostExtended.map((p, s) => s"""{"name":"${jsonEscape(p)}","implementations":${s.size}}""").mkString("[", ",", "]")
-    if ctx.architecture then
-      val depsJson = archPkgDeps.map { (pkg, deps) =>
-        val dArr = deps.map(d => s""""${jsonEscape(d)}"""").mkString("[", ",", "]")
-        s""""${jsonEscape(pkg)}":$dArr"""
-      }.mkString("{", ",", "}")
-      val hubJson = hubTypes.map((n, c) => s"""{"name":"${jsonEscape(n)}","score":$c}""").mkString("[", ",", "]")
-      println(s"""{"fileCount":${ctx.idx.fileCount},"symbolCount":${ctx.idx.symbols.size},"packageCount":${ctx.idx.packages.size},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"mostExtended":$extJson,"packageDependencies":$depsJson,"hubTypes":$hubJson}""")
-    else
-      println(s"""{"fileCount":${ctx.idx.fileCount},"symbolCount":${ctx.idx.symbols.size},"packageCount":${ctx.idx.packages.size},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"mostExtended":$extJson}""")
-  else
-    println(s"Project overview (${ctx.idx.fileCount} files, ${ctx.idx.symbols.size} symbols):\n")
-    println("Symbols by kind:")
-    symbolsByKind.foreach { (kind, syms) =>
-      println(s"  ${kind.toString.padTo(10, ' ')} ${syms.size}")
-    }
-    println(s"\nTop packages (by symbol count):")
-    topPackages.foreach { (pkg, syms) =>
-      println(s"  ${pkg.padTo(50, ' ')} ${syms.size}")
-    }
-    println(s"\nMost extended (by implementation count):")
-    mostExtended.foreach { (name, impls) =>
-      println(s"  ${name.padTo(30, ' ')} ${impls.size} impl")
-    }
-    if ctx.architecture then
-      println(s"\nPackage dependencies:")
-      if archPkgDeps.isEmpty then println("  (no cross-package dependencies found)")
-      else archPkgDeps.toList.sortBy(_._1).foreach { (pkg, deps) =>
-        println(s"  $pkg → ${deps.toList.sorted.mkString(", ")}")
-      }
-      println(s"\nHub types (by extension count):")
-      if hubTypes.isEmpty then println("  (none)")
-      else hubTypes.foreach { (name, count) =>
-        println(s"  ${name.padTo(30, ' ')} $count references")
-      }
+  CmdResult.Overview(OverviewData(
+    fileCount = ctx.idx.fileCount,
+    symbolCount = ctx.idx.symbols.size,
+    packageCount = ctx.idx.packages.size,
+    symbolsByKind = symbolsByKind.map((k, syms) => (kind = k, count = syms.size)),
+    topPackages = topPackages.map((p, syms) => (pkg = p, count = syms.size)),
+    mostExtended = mostExtended.map((n, impls) => (name = n, count = impls.size)),
+    pkgDeps = archPkgDeps,
+    hubTypes = hubTypes,
+    hasArchitecture = ctx.architecture
+  ))
 
-def cmdBody(args: List[String], ctx: CommandContext): Unit =
+def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex body <symbol> [--in <owner>]")
+    case None => CmdResult.UsageError("Usage: scalex body <symbol> [--in <owner>]")
     case Some(symbol) =>
       // Find files containing the symbol
       var defs = ctx.idx.findDefinition(symbol)
@@ -534,32 +359,17 @@ def cmdBody(args: List[String], ctx: CommandContext): Unit =
             ctx.idx.symbols.filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
       }
       // Collect (file, body) pairs
-      val resultsWithFiles = filesToSearch.flatMap { f =>
-        extractBody(f, symbol, ctx.inOwner).map(b => (f, b))
+      val blocks = filesToSearch.flatMap { f =>
+        extractBody(f, symbol, ctx.inOwner).map(b => (file = f, body = b))
       }
-      if ctx.jsonOutput then
-        val arr = resultsWithFiles.take(ctx.limit).map { case (file, b) =>
-          val rel = jsonEscape(ctx.workspace.relativize(file).toString)
-          s"""{"name":"${jsonEscape(b.symbolName)}","owner":"${jsonEscape(b.ownerName)}","file":"$rel","startLine":${b.startLine},"endLine":${b.endLine},"body":"${jsonEscape(b.sourceText)}"}"""
-        }.mkString("[", ",", "]")
-        println(arr)
+      if blocks.isEmpty then
+        CmdResult.NotFound(
+          s"""No body found for "$symbol"""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "body", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if resultsWithFiles.isEmpty then
-          println(s"No body found for \"$symbol\"")
-          printNotFoundHint(symbol, ctx.idx, "body", ctx.batchMode)
-        else
-          resultsWithFiles.take(ctx.limit).foreach { case (file, b) =>
-            val ownerStr = if b.ownerName.nonEmpty then s" — ${b.ownerName}" else ""
-            val rel = ctx.workspace.relativize(file)
-            println(s"Body of ${b.symbolName}$ownerStr — $rel:${b.startLine}:")
-            val bodyLines = b.sourceText.split("\n")
-            bodyLines.zipWithIndex.foreach { case (line, i) =>
-              println(s"  ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
-            }
-            println()
-          }
+        CmdResult.SourceBlocks(symbol, blocks)
 
-def cmdTests(args: List[String], ctx: CommandContext): Unit =
+def cmdTests(args: List[String], ctx: CommandContext): CmdResult =
   val nameFilter = args.headOption
   var filesToScan = ctx.idx.gitFiles.map(_.path).filter(f => isTestFile(f, ctx.workspace))
   ctx.pathFilter.foreach { p => filesToScan = filesToScan.filter(f => matchesPath(f, p, ctx.workspace)) }
@@ -572,390 +382,159 @@ def cmdTests(args: List[String], ctx: CommandContext): Unit =
       case None => suite
   }.filter(_.tests.nonEmpty)
   val showBody = nameFilter.isDefined
-  if ctx.jsonOutput then
-    val arr = allSuites.take(ctx.limit).map { suite =>
-      val rel = jsonEscape(ctx.workspace.relativize(suite.file).toString)
-      val fileLines = if showBody then
-        try Files.readAllLines(suite.file).asScala.toArray catch case _: Exception => Array.empty[String]
-      else Array.empty[String]
-      val testsJson = suite.tests.map { tc =>
-        val bodyField = if showBody then {
-          val bodies = extractBody(suite.file, tc.name, Some(suite.name))
-          bodies.headOption.map(b => s""","body":"${jsonEscape(b.sourceText)}"""").getOrElse("")
-        } else ""
-        s"""{"name":"${jsonEscape(tc.name)}","line":${tc.line}$bodyField}"""
-      }.mkString("[", ",", "]")
-      s"""{"suite":"${jsonEscape(suite.name)}","file":"$rel","line":${suite.line},"tests":$testsJson}"""
-    }.mkString("[", ",", "]")
-    println(arr)
-  else
-    if allSuites.isEmpty then
-      if nameFilter.isDefined then println(s"No tests matching \"${nameFilter.get}\"")
-      else println("No test suites found")
-    else
-      allSuites.take(ctx.limit).foreach { suite =>
-        val rel = ctx.workspace.relativize(suite.file)
-        println(s"${suite.name} — $rel:${suite.line}:")
-        suite.tests.foreach { tc =>
-          println(s"  test  \"${tc.name}\"  :${tc.line}")
-          if showBody || ctx.verbose then
-            val bodies = extractBody(suite.file, tc.name, Some(suite.name))
-            bodies.headOption.foreach { b =>
-              val bodyLines = b.sourceText.split("\n")
-              bodyLines.zipWithIndex.foreach { case (line, i) =>
-                println(s"    ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
-              }
-              println()
-            }
-        }
-        if !showBody && !ctx.verbose then println()
-      }
+  val suiteResults = allSuites.map { suite =>
+    val tests = suite.tests.map { tc =>
+      val body = if showBody || ctx.verbose then
+        extractBody(suite.file, tc.name, Some(suite.name)).headOption
+      else None
+      TestCaseResult(tc.name, tc.line, body)
+    }
+    TestSuiteResult(suite.name, suite.file, suite.line, tests)
+  }
+  val emptyMsg = if nameFilter.isDefined then s"""No tests matching "${nameFilter.get}"""" else "No test suites found"
+  CmdResult.TestSuites(suiteResults, showBody, emptyMsg)
 
-def cmdCoverage(args: List[String], ctx: CommandContext): Unit =
+def cmdCoverage(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex coverage <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex coverage <symbol>")
     case Some(symbol) =>
       val refs = ctx.idx.findReferences(symbol)
       val testRefs = refs.filter(r => isTestFile(r.file, ctx.workspace))
       val testFiles = testRefs.map(r => ctx.workspace.relativize(r.file).toString).distinct
-      if ctx.jsonOutput then
-        val refsJson = testRefs.take(ctx.limit).map(r => ctx.jRef(r)).mkString("[", ",", "]")
-        println(s"""{"symbol":"${jsonEscape(symbol)}","testFileCount":${testFiles.size},"referenceCount":${testRefs.size},"references":$refsJson}""")
-      else
-        if testRefs.isEmpty then
-          if refs.isEmpty then
-            println(s"""Coverage of "$symbol" — no references found""")
-            printNotFoundHint(symbol, ctx.idx, "coverage", ctx.batchMode)
-          else
-            println(s"""Coverage of "$symbol" — ${refs.size} refs but 0 in test files""")
-        else
-          println(s"""Coverage of "$symbol" — ${testRefs.size} refs in ${testFiles.size} test files:""")
-          testFiles.sorted.foreach { f =>
-            val fileRefs = testRefs.filter(r => ctx.workspace.relativize(r.file).toString == f)
-            println(s"  $f")
-            fileRefs.take(ctx.limit).foreach { r =>
-              println(s"    :${r.line}  ${r.contextLine}")
-            }
-          }
+      CmdResult.CoverageReport(symbol, refs.size, testRefs, testFiles)
 
-def cmdHierarchy(args: List[String], ctx: CommandContext): Unit =
+def cmdHierarchy(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex hierarchy <symbol> [--up] [--down]")
+    case None => CmdResult.UsageError("Usage: scalex hierarchy <symbol> [--up] [--down]")
     case Some(symbol) =>
       buildHierarchy(ctx.idx, symbol, ctx.goUp, ctx.goDown, ctx.workspace) match
         case None =>
-          println(s"No definition of \"$symbol\" found")
-          printNotFoundHint(symbol, ctx.idx, "hierarchy", ctx.batchMode)
+          CmdResult.NotFound(
+            s"""No definition of "$symbol" found""",
+            NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "hierarchy", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
         case Some(tree) =>
-          def nodeJson(n: HierarchyNode): String = {
-            val file = n.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
-            val kind = n.kind.map(k => s""""${k.toString.toLowerCase}"""").getOrElse("null")
-            val line = n.line.map(_.toString).getOrElse("null")
-            s"""{"name":"${jsonEscape(n.name)}","kind":$kind,"file":$file,"line":$line,"package":"${jsonEscape(n.packageName)}","isExternal":${n.isExternal}}"""
-          }
-          def treeJson(t: HierarchyTree): String = {
-            val ps = t.parents.map(treeJson).mkString("[", ",", "]")
-            val cs = t.children.map(treeJson).mkString("[", ",", "]")
-            s"""{"node":${nodeJson(t.root)},"parents":$ps,"children":$cs}"""
-          }
-          if ctx.jsonOutput then
-            println(treeJson(tree))
-          else
-            val rootNode = tree.root
-            val pkg = if rootNode.packageName.nonEmpty then s" (${rootNode.packageName})" else ""
-            val kind = rootNode.kind.map(_.toString.toLowerCase).getOrElse("unknown")
-            val loc = rootNode.file.map(f => s" — ${ctx.workspace.relativize(f)}:${rootNode.line.getOrElse(0)}").getOrElse("")
-            println(s"Hierarchy of $kind ${rootNode.name}$pkg$loc:")
-            if ctx.goUp then
-              println("  Parents:")
-              def printParents(parents: List[HierarchyTree], indent: String): Unit = {
-                parents.zipWithIndex.foreach { case (pt, i) =>
-                  val isLast = i == parents.size - 1
-                  val prefix = if isLast then s"$indent└── " else s"$indent├── "
-                  val nextIndent = if isLast then s"$indent    " else s"$indent│   "
-                  val n = pt.root
-                  val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
-                  val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
-                  val nloc = if n.isExternal then " [external]"
-                             else n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
-                  println(s"$prefix$nkind${n.name}$npkg$nloc")
-                  printParents(pt.parents, nextIndent)
-                }
-              }
-              if tree.parents.isEmpty then println("    (none)")
-              else printParents(tree.parents, "    ")
-            if ctx.goDown then
-              println("  Children:")
-              def printChildren(children: List[HierarchyTree], indent: String): Unit = {
-                children.zipWithIndex.foreach { case (ct, i) =>
-                  val isLast = i == children.size - 1
-                  val prefix = if isLast then s"$indent└── " else s"$indent├── "
-                  val nextIndent = if isLast then s"$indent    " else s"$indent│   "
-                  val n = ct.root
-                  val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
-                  val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
-                  val nloc = n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
-                  println(s"$prefix$nkind${n.name}$npkg$nloc")
-                  printChildren(ct.children, nextIndent)
-                }
-              }
-              if tree.children.isEmpty then println("    (none)")
-              else printChildren(tree.children, "    ")
+          CmdResult.HierarchyResult(symbol, tree)
 
-def cmdOverrides(args: List[String], ctx: CommandContext): Unit =
+def cmdOverrides(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex overrides <method> [--of <trait>]")
+    case None => CmdResult.UsageError("Usage: scalex overrides <method> [--of <trait>]")
     case Some(methodName) =>
       val results = findOverrides(ctx.idx, methodName, ctx.ofTrait, ctx.limit)
-      if ctx.jsonOutput then
-        val arr = results.map { o =>
-          val rel = jsonEscape(ctx.workspace.relativize(o.file).toString)
-          s"""{"enclosingClass":"${jsonEscape(o.enclosingClass)}","enclosingKind":"${o.enclosingKind.toString.toLowerCase}","file":"$rel","line":${o.line},"signature":"${jsonEscape(o.signature)}","package":"${jsonEscape(o.packageName)}"}"""
-        }.mkString("[", ",", "]")
-        println(arr)
+      if results.isEmpty then
+        val ofStr = ctx.ofTrait.map(t => s" of $t").getOrElse("")
+        CmdResult.NotFound(
+          s"""No overrides of "$methodName"$ofStr found""",
+          NotFoundHint(methodName, ctx.idx.fileCount, ctx.idx.parseFailures, "overrides", ctx.batchMode, methodName.contains("/") || methodName.startsWith(".")))
       else
-        if results.isEmpty then
-          val ofStr = ctx.ofTrait.map(t => s" of $t").getOrElse("")
-          println(s"No overrides of \"$methodName\"$ofStr found")
-          printNotFoundHint(methodName, ctx.idx, "overrides", ctx.batchMode)
-        else
-          val ofStr = ctx.ofTrait.map(t => s" (in implementations of $t)").getOrElse("")
-          println(s"Overrides of $methodName$ofStr — ${results.size} found:")
-          results.foreach { o =>
-            val rel = ctx.workspace.relativize(o.file)
-            val pkg = if o.packageName.nonEmpty then s" (${o.packageName})" else ""
-            println(s"  ${o.enclosingClass}$pkg — $rel:${o.line}")
-            println(s"    ${o.signature}")
-          }
+        val ofStr = ctx.ofTrait.map(t => s" (in implementations of $t)").getOrElse("")
+        CmdResult.OverrideList(
+          header = s"Overrides of $methodName$ofStr — ${results.size} found:",
+          results = results)
 
-def cmdExplain(args: List[String], ctx: CommandContext): Unit =
+def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex explain <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex explain <symbol>")
     case Some(symbol) =>
       var defs = ctx.idx.findDefinition(symbol)
       if ctx.noTests then defs = defs.filter(s => !isTestFile(s.file, ctx.workspace))
       ctx.pathFilter.foreach { p => defs = defs.filter(s => matchesPath(s.file, p, ctx.workspace)) }
       if defs.isEmpty then
-        if ctx.jsonOutput then println("""{"error":"not found"}""")
-        else
-          println(s"No definition of \"$symbol\" found")
-          printNotFoundHint(symbol, ctx.idx, "explain", ctx.batchMode)
+        CmdResult.NotFound(
+          s"""No definition of "$symbol" found""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "explain", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
         val sym = defs.head
-        val rel = ctx.workspace.relativize(sym.file)
-        val pkg = if sym.packageName.nonEmpty then s" (${sym.packageName})" else ""
-
         // Scaladoc
         val doc = extractScaladoc(sym.file, sym.line)
-
         // Members (for types)
         val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
         val members = if typeKinds.contains(sym.kind) then extractMembers(sym.file, symbol).take(10) else Nil
-
         // Implementations
         val impls = ctx.idx.findImplementations(symbol).take(ctx.implLimit)
-
         // Import count
         val importCount = ctx.idx.findImports(symbol, timeoutMs = 3000).size
+        CmdResult.Explanation(sym, doc, members, impls, importCount)
 
-        if ctx.jsonOutput then
-          val docJson = doc.map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
-          val membersJson = members.map { m =>
-            s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
-          }.mkString("[", ",", "]")
-          val implsJson = impls.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-          println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":$docJson,"members":$membersJson,"implementations":$implsJson,"importCount":$importCount}""")
-        else
-          println(s"Explanation of ${sym.kind.toString.toLowerCase} $symbol$pkg:\n")
-          println(s"  Definition: $rel:${sym.line}")
-          println(s"  Signature: ${sym.signature}")
-          if sym.parents.nonEmpty then println(s"  Extends: ${sym.parents.mkString(", ")}")
-          println()
-          doc match
-            case Some(d) =>
-              println("  Scaladoc:")
-              d.split("\n").foreach(l => println(s"    $l"))
-              println()
-            case None =>
-              println("  Scaladoc: (none)\n")
-          if members.nonEmpty then
-            println(s"  Members (top ${members.size}):")
-            members.foreach(m => println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}"))
-            println()
-          if impls.nonEmpty then
-            println(s"  Implementations (top ${impls.size}):")
-            impls.foreach(s => println(formatSymbol(s, ctx.workspace)))
-            println()
-          println(s"  Imported by: $importCount files")
-
-def cmdDeps(args: List[String], ctx: CommandContext): Unit =
+def cmdDeps(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex deps <symbol>")
+    case None => CmdResult.UsageError("Usage: scalex deps <symbol>")
     case Some(symbol) =>
       val (importDeps, bodyDeps) = extractDeps(ctx.idx, symbol, ctx.workspace)
-      if ctx.jsonOutput then
-        val iArr = importDeps.map { d =>
-          val file = d.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
-          val line = d.line.map(_.toString).getOrElse("null")
-          s"""{"name":"${jsonEscape(d.name)}","kind":"${jsonEscape(d.kind)}","file":$file,"line":$line,"package":"${jsonEscape(d.packageName)}"}"""
-        }.mkString("[", ",", "]")
-        val bArr = bodyDeps.map { d =>
-          val file = d.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
-          val line = d.line.map(_.toString).getOrElse("null")
-          s"""{"name":"${jsonEscape(d.name)}","kind":"${jsonEscape(d.kind)}","file":$file,"line":$line,"package":"${jsonEscape(d.packageName)}"}"""
-        }.mkString("[", ",", "]")
-        println(s"""{"imports":$iArr,"bodyReferences":$bArr}""")
+      if importDeps.isEmpty && bodyDeps.isEmpty then
+        CmdResult.NotFound(
+          s"""No dependencies found for "$symbol"""",
+          NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, "deps", ctx.batchMode, symbol.contains("/") || symbol.startsWith(".")))
       else
-        if importDeps.isEmpty && bodyDeps.isEmpty then
-          println(s"No dependencies found for \"$symbol\"")
-          printNotFoundHint(symbol, ctx.idx, "deps", ctx.batchMode)
-        else
-          println(s"Dependencies of \"$symbol\":")
-          if importDeps.nonEmpty then
-            println(s"\n  Imports:")
-            importDeps.take(ctx.limit).foreach { d =>
-              val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
-              println(s"    ${d.kind.padTo(9, ' ')} ${d.name}$loc")
-            }
-            if importDeps.size > ctx.limit then println(s"    ... and ${importDeps.size - ctx.limit} more")
-          if bodyDeps.nonEmpty then
-            println(s"\n  Body references:")
-            bodyDeps.take(ctx.limit).foreach { d =>
-              val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
-              println(s"    ${d.kind.padTo(9, ' ')} ${d.name}$loc")
-            }
-            if bodyDeps.size > ctx.limit then println(s"    ... and ${bodyDeps.size - ctx.limit} more")
+        CmdResult.Dependencies(symbol, importDeps, bodyDeps)
 
-def cmdContext(args: List[String], ctx: CommandContext): Unit =
+def cmdContext(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex context <file:line>")
+    case None => CmdResult.UsageError("Usage: scalex context <file:line>")
     case Some(arg) =>
       val parts = arg.split(":")
       if parts.length < 2 then
-        println("Usage: scalex context <file:line> (e.g. src/Main.scala:42)")
+        CmdResult.UsageError("Usage: scalex context <file:line> (e.g. src/Main.scala:42)")
       else
         val filePath = parts.dropRight(1).mkString(":")
         val lineNum = parts.last.toIntOption
         lineNum match
-          case None => println(s"Invalid line number: ${parts.last}")
+          case None => CmdResult.UsageError(s"Invalid line number: ${parts.last}")
           case Some(line) =>
             val resolved = if Path.of(filePath).isAbsolute then Path.of(filePath) else ctx.workspace.resolve(filePath)
             val scopes = extractScopes(resolved, line)
-            if ctx.jsonOutput then
-              val arr = scopes.map { s =>
-                s"""{"name":"${jsonEscape(s.name)}","kind":"${jsonEscape(s.kind)}","line":${s.line}}"""
-              }.mkString("[", ",", "]")
-              val rel = jsonEscape(ctx.workspace.relativize(resolved).toString)
-              println(s"""{"file":"$rel","line":$line,"scopes":$arr}""")
-            else
-              val rel = ctx.workspace.relativize(resolved)
-              println(s"Context at $rel:$line:")
-              if scopes.isEmpty then println("  (no enclosing scopes found)")
-              else
-                scopes.foreach { s =>
-                  println(s"  ${s.kind.padTo(9, ' ')} ${s.name} (line ${s.line})")
-                }
+            CmdResult.Scopes(resolved, line, scopes)
 
-def cmdDiff(args: List[String], ctx: CommandContext): Unit =
+def cmdDiff(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
-    case None => println("Usage: scalex diff <git-ref> (e.g. scalex diff HEAD~1)")
+    case None => CmdResult.UsageError("Usage: scalex diff <git-ref> (e.g. scalex diff HEAD~1)")
     case Some(ref) =>
       val changedFiles = runGitDiff(ctx.workspace, ref)
-      if changedFiles.isEmpty then
-        if ctx.jsonOutput then println("""{"added":[],"removed":[],"modified":[]}""")
-        else println(s"No Scala files changed compared to $ref")
-      else
-        val added = mutable.ListBuffer.empty[DiffSymbol]
-        val removed = mutable.ListBuffer.empty[DiffSymbol]
-        val modified = mutable.ListBuffer.empty[(before: DiffSymbol, after: DiffSymbol)]
+      val added = mutable.ListBuffer.empty[DiffSymbol]
+      val removed = mutable.ListBuffer.empty[DiffSymbol]
+      val modified = mutable.ListBuffer.empty[(before: DiffSymbol, after: DiffSymbol)]
 
-        changedFiles.take(ctx.limit * 5).foreach { relPath =>
-          val currentPath = ctx.workspace.resolve(relPath)
-          val currentSource = try Some(Files.readString(currentPath)) catch { case _: Exception => None }
-          val oldSource = gitShowFile(ctx.workspace, ref, relPath)
+      changedFiles.take(ctx.limit * 5).foreach { relPath =>
+        val currentPath = ctx.workspace.resolve(relPath)
+        val currentSource = try Some(Files.readString(currentPath)) catch { case _: Exception => None }
+        val oldSource = gitShowFile(ctx.workspace, ref, relPath)
 
-          val currentSyms = currentSource.map(s => extractSymbolsFromSource(s, relPath)).getOrElse(Nil)
-          val oldSyms = oldSource.map(s => extractSymbolsFromSource(s, relPath)).getOrElse(Nil)
+        val currentSyms = currentSource.map(s => extractSymbolsFromSource(s, relPath)).getOrElse(Nil)
+        val oldSyms = oldSource.map(s => extractSymbolsFromSource(s, relPath)).getOrElse(Nil)
 
-          val currentByKey = currentSyms.map(s => (s.name, s.kind) -> s).toMap
-          val oldByKey = oldSyms.map(s => (s.name, s.kind) -> s).toMap
+        val currentByKey = currentSyms.map(s => (s.name, s.kind) -> s).toMap
+        val oldByKey = oldSyms.map(s => (s.name, s.kind) -> s).toMap
 
-          // Added: in current but not in old
-          currentByKey.foreach { case (key, sym) =>
-            if !oldByKey.contains(key) then added += sym
-          }
-          // Removed: in old but not in current
-          oldByKey.foreach { case (key, sym) =>
-            if !currentByKey.contains(key) then removed += sym
-          }
-          // Modified: in both but signature changed
-          currentByKey.foreach { case (key, cSym) =>
-            oldByKey.get(key).foreach { oSym =>
-              if cSym.signature != oSym.signature || cSym.line != oSym.line then
-                modified += ((oSym, cSym))
-            }
+        // Added: in current but not in old
+        currentByKey.foreach { case (key, sym) =>
+          if !oldByKey.contains(key) then added += sym
+        }
+        // Removed: in old but not in current
+        oldByKey.foreach { case (key, sym) =>
+          if !currentByKey.contains(key) then removed += sym
+        }
+        // Modified: in both but signature changed
+        currentByKey.foreach { case (key, cSym) =>
+          oldByKey.get(key).foreach { oSym =>
+            if cSym.signature != oSym.signature || cSym.line != oSym.line then
+              modified += ((before = oSym, after = cSym))
           }
         }
-
-        if ctx.jsonOutput then
-          def diffSymJson(s: DiffSymbol): String =
-            s"""{"name":"${jsonEscape(s.name)}","kind":"${s.kind.toString.toLowerCase}","file":"${jsonEscape(s.file)}","line":${s.line},"package":"${jsonEscape(s.packageName)}","signature":"${jsonEscape(s.signature)}"}"""
-          val addedJson = added.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
-          val removedJson = removed.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
-          val modifiedJson = modified.take(ctx.limit).map { case (o, n) =>
-            s"""{"old":${diffSymJson(o)},"new":${diffSymJson(n)}}"""
-          }.mkString("[", ",", "]")
-          println(s"""{"ref":"${jsonEscape(ref)}","filesChanged":${changedFiles.size},"added":$addedJson,"removed":$removedJson,"modified":$modifiedJson}""")
-        else
-          println(s"Symbol changes compared to $ref (${changedFiles.size} files changed):")
-          if added.nonEmpty then
-            println(s"\n  Added (${added.size}):")
-            added.take(ctx.limit).foreach { s =>
-              println(s"    + ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
-            }
-            if added.size > ctx.limit then println(s"    ... and ${added.size - ctx.limit} more")
-          if removed.nonEmpty then
-            println(s"\n  Removed (${removed.size}):")
-            removed.take(ctx.limit).foreach { s =>
-              println(s"    - ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
-            }
-            if removed.size > ctx.limit then println(s"    ... and ${removed.size - ctx.limit} more")
-          if modified.nonEmpty then
-            println(s"\n  Modified (${modified.size}):")
-            modified.take(ctx.limit).foreach { case (o, n) =>
-              println(s"    ~ ${n.kind.toString.toLowerCase.padTo(9, ' ')} ${n.name} — ${n.file}:${n.line}")
-            }
-            if modified.size > ctx.limit then println(s"    ... and ${modified.size - ctx.limit} more")
-          if added.isEmpty && removed.isEmpty && modified.isEmpty then
-            println("  No symbol-level changes detected")
-
-def cmdAstPattern(args: List[String], ctx: CommandContext): Unit =
-  val results = astPatternSearch(ctx.idx, ctx.workspace, ctx.hasMethodFilter, ctx.extendsFilter, ctx.bodyContainsFilter, ctx.noTests, ctx.pathFilter, ctx.limit)
-  if ctx.jsonOutput then
-    val arr = results.map { m =>
-      val rel = jsonEscape(ctx.workspace.relativize(m.file).toString)
-      s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","file":"$rel","line":${m.line},"package":"${jsonEscape(m.packageName)}","signature":"${jsonEscape(m.signature)}"}"""
-    }.mkString("[", ",", "]")
-    println(arr)
-  else
-    val filters = List(
-      ctx.hasMethodFilter.map(m => s"has-method=$m"),
-      ctx.extendsFilter.map(e => s"extends=$e"),
-      ctx.bodyContainsFilter.map(b => s"body-contains=\"$b\"")
-    ).flatten.mkString(", ")
-    if results.isEmpty then
-      println(s"No types matching AST pattern ($filters)")
-    else
-      println(s"Types matching AST pattern ($filters) — ${results.size} found:")
-      results.foreach { m =>
-        val rel = ctx.workspace.relativize(m.file)
-        val pkg = if m.packageName.nonEmpty then s" (${m.packageName})" else ""
-        println(s"  ${m.kind.toString.toLowerCase.padTo(9, ' ')} ${m.name}$pkg — $rel:${m.line}")
       }
+
+      CmdResult.SymbolDiff(ref, changedFiles.size, added.toList, removed.toList, modified.toList)
+
+def cmdAstPattern(args: List[String], ctx: CommandContext): CmdResult =
+  val results = astPatternSearch(ctx.idx, ctx.workspace, ctx.hasMethodFilter, ctx.extendsFilter, ctx.bodyContainsFilter, ctx.noTests, ctx.pathFilter, ctx.limit)
+  val filters = List(
+    ctx.hasMethodFilter.map(m => s"has-method=$m"),
+    ctx.extendsFilter.map(e => s"extends=$e"),
+    ctx.bodyContainsFilter.map(b => s"""body-contains="$b"""")
+  ).flatten.mkString(", ")
+  CmdResult.AstMatches(filters, results)
 
 // ── Command dispatch ────────────────────────────────────────────────────────
 
-val commands: Map[String, (List[String], CommandContext) => Unit] = Map(
+val commands: Map[String, (List[String], CommandContext) => CmdResult] = Map(
   "index" -> cmdIndex, "search" -> cmdSearch, "def" -> cmdDef, "impl" -> cmdImpl,
   "refs" -> cmdRefs, "imports" -> cmdImports, "symbols" -> cmdSymbols, "file" -> cmdFile,
   "packages" -> cmdPackages, "annotated" -> cmdAnnotated, "grep" -> cmdGrep,
@@ -966,6 +545,7 @@ val commands: Map[String, (List[String], CommandContext) => Unit] = Map(
 )
 
 def runCommand(cmd: String, args: List[String], ctx: CommandContext): Unit =
-  commands.get(cmd) match
+  val result = commands.get(cmd) match
     case Some(handler) => handler(args, ctx)
-    case None => println(s"Unknown command: $cmd")
+    case None => CmdResult.UsageError(s"Unknown command: $cmd")
+  render(result, ctx)

--- a/src/format.scala
+++ b/src/format.scala
@@ -76,3 +76,673 @@ def formatRefWithContext(r: Reference, workspace: Path, contextN: Int): String =
     buf.append(s"\n    $marker $lineNum | $lineContent")
     i += 1
   buf.toString
+
+// ── Render ─────────────────────────────────────────────────────────────────
+
+def render(result: CmdResult, ctx: CommandContext): Unit = {
+  import CmdResult.*
+  result match {
+    case r: SymbolList      => renderSymbolList(r, ctx)
+    case r: RefList          => renderRefList(r, ctx)
+    case r: CategorizedRefs  => renderCategorizedRefs(r, ctx)
+    case r: FlatRefs         => renderFlatRefs(r, ctx)
+    case r: StringList       => renderStringList(r, ctx)
+    case r: IndexStats       => renderIndexStats(r, ctx)
+    case r: MemberSections   => renderMemberSections(r, ctx)
+    case r: DocEntries       => renderDocEntries(r, ctx)
+    case r: Overview         => renderOverview(r, ctx)
+    case r: SourceBlocks     => renderSourceBlocks(r, ctx)
+    case r: TestSuites       => renderTestSuites(r, ctx)
+    case r: CoverageReport   => renderCoverageReport(r, ctx)
+    case r: HierarchyResult  => renderHierarchyResult(r, ctx)
+    case r: OverrideList     => renderOverrideList(r, ctx)
+    case r: Explanation      => renderExplanation(r, ctx)
+    case r: Dependencies     => renderDependencies(r, ctx)
+    case r: Scopes           => renderScopes(r, ctx)
+    case r: SymbolDiff       => renderSymbolDiff(r, ctx)
+    case r: AstMatches       => renderAstMatches(r, ctx)
+    case r: GrepCount        => renderGrepCount(r, ctx)
+    case r: Packages         => renderPackages(r, ctx)
+    case r: NotFound         => renderNotFound(r, ctx)
+    case r: UsageError       => println(r.message)
+  }
+}
+
+private def renderHint(h: NotFoundHint): Unit = {
+  if h.batchMode then
+    println(s"  not found (0 matches in ${h.fileCount} files)")
+  else {
+    if h.looksLikePath then
+      println(s"""  Note: "${h.symbol}" looks like a path. Did you mean: scalex ${h.cmd} -w <workspace> ${h.symbol}?""")
+    println(s"  Hint: scalex indexes ${h.fileCount} git-tracked .scala files.")
+    if h.parseFailures > 0 then
+      println(s"  ${h.parseFailures} files had parse errors (run `scalex index --verbose` to list them).")
+    println(s"  Fallback: use Grep, Glob, or Read tools to search manually.")
+  }
+}
+
+private def mkNotFoundHint(symbol: String, ctx: CommandContext, cmd: String): NotFoundHint =
+  NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, cmd, ctx.batchMode, symbol.contains("/") || symbol.startsWith("."))
+
+private def renderSymbolList(r: CmdResult.SymbolList, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val items = if r.truncate then r.symbols.take(ctx.limit) else r.symbols
+    val arr = items.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
+    println(arr)
+  } else {
+    if r.symbols.isEmpty then {
+      if r.emptyMessage.nonEmpty then println(r.emptyMessage)
+    } else {
+      println(r.header)
+      val items = if r.truncate then r.symbols.take(ctx.limit) else r.symbols
+      items.foreach(s => println(ctx.fmt(s, ctx.workspace)))
+      if r.truncate && r.total > ctx.limit then println(s"  ... and ${r.total - ctx.limit} more")
+    }
+  }
+}
+
+private def renderRefList(r: CmdResult.RefList, ctx: CommandContext): Unit = {
+  r.stderrHint.foreach(System.err.println)
+  if ctx.jsonOutput then {
+    val jFn: Reference => String = if r.useContext then ctx.jRef else ref => jsonRef(ref, ctx.workspace)
+    val arr = r.refs.take(ctx.limit).map(jFn).mkString("[", ",", "]")
+    val hintStr = r.hint.getOrElse("")
+    println(s"""{"results":$arr,"timedOut":${r.timedOut}$hintStr}""")
+  } else {
+    if r.refs.isEmpty then {
+      if r.emptyMessage.nonEmpty then println(r.emptyMessage)
+    } else {
+      println(r.header)
+      val fFn: Reference => String = if r.useContext then ctx.fmtRef else ref => formatRef(ref, ctx.workspace)
+      r.refs.take(ctx.limit).foreach(ref => println(fFn(ref)))
+      if r.refs.size > ctx.limit then println(s"  ... and ${r.refs.size - ctx.limit} more")
+    }
+  }
+}
+
+private def renderCategorizedRefs(r: CmdResult.CategorizedRefs, ctx: CommandContext): Unit = {
+  r.stderrHint.foreach(System.err.println)
+  if ctx.jsonOutput then {
+    val entries = r.grouped.map { (cat, refs) =>
+      val arr = refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
+      s""""${cat.toString}":$arr"""
+    }.mkString(",")
+    println(s"""{"categories":{$entries},"timedOut":${r.timedOut}}""")
+  } else {
+    val total = r.grouped.values.map(_.size).sum
+    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    println(s"""References to "${r.symbol}" — $total found:$suffix""")
+    val confidenceOrder = List(Confidence.High, Confidence.Medium, Confidence.Low)
+    confidenceOrder.foreach { conf =>
+      val catRefs = r.grouped.flatMap { (cat, refs) =>
+        refs.map(ref => (cat, ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
+      }.filter(_._3 == conf).toList
+      if catRefs.nonEmpty then {
+        val label = conf match {
+          case Confidence.High   => "High confidence (import-matched)"
+          case Confidence.Medium => "Medium confidence (wildcard import)"
+          case Confidence.Low    => "Low confidence (no matching import)"
+        }
+        println(s"\n  $label:")
+        val byCat = catRefs.groupBy(_._1)
+        val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
+                         RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
+        order.foreach { cat =>
+          byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
+            println(s"\n    ${cat.toString}:")
+            entries.take(ctx.limit).foreach((_, ref, _) => println(s"    ${ctx.fmtRef(ref)}"))
+            if entries.size > ctx.limit then println(s"      ... and ${entries.size - ctx.limit} more")
+          }
+        }
+      }
+    }
+  }
+}
+
+private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
+    println(s"""{"results":$arr,"timedOut":${r.timedOut}}""")
+  } else {
+    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    println(s"""References to "${r.symbol}" — ${r.refs.size} found:$suffix""")
+    val annotated = r.refs.map(ref => (ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
+    val sorted = annotated.sortBy { case (_, c) => c.ordinal }
+    var lastConf: Option[Confidence] = None
+    var shown = 0
+    sorted.foreach { case (ref, conf) =>
+      if shown < ctx.limit then {
+        if !lastConf.contains(conf) then {
+          val label = conf match {
+            case Confidence.High   => "High confidence"
+            case Confidence.Medium => "Medium confidence"
+            case Confidence.Low    => "Low confidence"
+          }
+          println(s"\n  [$label]")
+          lastConf = Some(conf)
+        }
+        println(ctx.fmtRef(ref))
+        shown += 1
+      }
+    }
+    if r.refs.size > ctx.limit then println(s"  ... and ${r.refs.size - ctx.limit} more")
+  }
+}
+
+private def renderStringList(r: CmdResult.StringList, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.items.take(ctx.limit).map(f => s""""${jsonEscape(f)}"""").mkString("[", ",", "]")
+    println(arr)
+  } else {
+    if r.items.isEmpty then {
+      if r.emptyMessage.nonEmpty then println(r.emptyMessage)
+    } else {
+      println(r.header)
+      r.items.take(ctx.limit).foreach(f => println(s"  $f"))
+      if r.total > ctx.limit then println(s"  ... and ${r.total - ctx.limit} more")
+    }
+  }
+}
+
+private def renderIndexStats(r: CmdResult.IndexStats, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val byKind = r.symbolsByKind.map((k, c) => s""""${k.toString.toLowerCase}":$c""").mkString(",")
+    println(s"""{"fileCount":${r.fileCount},"symbolCount":${r.symbolCount},"packageCount":${r.packageCount},"symbolsByKind":{$byKind},"indexTimeMs":${r.indexTimeMs},"cachedLoad":${r.cachedLoad},"parsedCount":${r.parsedCount},"skippedCount":${r.skippedCount},"parseFailures":${r.parseFailures}}""")
+  } else {
+    if r.cachedLoad then
+      println(s"Indexed ${r.fileCount} files (${r.skippedCount} cached, ${r.parsedCount} parsed) in ${r.indexTimeMs}ms")
+    else
+      println(s"Indexed ${r.fileCount} files, ${r.symbolCount} symbols in ${r.indexTimeMs}ms")
+    println(s"Packages: ${r.packageCount}")
+    println()
+    println("Symbols by kind:")
+    r.symbolsByKind.foreach { (kind, count) =>
+      println(s"  ${kind.toString.padTo(10, ' ')} $count")
+    }
+    if r.parseFailures > 0 then {
+      println(s"\n${r.parseFailures} files had parse errors:")
+      if ctx.verbose then
+        r.parseFailedFiles.sorted.foreach(f => println(s"  $f"))
+      else
+        println("  Run with --verbose to see the list.")
+    }
+  }
+}
+
+private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val allMembers = r.sections.flatMap { sec =>
+      val ownMembers = sec.ownMembers.map { m =>
+        val rel = jsonEscape(ctx.workspace.relativize(sec.file).toString)
+        s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(r.symbol)}","ownerKind":"${sec.ownerKind.toString.toLowerCase}","package":"${jsonEscape(sec.packageName)}","inherited":false}"""
+      }
+      val inheritedMembers = sec.inherited.flatMap { (parentName, parentFile, parentPackage, members) =>
+        members.map { m =>
+          val rel = parentFile.map(f => jsonEscape(ctx.workspace.relativize(f).toString)).getOrElse("")
+          s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(parentName)}","ownerKind":"inherited","package":"${jsonEscape(parentPackage)}","inherited":true}"""
+        }
+      }
+      ownMembers ++ inheritedMembers
+    }
+    println(allMembers.take(ctx.limit).mkString("[", ",", "]"))
+  } else {
+    if r.sections.isEmpty then {
+      println(s"""No class/trait/object/enum "${r.symbol}" found""")
+    } else {
+      r.sections.foreach { sec =>
+        val rel = ctx.workspace.relativize(sec.file)
+        val pkg = if sec.packageName.nonEmpty then s" (${sec.packageName})" else ""
+        println(s"Members of ${sec.ownerKind.toString.toLowerCase} ${r.symbol}$pkg — $rel:${sec.line}:")
+        if sec.ownMembers.isEmpty then println("  (no members)")
+        else {
+          println(s"  Defined in ${r.symbol}:")
+          sec.ownMembers.take(ctx.limit).foreach { m =>
+            if ctx.verbose then
+              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
+            else
+              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
+          }
+          if sec.ownMembers.size > ctx.limit then println(s"    ... and ${sec.ownMembers.size - ctx.limit} more")
+        }
+        sec.inherited.foreach { (parentName, _, _, pMembers) =>
+          println(s"  Inherited from $parentName:")
+          pMembers.take(ctx.limit).foreach { m =>
+            if ctx.verbose then
+              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
+            else
+              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
+          }
+          if pMembers.size > ctx.limit then println(s"    ... and ${pMembers.size - ctx.limit} more")
+        }
+      }
+    }
+  }
+}
+
+private def renderDocEntries(r: CmdResult.DocEntries, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val entries = r.entries.take(ctx.limit).map { e =>
+      val rel = jsonEscape(ctx.workspace.relativize(e.sym.file).toString)
+      val doc = e.doc.map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
+      s"""{"name":"${jsonEscape(e.sym.name)}","kind":"${e.sym.kind.toString.toLowerCase}","file":"$rel","line":${e.sym.line},"package":"${jsonEscape(e.sym.packageName)}","doc":$doc}"""
+    }
+    println(entries.mkString("[", ",", "]"))
+  } else {
+    r.entries.take(ctx.limit).foreach { e =>
+      val rel = ctx.workspace.relativize(e.sym.file)
+      val pkg = if e.sym.packageName.nonEmpty then s" (${e.sym.packageName})" else ""
+      println(s"${e.sym.kind.toString.toLowerCase} ${r.symbol}$pkg — $rel:${e.sym.line}:")
+      e.doc match {
+        case Some(doc) => println(doc)
+        case None => println("  (no scaladoc)")
+      }
+      println()
+    }
+  }
+}
+
+private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
+  val d = r.data
+  if ctx.jsonOutput then {
+    val kindJson = d.symbolsByKind.map((k, c) => s""""${k.toString.toLowerCase}":$c""").mkString("{", ",", "}")
+    val pkgJson = d.topPackages.map((p, c) => s"""{"package":"${jsonEscape(p)}","count":$c}""").mkString("[", ",", "]")
+    val extJson = d.mostExtended.map((n, c) => s"""{"name":"${jsonEscape(n)}","implementations":$c}""").mkString("[", ",", "]")
+    if d.hasArchitecture then {
+      val depsJson = d.pkgDeps.map { (pkg, deps) =>
+        val dArr = deps.map(dep => s""""${jsonEscape(dep)}"""").mkString("[", ",", "]")
+        s""""${jsonEscape(pkg)}":$dArr"""
+      }.mkString("{", ",", "}")
+      val hubJson = d.hubTypes.map((n, c) => s"""{"name":"${jsonEscape(n)}","score":$c}""").mkString("[", ",", "]")
+      println(s"""{"fileCount":${d.fileCount},"symbolCount":${d.symbolCount},"packageCount":${d.packageCount},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"mostExtended":$extJson,"packageDependencies":$depsJson,"hubTypes":$hubJson}""")
+    } else {
+      println(s"""{"fileCount":${d.fileCount},"symbolCount":${d.symbolCount},"packageCount":${d.packageCount},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"mostExtended":$extJson}""")
+    }
+  } else {
+    println(s"Project overview (${d.fileCount} files, ${d.symbolCount} symbols):\n")
+    println("Symbols by kind:")
+    d.symbolsByKind.foreach { (kind, count) =>
+      println(s"  ${kind.toString.padTo(10, ' ')} $count")
+    }
+    println(s"\nTop packages (by symbol count):")
+    d.topPackages.foreach { (pkg, count) =>
+      println(s"  ${pkg.padTo(50, ' ')} $count")
+    }
+    println(s"\nMost extended (by implementation count):")
+    d.mostExtended.foreach { (name, count) =>
+      println(s"  ${name.padTo(30, ' ')} $count impl")
+    }
+    if d.hasArchitecture then {
+      println(s"\nPackage dependencies:")
+      if d.pkgDeps.isEmpty then println("  (no cross-package dependencies found)")
+      else d.pkgDeps.toList.sortBy(_._1).foreach { (pkg, deps) =>
+        println(s"  $pkg → ${deps.toList.sorted.mkString(", ")}")
+      }
+      println(s"\nHub types (by extension count):")
+      if d.hubTypes.isEmpty then println("  (none)")
+      else d.hubTypes.foreach { (name, count) =>
+        println(s"  ${name.padTo(30, ' ')} $count references")
+      }
+    }
+  }
+}
+
+private def renderSourceBlocks(r: CmdResult.SourceBlocks, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.blocks.take(ctx.limit).map { (file, b) =>
+      val rel = jsonEscape(ctx.workspace.relativize(file).toString)
+      s"""{"name":"${jsonEscape(b.symbolName)}","owner":"${jsonEscape(b.ownerName)}","file":"$rel","startLine":${b.startLine},"endLine":${b.endLine},"body":"${jsonEscape(b.sourceText)}"}"""
+    }.mkString("[", ",", "]")
+    println(arr)
+  } else {
+    r.blocks.take(ctx.limit).foreach { (file, b) =>
+      val ownerStr = if b.ownerName.nonEmpty then s" — ${b.ownerName}" else ""
+      val rel = ctx.workspace.relativize(file)
+      println(s"Body of ${b.symbolName}$ownerStr — $rel:${b.startLine}:")
+      val bodyLines = b.sourceText.split("\n")
+      bodyLines.zipWithIndex.foreach { case (line, i) =>
+        println(s"  ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
+      }
+      println()
+    }
+  }
+}
+
+private def renderTestSuites(r: CmdResult.TestSuites, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.suites.take(ctx.limit).map { suite =>
+      val rel = jsonEscape(ctx.workspace.relativize(suite.file).toString)
+      val testsJson = suite.tests.map { tc =>
+        val bodyField = if r.showBody then {
+          tc.body.map(b => s""","body":"${jsonEscape(b.sourceText)}"""").getOrElse("")
+        } else ""
+        s"""{"name":"${jsonEscape(tc.name)}","line":${tc.line}$bodyField}"""
+      }.mkString("[", ",", "]")
+      s"""{"suite":"${jsonEscape(suite.name)}","file":"$rel","line":${suite.line},"tests":$testsJson}"""
+    }.mkString("[", ",", "]")
+    println(arr)
+  } else {
+    if r.suites.isEmpty then {
+      println(r.emptyMessage)
+    } else {
+      r.suites.take(ctx.limit).foreach { suite =>
+        val rel = ctx.workspace.relativize(suite.file)
+        println(s"${suite.name} — $rel:${suite.line}:")
+        suite.tests.foreach { tc =>
+          println(s"""  test  "${tc.name}"  :${tc.line}""")
+          if r.showBody || ctx.verbose then {
+            tc.body.foreach { b =>
+              val bodyLines = b.sourceText.split("\n")
+              bodyLines.zipWithIndex.foreach { case (line, i) =>
+                println(s"    ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
+              }
+              println()
+            }
+          }
+        }
+        if !r.showBody && !ctx.verbose then println()
+      }
+    }
+  }
+}
+
+private def renderCoverageReport(r: CmdResult.CoverageReport, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val refsJson = r.testRefs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
+    println(s"""{"symbol":"${jsonEscape(r.symbol)}","testFileCount":${r.testFiles.size},"referenceCount":${r.testRefs.size},"references":$refsJson}""")
+  } else {
+    if r.testRefs.isEmpty then {
+      if r.totalRefs == 0 then {
+        println(s"""Coverage of "${r.symbol}" — no references found""")
+        renderHint(mkNotFoundHint(r.symbol, ctx, "coverage"))
+      } else {
+        println(s"""Coverage of "${r.symbol}" — ${r.totalRefs} refs but 0 in test files""")
+      }
+    } else {
+      println(s"""Coverage of "${r.symbol}" — ${r.testRefs.size} refs in ${r.testFiles.size} test files:""")
+      r.testFiles.sorted.foreach { f =>
+        val fileRefs = r.testRefs.filter(ref => ctx.workspace.relativize(ref.file).toString == f)
+        println(s"  $f")
+        fileRefs.take(ctx.limit).foreach { ref =>
+          println(s"    :${ref.line}  ${ref.contextLine}")
+        }
+      }
+    }
+  }
+}
+
+private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandContext): Unit = {
+  val tree = r.tree
+  def nodeJson(n: HierarchyNode): String = {
+    val file = n.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
+    val kind = n.kind.map(k => s""""${k.toString.toLowerCase}"""").getOrElse("null")
+    val line = n.line.map(_.toString).getOrElse("null")
+    s"""{"name":"${jsonEscape(n.name)}","kind":$kind,"file":$file,"line":$line,"package":"${jsonEscape(n.packageName)}","isExternal":${n.isExternal}}"""
+  }
+  def treeJson(t: HierarchyTree): String = {
+    val ps = t.parents.map(treeJson).mkString("[", ",", "]")
+    val cs = t.children.map(treeJson).mkString("[", ",", "]")
+    s"""{"node":${nodeJson(t.root)},"parents":$ps,"children":$cs}"""
+  }
+  if ctx.jsonOutput then {
+    println(treeJson(tree))
+  } else {
+    val rootNode = tree.root
+    val pkg = if rootNode.packageName.nonEmpty then s" (${rootNode.packageName})" else ""
+    val kind = rootNode.kind.map(_.toString.toLowerCase).getOrElse("unknown")
+    val loc = rootNode.file.map(f => s" — ${ctx.workspace.relativize(f)}:${rootNode.line.getOrElse(0)}").getOrElse("")
+    println(s"Hierarchy of $kind ${rootNode.name}$pkg$loc:")
+    if ctx.goUp then {
+      println("  Parents:")
+      def printParents(parents: List[HierarchyTree], indent: String): Unit = {
+        parents.zipWithIndex.foreach { case (pt, i) =>
+          val isLast = i == parents.size - 1
+          val prefix = if isLast then s"$indent└── " else s"$indent├── "
+          val nextIndent = if isLast then s"$indent    " else s"$indent│   "
+          val n = pt.root
+          val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
+          val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
+          val nloc = if n.isExternal then " [external]"
+                     else n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
+          println(s"$prefix$nkind${n.name}$npkg$nloc")
+          printParents(pt.parents, nextIndent)
+        }
+      }
+      if tree.parents.isEmpty then println("    (none)")
+      else printParents(tree.parents, "    ")
+    }
+    if ctx.goDown then {
+      println("  Children:")
+      def printChildren(children: List[HierarchyTree], indent: String): Unit = {
+        children.zipWithIndex.foreach { case (ct, i) =>
+          val isLast = i == children.size - 1
+          val prefix = if isLast then s"$indent└── " else s"$indent├── "
+          val nextIndent = if isLast then s"$indent    " else s"$indent│   "
+          val n = ct.root
+          val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
+          val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
+          val nloc = n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
+          println(s"$prefix$nkind${n.name}$npkg$nloc")
+          printChildren(ct.children, nextIndent)
+        }
+      }
+      if tree.children.isEmpty then println("    (none)")
+      else printChildren(tree.children, "    ")
+    }
+  }
+}
+
+private def renderOverrideList(r: CmdResult.OverrideList, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.results.map { o =>
+      val rel = jsonEscape(ctx.workspace.relativize(o.file).toString)
+      s"""{"enclosingClass":"${jsonEscape(o.enclosingClass)}","enclosingKind":"${o.enclosingKind.toString.toLowerCase}","file":"$rel","line":${o.line},"signature":"${jsonEscape(o.signature)}","package":"${jsonEscape(o.packageName)}"}"""
+    }.mkString("[", ",", "]")
+    println(arr)
+  } else {
+    println(r.header)
+    r.results.foreach { o =>
+      val rel = ctx.workspace.relativize(o.file)
+      val pkg = if o.packageName.nonEmpty then s" (${o.packageName})" else ""
+      println(s"  ${o.enclosingClass}$pkg — $rel:${o.line}")
+      println(s"    ${o.signature}")
+    }
+  }
+}
+
+private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Unit = {
+  val sym = r.sym
+  val rel = ctx.workspace.relativize(sym.file)
+  val pkg = if sym.packageName.nonEmpty then s" (${sym.packageName})" else ""
+  if ctx.jsonOutput then {
+    val docJson = r.doc.map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
+    val membersJson = r.members.map { m =>
+      s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
+    }.mkString("[", ",", "]")
+    val implsJson = r.impls.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
+    println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":$docJson,"members":$membersJson,"implementations":$implsJson,"importCount":${r.importCount}}""")
+  } else {
+    println(s"Explanation of ${sym.kind.toString.toLowerCase} ${sym.name}$pkg:\n")
+    println(s"  Definition: $rel:${sym.line}")
+    println(s"  Signature: ${sym.signature}")
+    if sym.parents.nonEmpty then println(s"  Extends: ${sym.parents.mkString(", ")}")
+    println()
+    r.doc match {
+      case Some(d) =>
+        println("  Scaladoc:")
+        d.split("\n").foreach(l => println(s"    $l"))
+        println()
+      case None =>
+        println("  Scaladoc: (none)\n")
+    }
+    if r.members.nonEmpty then {
+      println(s"  Members (top ${r.members.size}):")
+      r.members.foreach(m => println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}"))
+      println()
+    }
+    if r.impls.nonEmpty then {
+      println(s"  Implementations (top ${r.impls.size}):")
+      r.impls.foreach(s => println(formatSymbol(s, ctx.workspace)))
+      println()
+    }
+    println(s"  Imported by: ${r.importCount} files")
+  }
+}
+
+private def renderDependencies(r: CmdResult.Dependencies, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val iArr = r.importDeps.map { d =>
+      val file = d.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
+      val line = d.line.map(_.toString).getOrElse("null")
+      s"""{"name":"${jsonEscape(d.name)}","kind":"${jsonEscape(d.kind)}","file":$file,"line":$line,"package":"${jsonEscape(d.packageName)}"}"""
+    }.mkString("[", ",", "]")
+    val bArr = r.bodyDeps.map { d =>
+      val file = d.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
+      val line = d.line.map(_.toString).getOrElse("null")
+      s"""{"name":"${jsonEscape(d.name)}","kind":"${jsonEscape(d.kind)}","file":$file,"line":$line,"package":"${jsonEscape(d.packageName)}"}"""
+    }.mkString("[", ",", "]")
+    println(s"""{"imports":$iArr,"bodyReferences":$bArr}""")
+  } else {
+    println(s"""Dependencies of "${r.symbol}":""")
+    if r.importDeps.nonEmpty then {
+      println(s"\n  Imports:")
+      r.importDeps.take(ctx.limit).foreach { d =>
+        val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
+        println(s"    ${d.kind.padTo(9, ' ')} ${d.name}$loc")
+      }
+      if r.importDeps.size > ctx.limit then println(s"    ... and ${r.importDeps.size - ctx.limit} more")
+    }
+    if r.bodyDeps.nonEmpty then {
+      println(s"\n  Body references:")
+      r.bodyDeps.take(ctx.limit).foreach { d =>
+        val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
+        println(s"    ${d.kind.padTo(9, ' ')} ${d.name}$loc")
+      }
+      if r.bodyDeps.size > ctx.limit then println(s"    ... and ${r.bodyDeps.size - ctx.limit} more")
+    }
+  }
+}
+
+private def renderScopes(r: CmdResult.Scopes, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.scopes.map { s =>
+      s"""{"name":"${jsonEscape(s.name)}","kind":"${jsonEscape(s.kind)}","line":${s.line}}"""
+    }.mkString("[", ",", "]")
+    val rel = jsonEscape(ctx.workspace.relativize(r.file).toString)
+    println(s"""{"file":"$rel","line":${r.line},"scopes":$arr}""")
+  } else {
+    val rel = ctx.workspace.relativize(r.file)
+    println(s"Context at $rel:${r.line}:")
+    if r.scopes.isEmpty then println("  (no enclosing scopes found)")
+    else {
+      r.scopes.foreach { s =>
+        println(s"  ${s.kind.padTo(9, ' ')} ${s.name} (line ${s.line})")
+      }
+    }
+  }
+}
+
+private def renderSymbolDiff(r: CmdResult.SymbolDiff, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    if r.filesChanged == 0 then {
+      println("""{"added":[],"removed":[],"modified":[]}""")
+    } else {
+      def diffSymJson(s: DiffSymbol): String =
+        s"""{"name":"${jsonEscape(s.name)}","kind":"${s.kind.toString.toLowerCase}","file":"${jsonEscape(s.file)}","line":${s.line},"package":"${jsonEscape(s.packageName)}","signature":"${jsonEscape(s.signature)}"}"""
+      val addedJson = r.added.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
+      val removedJson = r.removed.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
+      val modifiedJson = r.modified.take(ctx.limit).map { (o, n) =>
+        s"""{"old":${diffSymJson(o)},"new":${diffSymJson(n)}}"""
+      }.mkString("[", ",", "]")
+      println(s"""{"ref":"${jsonEscape(r.ref)}","filesChanged":${r.filesChanged},"added":$addedJson,"removed":$removedJson,"modified":$modifiedJson}""")
+    }
+  } else {
+    if r.filesChanged == 0 then {
+      println(s"No Scala files changed compared to ${r.ref}")
+    } else {
+      println(s"Symbol changes compared to ${r.ref} (${r.filesChanged} files changed):")
+      if r.added.nonEmpty then {
+        println(s"\n  Added (${r.added.size}):")
+        r.added.take(ctx.limit).foreach { s =>
+          println(s"    + ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
+        }
+        if r.added.size > ctx.limit then println(s"    ... and ${r.added.size - ctx.limit} more")
+      }
+      if r.removed.nonEmpty then {
+        println(s"\n  Removed (${r.removed.size}):")
+        r.removed.take(ctx.limit).foreach { s =>
+          println(s"    - ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
+        }
+        if r.removed.size > ctx.limit then println(s"    ... and ${r.removed.size - ctx.limit} more")
+      }
+      if r.modified.nonEmpty then {
+        println(s"\n  Modified (${r.modified.size}):")
+        r.modified.take(ctx.limit).foreach { (_, n) =>
+          println(s"    ~ ${n.kind.toString.toLowerCase.padTo(9, ' ')} ${n.name} — ${n.file}:${n.line}")
+        }
+        if r.modified.size > ctx.limit then println(s"    ... and ${r.modified.size - ctx.limit} more")
+      }
+      if r.added.isEmpty && r.removed.isEmpty && r.modified.isEmpty then
+        println("  No symbol-level changes detected")
+    }
+  }
+}
+
+private def renderAstMatches(r: CmdResult.AstMatches, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.results.map { m =>
+      val rel = jsonEscape(ctx.workspace.relativize(m.file).toString)
+      s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","file":"$rel","line":${m.line},"package":"${jsonEscape(m.packageName)}","signature":"${jsonEscape(m.signature)}"}"""
+    }.mkString("[", ",", "]")
+    println(arr)
+  } else {
+    if r.results.isEmpty then
+      println(s"No types matching AST pattern (${r.filters})")
+    else {
+      println(s"Types matching AST pattern (${r.filters}) — ${r.results.size} found:")
+      r.results.foreach { m =>
+        val rel = ctx.workspace.relativize(m.file)
+        val pkg = if m.packageName.nonEmpty then s" (${m.packageName})" else ""
+        println(s"  ${m.kind.toString.toLowerCase.padTo(9, ' ')} ${m.name}$pkg — $rel:${m.line}")
+      }
+    }
+  }
+}
+
+private def renderGrepCount(r: CmdResult.GrepCount, ctx: CommandContext): Unit = {
+  r.stderrHint.foreach(System.err.println)
+  if ctx.jsonOutput then {
+    val hintStr = r.hint.getOrElse("")
+    println(s"""{"matches":${r.matches},"files":${r.files},"timedOut":${r.timedOut}$hintStr}""")
+  } else {
+    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    println(s"${r.matches} matches across ${r.files} files$suffix")
+  }
+}
+
+private def renderPackages(r: CmdResult.Packages, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val arr = r.packages.map(p => s""""${jsonEscape(p)}"""").mkString("[", ",", "]")
+    println(arr)
+  } else {
+    println(s"Packages (${r.packages.size}):")
+    r.packages.foreach(p => println(s"  $p"))
+  }
+}
+
+private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    r.hint.cmd match {
+      case "hierarchy" =>
+        // hierarchy never emits JSON for not-found case (matches original behavior)
+        println(r.message)
+        renderHint(r.hint)
+      case "explain" => println("""{"error":"not found"}""")
+      case "imports" => println(s"""{"results":[],"timedOut":${ctx.idx.timedOut}}""")
+      case "deps" => println("""{"imports":[],"bodyReferences":[]}""")
+      case _ => println("[]")
+    }
+  } else {
+    println(r.message)
+    renderHint(r.hint)
+  }
+}

--- a/src/model.scala
+++ b/src/model.scala
@@ -102,3 +102,53 @@ case class CommandContext(
   val fmtRef: Reference => String =
     if contextLines > 0 then r => formatRefWithContext(r, workspace, contextLines)
     else r => formatRef(r, workspace)
+
+// ── CmdResult types ────────────────────────────────────────────────────────
+
+case class NotFoundHint(symbol: String, fileCount: Int, parseFailures: Int, cmd: String, batchMode: Boolean, looksLikePath: Boolean)
+
+case class MemberSectionData(
+  file: Path, ownerKind: SymbolKind, packageName: String, line: Int,
+  ownMembers: List[MemberInfo],
+  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])]
+)
+
+case class DocEntryData(sym: SymbolInfo, doc: Option[String])
+
+case class OverviewData(
+  fileCount: Int, symbolCount: Int, packageCount: Int,
+  symbolsByKind: List[(kind: SymbolKind, count: Int)],
+  topPackages: List[(pkg: String, count: Int)],
+  mostExtended: List[(name: String, count: Int)],
+  pkgDeps: Map[String, Set[String]],
+  hubTypes: List[(name: String, score: Int)],
+  hasArchitecture: Boolean
+)
+
+case class TestCaseResult(name: String, line: Int, body: Option[BodyInfo])
+case class TestSuiteResult(name: String, file: Path, line: Int, tests: List[TestCaseResult])
+
+enum CmdResult:
+  case SymbolList(header: String, symbols: List[SymbolInfo], total: Int, emptyMessage: String = "", truncate: Boolean = true)
+  case RefList(header: String, refs: List[Reference], timedOut: Boolean, hint: Option[String] = None, useContext: Boolean = true, emptyMessage: String = "", stderrHint: Option[String] = None)
+  case CategorizedRefs(symbol: String, grouped: Map[RefCategory, List[Reference]], targetPkgs: Set[String], timedOut: Boolean, stderrHint: Option[String] = None)
+  case FlatRefs(symbol: String, refs: List[Reference], targetPkgs: Set[String], timedOut: Boolean)
+  case StringList(header: String, items: List[String], total: Int, emptyMessage: String = "")
+  case IndexStats(fileCount: Int, symbolCount: Int, packageCount: Int, symbolsByKind: List[(kind: SymbolKind, count: Int)], indexTimeMs: Long, cachedLoad: Boolean, parsedCount: Int, skippedCount: Int, parseFailures: Int, parseFailedFiles: List[String])
+  case MemberSections(symbol: String, sections: List[MemberSectionData])
+  case DocEntries(symbol: String, entries: List[DocEntryData])
+  case Overview(data: OverviewData)
+  case SourceBlocks(symbol: String, blocks: List[(file: Path, body: BodyInfo)])
+  case TestSuites(suites: List[TestSuiteResult], showBody: Boolean, emptyMessage: String = "No test suites found")
+  case CoverageReport(symbol: String, totalRefs: Int, testRefs: List[Reference], testFiles: List[String])
+  case HierarchyResult(symbol: String, tree: HierarchyTree)
+  case OverrideList(header: String, results: List[OverrideInfo])
+  case Explanation(sym: SymbolInfo, doc: Option[String], members: List[MemberInfo], impls: List[SymbolInfo], importCount: Int)
+  case Dependencies(symbol: String, importDeps: List[DepInfo], bodyDeps: List[DepInfo])
+  case Scopes(file: Path, line: Int, scopes: List[ScopeInfo])
+  case SymbolDiff(ref: String, filesChanged: Int, added: List[DiffSymbol], removed: List[DiffSymbol], modified: List[(before: DiffSymbol, after: DiffSymbol)])
+  case AstMatches(filters: String, results: List[AstPatternMatch])
+  case GrepCount(matches: Int, files: Int, timedOut: Boolean, hint: Option[String] = None, stderrHint: Option[String] = None)
+  case Packages(packages: List[String])
+  case NotFound(message: String, hint: NotFoundHint)
+  case UsageError(message: String)


### PR DESCRIPTION
## Summary

- Commands now return `CmdResult` enum values instead of calling `println` directly
- Single `render()` function in `format.scala` handles all JSON/text output dispatch
- Eliminates ~130 scattered `println` calls and ~20 duplicated JSON/text branches across 24 commands
- `printNotFoundHint` removed; hint rendering consolidated into `renderHint` helper

## Details

| File | Change |
|------|--------|
| `model.scala` | +`CmdResult` enum (23 variants), +6 supporting types |
| `format.scala` | +`render(result, ctx)` with per-variant helpers |
| `commands.scala` | All 24 `cmdXxx` return `CmdResult`; dispatch map type updated |
| `cli.test.scala` | 2 tests updated to use `runCommand` instead of removed `printNotFoundHint` |

## Test plan

- [x] All 176 tests pass with identical output
- [x] Manual smoke tests: `search`, `def --json`, `overview`, `packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)