### PR TITLE
feat: add `scalex api <package>` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `scalex api <package>` command — show a package's public API surface by cross-referencing imports; symbols sorted by external importer count; supports `--kind`, `--no-tests`, `--path`, `--json`; zero index change, pure in-memory query (#102, #103)
 - `--brief` flag for `members` command — show names only instead of signatures (signatures are now the default) (#102)
 - `--strict` flag for `refs` and `imports` commands — treats `_` and `$` as word characters for stricter boundary matching (#101)
 - `deps --depth N` — transitive dependency expansion with cycle detection and depth indentation; hard-capped at 5 (#103)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Note: `marketplace.json` is at the repo root (`.claude-plugin/marketplace.json`)
 
 When adding or changing commands/flags in `src/cli.scala`:
 - Update help text in the `main` function
-- Update `plugin/skills/scalex/SKILL.md` (commands, options table, common workflows, description frontmatter). Description must be double-quoted YAML and under 1024 chars (for GitHub Copilot CLI compatibility)
+- Update `plugin/skills/scalex/SKILL.md` (commands, options table, common workflows, description frontmatter). Description must be double-quoted YAML and under 1024 chars (for GitHub Copilot CLI compatibility). **Always run `./scripts/check-skill-frontmatter.sh` after editing SKILL.md** to validate
 - Update `docs/ROADMAP.md`
 - Update `CHANGELOG.md`
 - Update `README.md` (commands block, AI-Friendly Features, "Use it" examples). README does NOT duplicate the options table — it links to SKILL.md

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ scalex search hms                          # Fuzzy camelCase: finds HttpMessageS
 scalex file PaymentService                 # Find files by name (like IntelliJ)
 scalex packages                            # List all packages
 scalex package com.example                 # Explore a specific package
+scalex api com.example                     # What does this package export?
 
 # Understand
 scalex def UserService --verbose           # Definition with signature
@@ -224,6 +225,7 @@ scalex diff <git-ref>           Symbol-level diff vs git ref    (aka: symbol dif
 scalex ast-pattern              Structural AST search           (aka: pattern search)
 scalex tests                    List test cases structurally    (aka: find tests)
 scalex coverage <symbol>        Is this symbol tested?          (aka: test coverage)
+scalex api <package>            Public API surface of a package (aka: exported symbols)
 ```
 
 All commands support `--json`, `--path PREFIX`, `--no-tests`, and `--limit N`. See the full [command reference and options](plugin/skills/scalex/SKILL.md) for detailed usage, examples, and all flags.
@@ -236,6 +238,7 @@ All commands support `--json`, `--path PREFIX`, `--no-tests`, and `--limit N`. S
 - `explain --expand N` recursively expands implementations — shows each subtype's members in one call
 - `def pkg.Name` resolves by package-qualified name — no ambiguity, no follow-up disambiguation
 - `impl Foo` finds `class Bar extends Mixin[Foo]` — type-param parent indexing discovers parametric inheritance
+- `api` shows a package's public API surface — which symbols are imported externally, sorted by importer count
 - `body` extracts source without a Read call — eliminates ~50% of follow-up file reads
 - `refs` returns categorized results (Definition/ExtendedBy/ImportedBy/UsedAsType) — no post-processing
 - `hierarchy` shows the full inheritance tree in one call — parents up, children down

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,6 @@
 
 ## Pending
 
-- [ ] `scalex api <package>` (#102, #103) — show symbols imported by other packages (the public API surface); cross-reference existing import data to find what a package exports; zero index change, pure in-memory query
 - [ ] Publish plugin to Claude Code marketplace
 
 ## Completed
@@ -103,6 +102,9 @@
 #### Exploration & UX (#93–#96)
 - Fuzzy "did you mean?" on not-found, `package` command
 - `overview --no-tests`, `overview --focus-package`
+
+#### API surface (#102, #103)
+- `scalex api <package>` — show which symbols are imported by other packages (public API surface); cross-reference import data with `packageToSymbols`; zero index change, pure in-memory query
 
 #### Community feedback (#101–#103)
 - Package-qualified symbol lookup, type param indexing in extends clauses

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scalex
-description: "Scala code intelligence CLI for navigating Scala 2/3 codebases. Use when working with .scala files to find definitions (class/trait/object/def/val/type/enum/given), who extends a trait, usages/imports of a symbol, class members, scaladoc, codebase overview, files by name, annotated symbols, or file contents. Triggers: \"where is X defined\", \"who implements Y\", \"find usages of Z\", \"what methods does X have\", \"show source of X\", \"inheritance tree\", \"explain this type\", \"what changed since last commit\", \"find types extending X with method Y\", or before renaming/refactoring. Test navigation: \"what tests exist\", \"is X tested\", \"show test for Y\", \"find tests covering Z\". Use proactively exploring unfamiliar Scala code — faster than grep. Supports fuzzy camelCase search (e.g. \"hms\" finds HttpMessageService). Always prefer scalex over grep/glob for Scala symbol lookups. Use `scalex grep` for .scala content search — integrates with --path and --no-tests filters."
+description: "Scala code intelligence CLI for Scala 2/3 codebases. Find definitions, implementations, usages, imports, members, scaladoc, codebase overview, package API surface, files, annotated symbols, file contents. Triggers: \"where is X defined\", \"who implements Y\", \"find usages of Z\", \"what methods does X have\", \"show source of X\", \"inheritance tree\", \"explain this type\", \"what changed since commit\", \"find types extending X with method Y\", \"what does this package export\", or before renaming. Test navigation: \"what tests exist\", \"is X tested\", \"show test for Y\", \"find tests covering Z\". Use proactively exploring unfamiliar Scala code. Supports fuzzy camelCase search (e.g. \"hms\" finds HttpMessageService). Prefer scalex over grep/glob for Scala symbol lookups. Use `scalex grep` for .scala content search — integrates with --path and --no-tests filters."
 ---
 
 You have access to `scalex`, a Scala code intelligence CLI that understands Scala syntax (classes, traits, objects, enums, givens, extensions, type aliases, defs, vals). It parses source files via Scalameta — no compiler or build server needed. Works with both Scala 3 and Scala 2 files (tries Scala 3 dialect first, falls back to Scala 2.13).
@@ -420,6 +420,29 @@ Package com.example (45 symbols):
     ...
 ```
 
+### `scalex api <package> [--kind K] [--no-tests] [--path PREFIX] [--limit N]` — public API surface
+
+Shows which symbols in a package are actually imported by other packages — the public API surface. Cross-references stored import data with the package's symbol list. Symbols sorted by external importer count (descending). Internal-only symbols (never imported externally) listed at the bottom.
+
+Package name is fuzzy matched (same as `package` command): exact → suffix → substring. Zero index change — pure in-memory query.
+
+```bash
+scalex api com.example                  # public API surface of com.example
+scalex api example                      # fuzzy match on package name
+scalex api com.example --kind trait     # only traits in the API surface
+scalex api com.example --no-tests       # exclude test symbols
+scalex api com.example --json           # structured JSON output
+```
+```
+API surface of com.example (8 of 15 symbols imported externally):
+
+  UserServiceLive           class     12 importers  src/.../UserServiceLive.scala:8
+  User                      class      9 importers  src/.../Model.scala:3
+  UserService               trait      8 importers  src/.../UserService.scala:7
+
+  Not imported externally (7): Role, UserId, userOrdering, ...
+```
+
 ### `scalex symbols <file> [--verbose]` / `scalex packages` — file symbols / list packages
 
 `symbols` lists everything defined in a file (`--verbose` for signatures). `packages` lists all packages in the index.
@@ -519,6 +542,8 @@ Most commands are self-explanatory from their name — `scalex def X`, `scalex m
 **"What's the impact of renaming X?"** → `scalex refs X` (categorized by default — groups by Definition/ExtendedBy/ImportedBy/UsedAsType/Usage/Comment)
 
 **"What's in this package?"** → `scalex package com.example` — all symbols grouped by kind; fuzzy match on package name
+
+**"What does this package export?"** → `scalex api com.example` — shows symbols imported by other packages, sorted by importer count
 
 **"Too many results / noisy output"** → combine `--no-tests`, `--path compiler/src/`, `--kind class`, or `search --prefix`/`--exact`
 

--- a/scripts/check-skill-frontmatter.sh
+++ b/scripts/check-skill-frontmatter.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Validates SKILL.md frontmatter against known compatibility constraints.
+# Checks from PR #92: https://github.com/nguyenyou/scalex/pull/92
+#
+# 1. description must be double-quoted YAML (unquoted colons break parsers)
+# 2. description must be ≤ 1024 characters (GitHub Copilot CLI hard limit)
+#
+# Usage: ./scripts/check-skill-frontmatter.sh [path/to/SKILL.md]
+
+set -euo pipefail
+
+SKILL_FILE="${1:-plugin/skills/scalex/SKILL.md}"
+MAX_DESC_LEN=1024
+
+if [[ ! -f "$SKILL_FILE" ]]; then
+  echo "FAIL: File not found: $SKILL_FILE"
+  exit 1
+fi
+
+errors=0
+
+# ── Check 1: Frontmatter exists ──────────────────────────────────────────────
+
+if ! head -1 "$SKILL_FILE" | grep -q '^---$'; then
+  echo "FAIL: No YAML frontmatter found (file must start with ---)"
+  exit 1
+fi
+
+# Extract the frontmatter block (between first and second ---)
+frontmatter=$(sed -n '2,/^---$/p' "$SKILL_FILE" | sed '$d')
+
+# ── Check 2: description is double-quoted ─────────────────────────────────────
+
+desc_line=$(echo "$frontmatter" | grep '^description:' || true)
+
+if [[ -z "$desc_line" ]]; then
+  echo "FAIL: No 'description' field found in frontmatter"
+  errors=$((errors + 1))
+else
+  # Extract the value after "description: "
+  desc_value="${desc_line#description: }"
+
+  # Check it starts and ends with double quotes
+  if [[ "$desc_value" == \"*\" ]]; then
+    echo "PASS: description is double-quoted (valid YAML for all parsers)"
+  else
+    echo "FAIL: description is NOT double-quoted — colons in unquoted values"
+    echo "      cause YAML parse errors in GitHub Copilot CLI and other tools."
+    echo "      Fix: wrap the description value in double quotes."
+    errors=$((errors + 1))
+  fi
+
+  # ── Check 3: description length ≤ 1024 chars ───────────────────────────────
+
+  # Strip surrounding quotes to get the actual content length
+  stripped="${desc_value#\"}"
+  stripped="${stripped%\"}"
+  char_count=${#stripped}
+
+  if [[ $char_count -le $MAX_DESC_LEN ]]; then
+    echo "PASS: description length is $char_count chars (limit: $MAX_DESC_LEN)"
+  else
+    echo "FAIL: description is $char_count chars — exceeds $MAX_DESC_LEN char limit"
+    echo "      GitHub Copilot CLI enforces a hard 1024-character limit."
+    echo "      Trim $((char_count - MAX_DESC_LEN)) characters to fix."
+    errors=$((errors + 1))
+  fi
+fi
+
+# ── Check 4: name field exists ────────────────────────────────────────────────
+
+name_line=$(echo "$frontmatter" | grep '^name:' || true)
+
+if [[ -z "$name_line" ]]; then
+  echo "FAIL: No 'name' field found in frontmatter"
+  errors=$((errors + 1))
+else
+  echo "PASS: name field present"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+if [[ $errors -eq 0 ]]; then
+  echo "All checks passed."
+else
+  echo "$errors check(s) failed."
+  exit 1
+fi

--- a/site/index.html
+++ b/site/index.html
@@ -486,7 +486,7 @@
 
   <!-- Commands -->
   <section class="reveal">
-    <h2>26 commands. <span class="red">Zero config.</span></h2>
+    <h2>27 commands. <span class="red">Zero config.</span></h2>
     <p class="section-sub">Point it at any git repo with Scala files. Works on Scala 2 and 3, auto-detects dialect per file. Java-aware — tracks .java files for cross-language references.</p>
 
     <div class="cmd-grid">
@@ -593,6 +593,10 @@
       <div class="cmd-card">
         <div class="cmd-name">scalex coverage</div>
         <div class="cmd-desc">Is this symbol tested? Refs filtered to test files only, with count and file list.</div>
+      </div>
+      <div class="cmd-card">
+        <div class="cmd-name">scalex api</div>
+        <div class="cmd-desc">Public API surface of a package — which symbols are imported externally, sorted by importer count.</div>
       </div>
     </div>
   </section>

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -129,6 +129,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         |  scalex ast-pattern              Structural AST search           (aka: pattern search)
         |  scalex tests                    List test cases structurally    (aka: find tests)
         |  scalex coverage <symbol>        Is this symbol tested?          (aka: test coverage)
+        |  scalex api <package>            Public API surface of a package (aka: exported symbols)
         |
         |Options:
         |  -w, --workspace PATH  Set workspace path (default: current directory)

--- a/src/commands/api.scala
+++ b/src/commands/api.scala
@@ -1,0 +1,38 @@
+def cmdApi(args: List[String], ctx: CommandContext): CmdResult =
+  args.headOption match
+    case None => CmdResult.UsageError("Usage: scalex api <package>")
+    case Some(pkg) =>
+      val lower = pkg.toLowerCase
+      // Package resolution: exact → suffix → substring (same as cmdPackage)
+      def bestMatch(candidates: Iterable[String]): Option[String] =
+        if candidates.isEmpty then None
+        else Some(candidates.maxBy(p => ctx.idx.packageToSymbols.getOrElse(p, Nil).size))
+      val matched = ctx.idx.packages.find(_.equalsIgnoreCase(pkg))
+        .orElse(bestMatch(ctx.idx.packages.filter(_.toLowerCase.endsWith("." + lower))))
+        .orElse(bestMatch(ctx.idx.packages.filter(_.toLowerCase.contains(lower))))
+      matched match
+        case None =>
+          val segments = lower.split("[.]").filter(_.nonEmpty)
+          val pkgSuggestions = if segments.nonEmpty then
+            ctx.idx.packages.filter { p =>
+              val pl = p.toLowerCase
+              segments.exists(seg => pl.contains(seg))
+            }.toList.sortBy(p => -ctx.idx.packageToSymbols.getOrElse(p, Nil).size).take(5)
+          else Nil
+          CmdResult.NotFound(
+            s"""Package "$pkg" not found""",
+            NotFoundHint(pkg, ctx.idx.fileCount, ctx.idx.parseFailures, "api", ctx.batchMode, false, pkgSuggestions))
+        case Some(resolvedPkg) =>
+          val surface = ctx.idx.findApiSurface(resolvedPkg)
+          // Apply kind/test/path filters to the symbols
+          val filteredSymbols = filterSymbols(surface.map(_.symbol), ctx).toSet
+          val filtered = surface.filter(e => filteredSymbols.contains(e.symbol))
+          val (exported, internal) = filtered.partition(_.importerCount > 0)
+          val sorted = exported.sortBy(e => -e.importerCount)
+          val allPkgSymbols = ctx.idx.packageToSymbols.getOrElse(resolvedPkg, Set.empty)
+          CmdResult.ApiSurface(
+            pkg = resolvedPkg,
+            symbols = sorted,
+            totalInPackage = allPkgSymbols.size,
+            internalOnly = internal.map(_.symbol.name).sorted
+          )

--- a/src/dispatch.scala
+++ b/src/dispatch.scala
@@ -8,6 +8,7 @@ val commands: Map[String, (List[String], CommandContext) => CmdResult] = Map(
   "body" -> cmdBody, "tests" -> cmdTests, "coverage" -> cmdCoverage,
   "hierarchy" -> cmdHierarchy, "overrides" -> cmdOverrides, "explain" -> cmdExplain,
   "deps" -> cmdDeps, "context" -> cmdContext, "diff" -> cmdDiff, "ast-pattern" -> cmdAstPattern,
+  "api" -> cmdApi,
 )
 
 def runCommand(cmd: String, args: List[String], ctx: CommandContext): Unit =

--- a/src/format.scala
+++ b/src/format.scala
@@ -105,6 +105,7 @@ def render(result: CmdResult, ctx: CommandContext): Unit = {
     case r: GrepCount        => renderGrepCount(r, ctx)
     case r: Packages         => renderPackages(r, ctx)
     case r: PackageSymbols   => renderPackageSymbols(r, ctx)
+    case r: ApiSurface       => renderApiSurface(r, ctx)
     case r: NotFound         => renderNotFound(r, ctx)
     case r: UsageError       => println(r.message)
   }
@@ -817,6 +818,35 @@ private def renderPackageSymbols(r: CmdResult.PackageSymbols, ctx: CommandContex
   }
 }
 
+private def renderApiSurface(r: CmdResult.ApiSurface, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val items = r.symbols.take(ctx.limit).map { (sym, count) =>
+      val rel = jsonEscape(ctx.workspace.relativize(sym.file).toString)
+      s"""{"name":"${jsonEscape(sym.name)}","kind":"${sym.kind.toString.toLowerCase}","file":"$rel","line":${sym.line},"package":"${jsonEscape(sym.packageName)}","importerCount":$count}"""
+    }.mkString("[", ",", "]")
+    val internalJson = r.internalOnly.map(n => s""""${jsonEscape(n)}"""").mkString("[", ",", "]")
+    println(s"""{"package":"${jsonEscape(r.pkg)}","exportedCount":${r.symbols.size},"totalInPackage":${r.totalInPackage},"symbols":$items,"internalOnly":$internalJson}""")
+  } else {
+    if r.symbols.isEmpty && r.internalOnly.isEmpty then {
+      println(s"""API surface of ${r.pkg}: no symbols found""")
+    } else {
+      val exportedCount = r.symbols.size
+      println(s"API surface of ${r.pkg} ($exportedCount of ${r.totalInPackage} symbols imported externally):\n")
+      r.symbols.take(ctx.limit).foreach { (sym, count) =>
+        val rel = ctx.workspace.relativize(sym.file)
+        val importerLabel = if count == 1 then "importer" else "importers"
+        println(s"  ${sym.name.padTo(25, ' ')} ${sym.kind.toString.toLowerCase.padTo(9, ' ')} $count $importerLabel  $rel:${sym.line}")
+      }
+      if r.symbols.size > ctx.limit then println(s"  ... and ${r.symbols.size - ctx.limit} more")
+      if r.internalOnly.nonEmpty then {
+        val shown = r.internalOnly.take(10)
+        val suffix = if r.internalOnly.size > 10 then s", ... and ${r.internalOnly.size - 10} more" else ""
+        println(s"\n  Not imported externally (${r.internalOnly.size}): ${shown.mkString(", ")}$suffix")
+      }
+    }
+  }
+}
+
 private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
   val suggestionsJson = r.hint.suggestions.map(s => s""""${jsonEscape(s)}"""").mkString("[", ",", "]")
   if ctx.jsonOutput then {
@@ -828,7 +858,7 @@ private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
       case "explain" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
       case "imports" => println(s"""{"results":[],"timedOut":${ctx.idx.timedOut},"suggestions":$suggestionsJson}""")
       case "deps" => println(s"""{"imports":[],"bodyReferences":[],"suggestions":$suggestionsJson}""")
-      case "package" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
+      case "package" | "api" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
       case _ => println(s"""{"results":[],"suggestions":$suggestionsJson}""")
     }
   } else {

--- a/src/index.scala
+++ b/src/index.scala
@@ -630,6 +630,84 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   private def isIdentChar(c: Char): Boolean =
     c.isLetterOrDigit || c == '_' || c == '$'
 
+  def findApiSurface(targetPkg: String): List[(symbol: SymbolInfo, importerCount: Int)] =
+    Timings.phase("api-surface") {
+      val targetSymNames = packageToSymbols.getOrElse(targetPkg, Set.empty)
+      if targetSymNames.isEmpty then Nil
+      else {
+
+      // Count external importers per symbol name
+      val importerCounts = mutable.HashMap.empty[String, mutable.HashSet[String]]
+      targetSymNames.foreach(n => importerCounts(n) = mutable.HashSet.empty)
+
+      indexedFiles.foreach { idxFile =>
+        val filePkg = filePackage(idxFile)
+        if filePkg != targetPkg then
+          idxFile.imports.foreach { imp =>
+            parseImportTarget(imp).foreach { (pkg, names, isWildcard) =>
+              if pkg == targetPkg then {
+                if isWildcard then
+                  // Credit all symbols in the package
+                  targetSymNames.foreach { symName =>
+                    importerCounts(symName).add(idxFile.relativePath)
+                  }
+                else
+                  names.foreach { name =>
+                    if importerCounts.contains(name) then
+                      importerCounts(name).add(idxFile.relativePath)
+                  }
+              }
+            }
+          }
+      }
+
+      // Build result with SymbolInfo objects
+      val symsByName = allSymbols.filter(_.packageName == targetPkg).groupBy(_.name)
+      targetSymNames.toList.flatMap { name =>
+        symsByName.getOrElse(name, Nil).headOption.map { sym =>
+          (symbol = sym, importerCount = importerCounts.getOrElse(name, mutable.HashSet.empty).size)
+        }
+      }
+      }
+    }
+
+  private def parseImportTarget(imp: String): Option[(pkg: String, names: List[String], isWildcard: Boolean)] =
+    val trimmed = imp.trim.stripPrefix("import ")
+    if trimmed.isEmpty then None
+    else {
+
+    // Handle brace-enclosed imports: import pkg.{A, B, C as D, _}
+    val braceStart = trimmed.indexOf('{')
+    if braceStart >= 0 then
+      val pkg = trimmed.substring(0, braceStart).stripSuffix(".")
+      val braceEnd = trimmed.indexOf('}', braceStart)
+      val inner = if braceEnd >= 0 then trimmed.substring(braceStart + 1, braceEnd) else trimmed.substring(braceStart + 1)
+      val parts = inner.split(',').map(_.trim).filter(_.nonEmpty)
+      var isWildcard = false
+      val names = mutable.ListBuffer.empty[String]
+      parts.foreach { part =>
+        if part == "_" || part == "*" then isWildcard = true
+        else
+          // Handle "Foo as Bar" or "Foo => Bar" — we want the original name (Foo)
+          val asIdx = part.indexOf(" as ")
+          val arrowIdx = part.indexOf(" => ")
+          val name = if asIdx >= 0 then part.substring(0, asIdx).trim
+                     else if arrowIdx >= 0 then part.substring(0, arrowIdx).trim
+                     else part.trim
+          if name.nonEmpty && name != "_" && name != "*" then names += name
+      }
+      Some((pkg, names.toList, isWildcard))
+    else
+      // Simple import: import pkg.Name or import pkg._ or import pkg.*
+      val lastDot = trimmed.lastIndexOf('.')
+      if lastDot < 0 then None
+      else
+        val pkg = trimmed.substring(0, lastDot)
+        val name = trimmed.substring(lastDot + 1)
+        if name == "_" || name == "*" then Some((pkg, Nil, true))
+        else Some((pkg, List(name), false))
+    }
+
   private def containsWordStrict(line: String, word: String): Boolean =
     var i = line.indexOf(word)
     while i >= 0 do

--- a/src/model.scala
+++ b/src/model.scala
@@ -193,5 +193,6 @@ enum CmdResult:
   case GrepCount(matches: Int, files: Int, timedOut: Boolean, hint: Option[String] = None, stderrHint: Option[String] = None)
   case Packages(packages: List[String])
   case PackageSymbols(pkg: String, symbols: List[SymbolInfo])
+  case ApiSurface(pkg: String, symbols: List[(symbol: SymbolInfo, importerCount: Int)], totalInPackage: Int, internalOnly: List[String])
   case NotFound(message: String, hint: NotFoundHint)
   case UsageError(message: String)


### PR DESCRIPTION
## Summary
- Add `scalex api <package>` command that shows a package's public API surface by cross-referencing stored import data with `packageToSymbols`
- Symbols sorted by external importer count (descending), internal-only symbols listed at bottom
- Zero index change — pure in-memory query (~14ms on Airstream, 396 symbols)
- Add `scripts/check-skill-frontmatter.sh` to validate SKILL.md frontmatter (double-quoted YAML, ≤1024 chars per PR #92)

## Test plan
- [x] All 210 existing tests pass (`scala-cli test src/ tests/`)
- [x] Manual test: `scalex api com.raquo -w Airstream` — correct output with importer counts
- [x] Manual test: `scalex api com.raquo --json` — valid JSON output
- [x] Manual test: `scalex api nonexistent` — shows not-found with suggestions
- [x] Manual test: `scalex api com.raquo --timings` — api-surface phase ~14ms
- [x] `scripts/check-skill-frontmatter.sh` passes (description: 881 chars, double-quoted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)