### PR TITLE
fix: handle empty array under set -u in build script

### DIFF
--- a/build-native.sh
+++ b/build-native.sh
@@ -17,7 +17,7 @@ scala-cli package --native-image \
   --force \
   -- --no-fallback \
   --initialize-at-run-time=com.google.common.hash.Striped64,com.google.common.hash.LongAdder,com.google.common.hash.BloomFilter,com.google.common.hash.BloomFilterStrategies \
-  "${MARCH_FLAG[@]}"
+  ${MARCH_FLAG[@]+"${MARCH_FLAG[@]}"}
 
 echo ""
 echo "Built: $OUT"


### PR DESCRIPTION
## Summary
- `MARCH_FLAG` array is empty on CI — `set -u` (nounset) treats `${MARCH_FLAG[@]}` as unbound variable
- Fix: use `${arr[@]+"${arr[@]}"}` idiom for safe empty array expansion
- Tested locally with `CI=true ./build-native.sh`

After merging, re-tag v1.14.0 to trigger release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)