### PR TITLE
perf: lazy map building in WorkspaceIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Enhanced `bench.sh` — index size reporting, diverse query benchmarks, `--timings` integration
 - `bench-compare.sh` — compare two hyperfine JSON exports, flag >5% regressions
 
+### Changed
+- Lazy map building in `WorkspaceIndex` — derived indexes (`symbolsByName`, `parentIndex`, `filesByPath`, etc.) are now `lazy val` fields computed on first access instead of eagerly built in a monolithic `index-build` phase. Commands that use only 1–2 maps skip building the rest. Benchmarked on scala3 compiler (17.7k files): `file` 2.16x faster (951→441ms), `impl` 2.00x (928→465ms), `packages` 1.86x (904→486ms), `def` 1.31x (905→693ms), `grep` 1.59x (1442→904ms)
+
 ### Fixed
 - `explain` now ranks class/trait/object/enum above val/def when selecting the primary symbol — previously took the first unranked result, so `explain Observer` could resolve to a `val observer` instead of `trait Observer` (#80)
 - `hierarchy --up` and `--down` now correctly walk the inheritance tree — cycle-detection was pre-seeded with the root symbol, causing both directions to always return `(none)` (#80)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -264,7 +264,7 @@ Feedback from real-world usage exploring the Airstream library (~240 files).
 Benchmark data shows every query pays ~770ms baseline just to load+build the index. Actual query logic adds only 28–470ms. The warm-load path (`cache-load` 38% + `index-build` 48%) is the dominant bottleneck.
 
 **High priority:**
-- [ ] Lazy map building — build `symbolsByName`, `parentIndex`, `filesByPath`, `annotationIndex`, `packageToSymbols`, `aliasIndex` etc. on first access instead of eagerly; most commands use only 1–2 maps. Expected: ~150–200ms savings on typical queries
+- [x] Lazy map building — `lazy val` fields in `WorkspaceIndex` compute derived maps on first access; most commands use only 1–2 maps. Measured: `file` 2.16x, `impl` 2.00x, `packages` 1.86x, `def` 1.31x faster on scala3 (17.7k files)
 - [ ] Separate bloom storage — store bloom filters in `blooms.bin` separate from `index.bin`; non-bloom commands (`def`, `search`, `impl`, `packages`, `hierarchy`) load ~7MB instead of 22MB. Expected: ~100–150ms savings on non-bloom commands
 
 **Medium priority:**

--- a/src/index.scala
+++ b/src/index.scala
@@ -184,19 +184,83 @@ object IndexPersistence:
 // ── Workspace index ─────────────────────────────────────────────────────────
 
 class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
-  var symbols: List[SymbolInfo] = Nil
-  var filesByPath: Map[Path, List[SymbolInfo]] = Map.empty
-  var symbolsByName: Map[String, List[SymbolInfo]] = Map.empty
-  var packages: Set[String] = Set.empty
   var gitFiles: List[GitFile] = Nil
   private var indexedFiles: List[IndexedFile] = Nil
-  var parentIndex: Map[String, List[SymbolInfo]] = Map.empty
 
-  private var distinctSymbols: List[SymbolInfo] = Nil
-  var packageToSymbols: Map[String, Set[String]] = Map.empty
-  private var indexedByPath: Map[String, IndexedFile] = Map.empty
-  private var aliasIndex: Map[String, List[(file: IndexedFile, alias: String)]] = Map.empty
-  private var annotationIndex: Map[String, List[SymbolInfo]] = Map.empty
+  private lazy val allSymbols: List[SymbolInfo] =
+    Timings.phase("build-allSymbols") {
+      indexedFiles.flatMap(_.symbols)
+    }
+
+  lazy val symbols: List[SymbolInfo] = allSymbols
+
+  lazy val filesByPath: Map[Path, List[SymbolInfo]] =
+    Timings.phase("build-filesByPath") {
+      allSymbols.groupBy(_.file)
+    }
+
+  lazy val symbolsByName: Map[String, List[SymbolInfo]] =
+    Timings.phase("build-symbolsByName") {
+      allSymbols.groupBy(_.name.toLowerCase)
+    }
+
+  lazy val packages: Set[String] =
+    Timings.phase("build-packages") {
+      allSymbols.iterator.map(_.packageName).filter(_.nonEmpty).toSet
+    }
+
+  lazy val parentIndex: Map[String, List[SymbolInfo]] =
+    Timings.phase("build-parentIndex") {
+      val pIdx = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
+      allSymbols.foreach { s =>
+        s.parents.foreach { p =>
+          pIdx.getOrElseUpdate(p.toLowerCase, mutable.ListBuffer.empty) += s
+        }
+      }
+      pIdx.map((k, v) => k -> v.toList).toMap
+    }
+
+  private lazy val distinctSymbols: List[SymbolInfo] =
+    Timings.phase("build-distinctSymbols") {
+      val seen = mutable.HashSet.empty[(String, Path, Int)]
+      allSymbols.filter(s => seen.add((s.name, s.file, s.line)))
+    }
+
+  lazy val packageToSymbols: Map[String, Set[String]] =
+    Timings.phase("build-packageToSymbols") {
+      val pkgToSyms = mutable.HashMap.empty[String, mutable.HashSet[String]]
+      allSymbols.foreach { s =>
+        pkgToSyms.getOrElseUpdate(s.packageName, mutable.HashSet.empty) += s.name
+      }
+      pkgToSyms.map((k, v) => k -> v.toSet).toMap
+    }
+
+  private lazy val indexedByPath: Map[String, IndexedFile] =
+    Timings.phase("build-indexedByPath") {
+      indexedFiles.map(f => f.relativePath -> f).toMap
+    }
+
+  private lazy val aliasIndex: Map[String, List[(file: IndexedFile, alias: String)]] =
+    Timings.phase("build-aliasIndex") {
+      val aIdx = mutable.HashMap.empty[String, mutable.ListBuffer[(file: IndexedFile, alias: String)]]
+      indexedFiles.foreach { f =>
+        f.aliases.foreach { (orig, alias) =>
+          aIdx.getOrElseUpdate(orig, mutable.ListBuffer.empty) += ((f, alias))
+        }
+      }
+      aIdx.map((k, v) => k -> v.toList).toMap
+    }
+
+  private lazy val annotationIndex: Map[String, List[SymbolInfo]] =
+    Timings.phase("build-annotationIndex") {
+      val aByAnnot = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
+      allSymbols.foreach { s =>
+        s.annotations.foreach { a =>
+          aByAnnot.getOrElseUpdate(a.toLowerCase, mutable.ListBuffer.empty) += s
+        }
+      }
+      aByAnnot.map((k, v) => k -> v.toList).toMap
+    }
 
   var fileCount: Int = 0
   var indexTimeMs: Long = 0
@@ -259,55 +323,6 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       case f if f.parseFailed => f.relativePath
     }
     parseFailures = parseFailedFiles.size
-    Timings.phase("index-build") {
-      // Single-pass over symbols: build all symbol-level indexes
-      val allSyms = mutable.ListBuffer.empty[SymbolInfo]
-      val byPath = mutable.HashMap.empty[Path, mutable.ListBuffer[SymbolInfo]]
-      val byName = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      val pkgs = mutable.HashSet.empty[String]
-      val pIdx = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      val pkgToSyms = mutable.HashMap.empty[String, mutable.HashSet[String]]
-      val distinctSeen = mutable.HashSet.empty[(String, Path, Int)]
-      val distinctBuf = mutable.ListBuffer.empty[SymbolInfo]
-      val aByAnnot = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      indexedFiles.foreach { f =>
-        f.symbols.foreach { s =>
-          allSyms += s
-          byPath.getOrElseUpdate(s.file, mutable.ListBuffer.empty) += s
-          byName.getOrElseUpdate(s.name.toLowerCase, mutable.ListBuffer.empty) += s
-          if s.packageName.nonEmpty then pkgs += s.packageName
-          s.parents.foreach { p =>
-            pIdx.getOrElseUpdate(p.toLowerCase, mutable.ListBuffer.empty) += s
-          }
-          s.annotations.foreach { a =>
-            aByAnnot.getOrElseUpdate(a.toLowerCase, mutable.ListBuffer.empty) += s
-          }
-          pkgToSyms.getOrElseUpdate(s.packageName, mutable.HashSet.empty) += s.name
-          val key = (s.name, s.file, s.line)
-          if distinctSeen.add(key) then distinctBuf += s
-        }
-      }
-      symbols = allSyms.toList
-      distinctSymbols = distinctBuf.toList
-      filesByPath = byPath.map((k, v) => k -> v.toList).toMap
-      symbolsByName = byName.map((k, v) => k -> v.toList).toMap
-      packages = pkgs.toSet
-      parentIndex = pIdx.map((k, v) => k -> v.toList).toMap
-      annotationIndex = aByAnnot.map((k, v) => k -> v.toList).toMap
-      packageToSymbols = pkgToSyms.map((k, v) => k -> v.toSet).toMap
-
-      // Single-pass over indexedFiles: build file-level indexes
-      val iByPath = mutable.HashMap.empty[String, IndexedFile]
-      val aIdx = mutable.HashMap.empty[String, mutable.ListBuffer[(file: IndexedFile, alias: String)]]
-      indexedFiles.foreach { f =>
-        iByPath(f.relativePath) = f
-        f.aliases.foreach { (orig, alias) =>
-          aIdx.getOrElseUpdate(orig, mutable.ListBuffer.empty) += ((f, alias))
-        }
-      }
-      indexedByPath = iByPath.toMap
-      aliasIndex = aIdx.map((k, v) => k -> v.toList).toMap
-    }
     indexTimeMs = (System.nanoTime() - t0) / 1_000_000
 
     if parsedCount > 0 then


### PR DESCRIPTION
## Summary
- Convert 10+ derived indexes in `WorkspaceIndex` from eagerly-built `var` fields to `lazy val` computed on first access
- Remove monolithic `index-build` phase (~258ms) — each map now builds independently only when needed
- Each lazy val wraps computation in `Timings.phase("build-*")` for `--timings` observability

## Benchmark results (scala3 compiler, 17.7k files, 203K symbols)

| Command | Before | After | Speedup |
|---------|--------|-------|---------|
| `file` | 951ms | 441ms | **2.16x** |
| `impl` | 928ms | 465ms | **2.00x** |
| `packages` | 904ms | 486ms | **1.86x** |
| `search` | 936ms | 577ms | **1.62x** |
| `grep` | 1442ms | 904ms | **1.59x** |
| `refs` | 1023ms | 768ms | **1.33x** |
| `def` | 905ms | 693ms | **1.31x** |

## Test plan
- [x] All 179 tests pass (`scala-cli test src/`)
- [x] `--timings` shows individual `build-*` phases instead of monolithic `index-build`
- [x] `grep`/`file` show zero `build-*` phases
- [x] Head-to-head hyperfine comparison confirms speedups across all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)