### PR TITLE
fix: correct warm load time in SKILL.md

### DIFF
--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -5,7 +5,7 @@ description: Scala code intelligence CLI for navigating Scala codebases (Scala 2
 
 You have access to `scalex`, a Scala code intelligence CLI that understands Scala syntax (classes, traits, objects, enums, givens, extensions, type aliases, defs, vals). It parses source files via Scalameta — no compiler or build server needed. Works with both Scala 3 and Scala 2 files (tries Scala 3 dialect first, falls back to Scala 2.13).
 
-First run on a project indexes all git-tracked `.scala` files (~3s for 14k files). Subsequent runs use OID-based caching and only re-parse changed files (~300ms).
+First run on a project indexes all git-tracked `.scala` files (~3s for 14k files). Subsequent runs use OID-based caching and only re-parse changed files (~400-500ms).
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Update warm load time from ~300ms to ~400-500ms in SKILL.md to match actual benchmark data (412ms on scala3, 540ms on production monorepo)

## Test plan
- [ ] Verify SKILL.md reads correctly after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)