### PR TITLE
fix: explain ranking and hierarchy walking (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `explain` now ranks class/trait/object/enum above val/def when selecting the primary symbol — previously took the first unranked result, so `explain Observer` could resolve to a `val observer` instead of `trait Observer` (#80)
+- `hierarchy --up` and `--down` now correctly walk the inheritance tree — cycle-detection was pre-seeded with the root symbol, causing both directions to always return `(none)` (#80)
+
 ## [1.14.0] — 2026-03-16
 
 ### Fixed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -242,6 +242,16 @@ Feedback from dogfooding scalex on itself — test cases (`test("name") { ... }`
 ### ~~Multi-workspace / cross-project awareness (#64)~~
 - ~~Support indexing additional source roots beyond the current workspace~~ — unnecessary complexity; users can simply instruct the agent to run scalex with `-w` on the target workspace instead
 
+### Symbol disambiguation (#80) — DONE
+
+Feedback from real-world usage exploring the Airstream library (~240 files).
+
+**`explain` should use `def` ranking:**
+- [x] Apply the same `sortBy` ranking (class/trait/object/enum > type/given > def/val) in `explain` before selecting the primary symbol — was taking `defs.head` unranked, so `explain Observer` resolved to a `val observer` instead of `trait Observer`
+
+**`hierarchy` cycle-detection fix:**
+- [x] Fix `hierarchy --up` and `--down` returning `(none)` — `buildHierarchy` initialized `visited = Set(sym.name)` before calling `walkUp`/`walkDown`, causing them to exit immediately; fixed by passing `Set.empty`
+
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")
 - [ ] `scalex imports <file>` — show what a file imports (its dependencies)

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -46,8 +46,8 @@ def buildHierarchy(idx: WorkspaceIndex, symbolName: String, goUp: Boolean, goDow
     }
   }
 
-  val parents = if goUp then walkUp(sym.name, Set(sym.name.toLowerCase)) else Nil
-  val children = if goDown then walkDown(sym.name, Set(sym.name.toLowerCase)) else Nil
+  val parents = if goUp then walkUp(sym.name, Set.empty) else Nil
+  val children = if goDown then walkDown(sym.name, Set.empty) else Nil
   Some(HierarchyTree(rootNode, parents, children))
 }
 

--- a/src/analysis.test.scala
+++ b/src/analysis.test.scala
@@ -29,6 +29,30 @@ class AnalysisSuite extends ScalexTestBase:
     assertEquals(tree.root.name, "UserService")
   }
 
+  test("buildHierarchy --down finds children (regression #80)") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val result = buildHierarchy(idx, "UserService", goUp = false, goDown = true, workspace)
+    assert(result.isDefined, "Should find hierarchy for UserService")
+    val tree = result.get
+    val childNames = tree.children.map(_.root.name).toSet
+    assert(childNames.contains("UserServiceLive"),
+      s"Should find UserServiceLive as child: $childNames")
+    assert(childNames.contains("OldService"),
+      s"Should find OldService as child: $childNames")
+  }
+
+  test("buildHierarchy --up finds parents (regression #80)") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val result = buildHierarchy(idx, "UserServiceLive", goUp = true, goDown = false, workspace)
+    assert(result.isDefined, "Should find hierarchy for UserServiceLive")
+    val tree = result.get
+    val parentNames = tree.parents.map(_.root.name).toSet
+    assert(parentNames.contains("UserService"),
+      s"Should find UserService as parent: $parentNames")
+  }
+
   test("buildHierarchy goUp=false produces empty parents") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
@@ -86,6 +110,19 @@ class AnalysisSuite extends ScalexTestBase:
   }
 
   // ── explain command — constituent calls ───────────────────────────────
+
+  test("explain ranks class/trait above val/object (regression #80)") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // UserService has trait + object + val references — explain should pick the trait
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      runCommand("explain", List("UserService"), CommandContext(idx = idx, workspace = workspace))
+    }
+    val output = out.toString
+    assert(output.contains("trait UserService"),
+      s"explain should pick trait UserService, not val/object: $output")
+  }
 
   test("explain: constituent calls work together for PaymentService") {
     val idx = WorkspaceIndex(workspace)

--- a/src/commands.scala
+++ b/src/commands.scala
@@ -438,6 +438,16 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
       var defs = ctx.idx.findDefinition(symbol)
       if ctx.noTests then defs = defs.filter(s => !isTestFile(s.file, ctx.workspace))
       ctx.pathFilter.foreach { p => defs = defs.filter(s => matchesPath(s.file, p, ctx.workspace)) }
+      // Rank: class/trait/object/enum first (same as def command)
+      defs = defs.sortBy { s =>
+        val kindRank = s.kind match
+          case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+          case SymbolKind.Type | SymbolKind.Given => 1
+          case _ => 2
+        val testRank = if isTestFile(s.file, ctx.workspace) then 1 else 0
+        val pathLen = ctx.workspace.relativize(s.file).toString.length
+        (kindRank, testRank, pathLen)
+      }
       if defs.isEmpty then
         CmdResult.NotFound(
           s"""No definition of "$symbol" found""",


### PR DESCRIPTION
## Summary
- **`explain` ranking**: Apply same `sortBy` as `def` command (class/trait/object/enum first) before selecting primary symbol — fixes `explain Observer` resolving to `val observer` instead of `trait Observer`
- **`hierarchy --up/--down`**: Fix cycle-detection bug where visited set was pre-seeded with root symbol, causing `walkUp`/`walkDown` to return `(none)` immediately
- 3 regression tests added to `AnalysisSuite`

Closes #80

## Test plan
- [x] `scala-cli test src/` — 179 tests pass (3 new)
- [x] Verified against Airstream codebase: `explain Observer` → `trait Observer`, `hierarchy Observable --down` → full tree with 60+ descendants

🤖 Generated with [Claude Code](https://claude.com/claude-code)