### PR TITLE
docs: record warm-load round 2 findings (no gain)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -257,7 +257,7 @@ Feedback from real-world usage exploring the Airstream library (~240 files).
 - [x] Microbenchmark harness (`src/bench.scala`) — isolated per-function benchmarks with warmup, mean/median/p99/stddev; covers extractSymbols, bloom filter, persistence, search, refs
 - [x] Enhanced `bench.sh` — index size reporting, diverse query benchmarks (miss, heavy refs, fuzzy, grep, hierarchy), `--timings` integration, `bench-compare.sh` for regression detection
 
-### Warm-load optimization
+### Warm-load optimization — DONE
 
 Benchmark data shows every query pays ~770ms baseline just to load+build the index. Actual query logic adds only 28–470ms. The warm-load path (`cache-load` 38% + `index-build` 48%) is the dominant bottleneck.
 
@@ -271,6 +271,29 @@ Benchmark data shows every query pays ~770ms baseline just to load+build the ind
 
 **Lower priority:**
 - [ ] Memory-mapped I/O — replace `DataInputStream(BufferedInputStream(...))` with `MappedByteBuffer` for cache-load; eliminates kernel→user copy, lets OS page in only needed data
+
+### Warm-load optimization round 2 — TRIED, NO GAIN
+
+Post lazy-maps benchmarks (scala3, 17.7k files, 203K symbols) show two remaining bottlenecks:
+
+| Bottleneck | Time | % of total | Affects |
+|---|---|---|---|
+| `cache-load` | ~290ms | 45–79% | Every command |
+| `build-symbolsByName` | ~230ms | 40% | `def`, `refs`, `imports` |
+
+Cheapest commands (`grep`, `file`) are ~361ms. Most expensive (`def`, `refs`) are ~591–666ms.
+
+**Attempted (v7 format, reverted — no measurable improvement):**
+- ~~Blooms at end~~ — moved bloom filters to contiguous section at end of `index.bin`. Non-bloom commands skip ~12MB of blooms (saves ~67ms on cache-load), but adding lowerName strings grew the index from 22MB→24MB, offsetting the savings. Net: +10ms on `file`, -11ms on `def` — within noise
+- ~~2-byte indices~~ — plan assumed ~60K string table entries fitting in unsigned short. Actual table has **269K entries** (signatures, imports, parents, annotations all interned). `indexWidth=4` always, dead code on real codebases
+- ~~Pre-interned lowercase names~~ — stored `name.toLowerCase` per symbol. Added ~80K extra strings (+2MB index). `build-symbolsByName` unchanged at ~230ms because **`toLowerCase` is not the bottleneck — `groupBy` hash map building is**
+
+Hyperfine v6 vs v7 (7 runs each, warmup 2): `file` 361→371ms, `def` 591→580ms, `impl` 387→395ms, `refs` 666→646ms. All within σ.
+
+**Remaining ideas:**
+- [ ] Lazy symbol deserialization — deserialize `IndexedFile.symbols` on demand; `grep`/`file` never access symbols, skip deserialization entirely. The 269K-string readUTF loop is the true cache-load bottleneck
+- [ ] Pre-grouped symbol storage — store symbols pre-grouped by `name.toLowerCase` in binary index; skip the `groupBy` over 203K symbols entirely (the hash map building, not toLowerCase, is the ~230ms cost)
+- [ ] Memory-mapped I/O — `MappedByteBuffer` instead of `DataInputStream`; eliminates kernel→user copy, OS pages in only needed data
 
 ### Other
 - [x] `scalex file <query>` — fuzzy search file names (camelCase-aware, like IntelliJ's "search files")


### PR DESCRIPTION
## Summary

- Attempted three index format v7 optimizations for warm-load performance: blooms-at-end, 2-byte string indices, pre-interned lowercase names
- Benchmarked on scala3 compiler (17.7k files, 203K symbols) — all results within noise
- **Reverted code changes**, updated roadmap with findings and corrected bottleneck analysis

### Why it didn't work

| Optimization | Expected | Actual |
|---|---|---|
| 2-byte indices | String table ~60K entries, fits in u16 | **269K entries** — never activates |
| Pre-interned lowerName | Eliminate 203K `toLowerCase` calls | `groupBy` hash map building is the bottleneck, not `toLowerCase` |
| Blooms at end | Skip ~12MB for non-bloom commands | Index grew 22→24MB from extra strings, offsetting savings |

### Hyperfine results (v6 vs v7, 7 runs, warmup 2)

| Command | v6 (ms) | v7 (ms) | Diff |
|---|---|---|---|
| `file` | 361 | 371 | +2.8% |
| `def` | 591 | 580 | -1.9% |
| `impl` | 387 | 395 | +2.1% |
| `refs` | 666 | 646 | -3.0% |

## Test plan

- [ ] No code changes — only `docs/ROADMAP.md` updated
- [ ] Roadmap documents actual string table size, real bottlenecks, and remaining ideas

🤖 Generated with [Claude Code](https://claude.com/claude-code)