### PR TITLE
chore: bump plugin version to 1.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "scalex",
       "source": "./plugin",
       "description": "Scala code intelligence for AI agents — search symbols, find definitions, find implementations, find references, explore imports. Works on Scala 2 and 3 codebases without a compiler or build server.",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugin/skills/scalex/scripts/scalex-cli
+++ b/plugin/skills/scalex/scripts/scalex-cli
@@ -7,7 +7,7 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="1.14.0"
+EXPECTED_VERSION="1.15.0"
 REPO="nguyenyou/scalex"
 
 # Cache location: follow XDG spec (like Mill uses ~/.cache/mill/download/)


### PR DESCRIPTION
## Summary
- Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli` to 1.15.0
- Bump `version` in `.claude-plugin/marketplace.json` to 1.15.0

Post-release version bump for v1.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)