### PR TITLE
release: v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.15.0] — 2026-03-16
 
 ### Added
 - `--timings` flag — prints per-phase timing breakdown to stderr (git-ls-files, cache-load, oid-compare, parse, index-build, cache-save, bloom-screen, text-search); works in both JVM and native image

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.14.0"
+val ScalexVersion = "1.15.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to 1.15.0
- Move `[Unreleased]` changelog to `[1.15.0] — 2026-03-16`

## What's in 1.15.0
- **Perf**: Lazy map building — 1.3–2.2x faster queries on large codebases
- **Added**: `--timings` flag, profiling/benchmarking tooling
- **Fixed**: `explain` ranking, `hierarchy` cycle detection (#80)

## Next steps after merge
1. Tag `v1.15.0` and push — triggers CI to build native binaries + create release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)