### PR TITLE
feat: reduce round-trips — 9 UX features for one-call answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- `overview` defaults to `--no-tests` — production code is almost always the intent; use `--include-tests` to opt in (#119, #120)
+- `explain --verbose` shows member signatures instead of just names (#119, #120)
+- `explain` inlines "Imported by" file list when count <= 10; shows count + hint otherwise (#119, #120)
+- `refs --count` summary mode — category counts without full file lists (e.g. "12 importers, 4 extensions, 30 usages") (#119, #120)
+- Companion-aware `members` — auto-shows companion object/class members alongside the primary type (#119, #120)
+- `Owner.member` dotted syntax for `def` and `explain` — `def MyService.findUser` resolves to the member directly (#119, #120)
+- `api --used-by <package>` — filter importers to only those from a specific package; coupling analysis (#120)
+- `search` ranking includes import popularity — symbols from heavily-imported types surface first (#119, #120)
+- `search --returns <Type>` / `--takes <Type>` — filter search results by signature substring (#119, #120)
+
 ## [1.16.0] — 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,26 +146,30 @@ cd /path/to/your/scala/project
 # Discover
 scalex search Service --kind trait         # Find traits by name
 scalex search hms                          # Fuzzy camelCase: finds HttpMessageService
+scalex search find --returns Boolean       # Filter by return type
 scalex file PaymentService                 # Find files by name (like IntelliJ)
 scalex packages                            # List all packages
 scalex package com.example                 # Explore a specific package
 scalex api com.example                     # What does this package export?
+scalex api com.example --used-by com.web   # Coupling: what does web use from example?
 
 # Understand
 scalex def UserService --verbose           # Definition with signature
-scalex explain UserService                 # One-shot: def + doc + members + impls
+scalex def UserService.findUser            # Owner.member dotted syntax
+scalex explain UserService --verbose       # One-shot: def + doc + signatures + impls
 scalex members UserService --inherited     # Full API surface including parents
 scalex hierarchy UserService               # Inheritance tree (parents + children)
 
 # Navigate
 scalex refs UserService                    # Categorized references
+scalex refs UserService --count            # Summary: "12 importers, 4 extensions, ..."
 scalex impl UserService                    # Who extends this?
 scalex imports UserService                 # Who imports this?
 scalex grep "def.*process" --no-tests      # Regex content search
 scalex body findUser --in UserServiceLive  # Extract method body without Read
 
 # Refine
-scalex members Signal                      # Signatures by default
+scalex members Signal                      # Signatures by default + companion hint
 scalex members Signal --brief              # Names only
 scalex refs Cache --strict                 # No underscore/dollar false positives
 scalex deps Phase --depth 2                # Transitive dependencies
@@ -234,13 +238,18 @@ All commands support `--json`, `--path PREFIX`, `--no-tests`, and `--limit N`. S
 
 **Fewer round-trips.** The biggest cost for an AI agent isn't latency — it's the number of tool calls. Each call costs tokens, reasoning, and context window space.
 
-- `explain` replaces 4-5 calls (def + doc + members + impl + imports) with one; auto-shows companion object/class members
+- `explain` replaces 4-5 calls (def + doc + members + impl + imports) with one; auto-shows companion object/class members; `--verbose` shows full signatures
 - `explain --expand N` recursively expands implementations — shows each subtype's members in one call
 - `def pkg.Name` resolves by package-qualified name — no ambiguity, no follow-up disambiguation
+- `def Owner.member` navigates directly to a member — `def MyService.findUser` resolves without `body --in`
 - `impl Foo` finds `class Bar extends Mixin[Foo]` — type-param parent indexing discovers parametric inheritance
-- `api` shows a package's public API surface — which symbols are imported externally, sorted by importer count
+- `api` shows a package's public API surface — `--used-by` filters to a specific consumer package
+- `members` auto-shows companion object/class members alongside the primary type
+- `refs --count` gives category counts in one line — fast impact triage without reading full file lists
 - `body` extracts source without a Read call — eliminates ~50% of follow-up file reads
 - `refs` returns categorized results (Definition/ExtendedBy/ImportedBy/UsedAsType) — no post-processing
+- `search` ranks by import popularity; `--returns` / `--takes` filter by signature
+- `overview` defaults to `--no-tests` — production code is almost always the intent
 - `hierarchy` shows the full inheritance tree in one call — parents up, children down
 - `batch` loads the index once for multiple queries — 5 queries in ~1s instead of ~5s
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,18 @@
 
 ## Completed
 
+### Reduce round-trips (#119, #120)
+
+- `overview` defaults to `--no-tests`; `--include-tests` to opt in
+- `Owner.member` dotted syntax for `explain` and `def` — `def MyService.findUser` resolves directly
+- `explain --verbose` — show member signatures inline instead of just names
+- `explain` inlines "Imported by" file list when count ≤ 10, shows count + hint otherwise
+- `refs --count` summary mode — "12 importers, 4 extensions, 30 usages" without full file lists
+- Companion-aware `members` — auto-shows companion object/class members
+- `api --used-by <package>` — coupling analysis: which types from pkg A are used by pkg B
+- `search` ranks by import count — heavily-imported types surface first
+- `search --returns <Type>` / `--takes <Type>` — signature substring filter
+
 ### Phase 1–5: Foundation
 
 - Git file listing, Scalameta parsing, in-memory index, find definition, find references, CLI

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -39,12 +39,13 @@ All commands default to current directory. You can set the workspace with `-w` /
 
 ### `scalex def <symbol> [--verbose] [--kind K] [--no-tests] [--path PREFIX]` — find definition
 
-Returns where a symbol is defined, including given instances that grep would miss. Use `--verbose` to see the full signature inline — saves a follow-up Read call. Results are ranked: class/trait/object/enum first, non-test before test, shorter paths first. Supports **package-qualified names** — `def com.example.Cache` or partial `def cache.Cache` disambiguates by package.
+Returns where a symbol is defined, including given instances that grep would miss. Use `--verbose` to see the full signature inline — saves a follow-up Read call. Results are ranked: class/trait/object/enum first, non-test before test, shorter paths first. Supports **package-qualified names** — `def com.example.Cache` or partial `def cache.Cache` disambiguates by package. Also supports **Owner.member dotted syntax** — `def MyService.findUser` resolves to the `findUser` member inside `MyService`.
 
 ```bash
 scalex def PaymentService --verbose
 scalex def com.example.payment.PaymentService  # fully-qualified lookup
 scalex def payment.PaymentService              # partial qualification
+scalex def PaymentService.processPayment       # Owner.member dotted syntax
 scalex def Driver --kind class              # only class definitions
 scalex def Driver --no-tests --path compiler/src/  # exclude tests, restrict to subtree
 ```
@@ -68,14 +69,15 @@ scalex impl PaymentService --no-tests --path core/src/
              class PaymentServiceLive extends PaymentService
 ```
 
-### `scalex refs <symbol> [--flat] [--strict] [--category CAT] [--no-tests] [--path PREFIX] [-C N] [--limit N]` — find references
+### `scalex refs <symbol> [--flat] [--count] [--strict] [--category CAT] [--no-tests] [--path PREFIX] [-C N] [--limit N]` — find references
 
 Finds all usages of a symbol using word-boundary text matching. Uses bloom filters to skip files that definitely don't contain the symbol, then reads candidate files. Has a 20-second timeout — on very large codebases with a common symbol, output may say "(timed out — partial results)".
 
-Output is **categorized by default** — groups results into Definition, ExtendedBy, ImportedBy, UsedAsType, Usage, and Comment so you can understand impact at a glance. Use `--category CAT` to filter to a single category (e.g. `--category ExtendedBy`). Use `-C N` to show N lines of context around each reference (like `grep -C`) — reduces follow-up Read calls. Use `--flat` to get a flat list instead.
+Output is **categorized by default** — groups results into Definition, ExtendedBy, ImportedBy, UsedAsType, Usage, and Comment so you can understand impact at a glance. Use `--category CAT` to filter to a single category (e.g. `--category ExtendedBy`). Use `-C N` to show N lines of context around each reference (like `grep -C`) — reduces follow-up Read calls. Use `--flat` to get a flat list instead. Use `--count` to get category counts without full file lists — fast impact triage.
 
 ```bash
 scalex refs PaymentService                        # categorized by default
+scalex refs PaymentService --count               # summary: "12 importers, 4 extensions, 30 usages"
 scalex refs PaymentService --category ExtendedBy  # only show ExtendedBy
 scalex refs PaymentService --no-tests --path core/src/
 scalex refs PaymentService -C 3                   # show 3 lines of context
@@ -106,6 +108,8 @@ scalex imports PaymentService --no-tests
 ### `scalex members <symbol> [--verbose] [--brief] [--inherited] [--kind K] [--no-tests] [--path PREFIX] [--limit N]` — list members
 
 Lists member declarations (def, val, var, type) inside a class, trait, object, or enum body. Parses source on-the-fly — NOT stored in the index, so no index bloat. Single file parse is <50ms. Shows full signatures by default; use `--brief` for names only.
+
+**Companion-aware**: automatically shows companion object/class members alongside the primary symbol — no follow-up query needed.
 
 Use `--inherited` to walk the extends chain and include members from parent types — gives the full API surface in one call. Child overrides win when the same member exists in both parent and child.
 
@@ -138,20 +142,22 @@ trait PaymentService (com.example) — src/.../PaymentService.scala:7:
  */
 ```
 
-### `scalex overview [--architecture] [--focus-package PKG] [--no-tests] [--limit N]` — codebase summary
+### `scalex overview [--architecture] [--focus-package PKG] [--include-tests] [--limit N]` — codebase summary
 
 One-shot architectural summary. Shows symbols by kind, top packages by symbol count, and most-extended traits/classes. All computed from existing in-memory index data — no extra I/O. Use `--limit N` to control "top N" lists (default: 20).
 
+**Defaults to `--no-tests`** — production code is almost always the intent. Use `--include-tests` to opt in to test files.
+
 Use `--architecture` to also show package dependency graph (from imports) and hub types (most-extended + most-referenced) — gives a structural understanding of the codebase in one call.
 
-Use `--focus-package PKG` to scope the dependency graph to a single package — shows direct dependencies and direct dependents only. Auto-enables `--architecture` when used. Use `--no-tests` to exclude test files from all counts and lists.
+Use `--focus-package PKG` to scope the dependency graph to a single package — shows direct dependencies and direct dependents only. Auto-enables `--architecture` when used.
 
 ```bash
 scalex overview
 scalex overview --limit 5
 scalex overview --architecture               # + package deps + hub types
 scalex overview --focus-package com.example   # scoped dependency view
-scalex overview --no-tests                   # exclude test fixtures
+scalex overview --include-tests              # include test files
 ```
 ```
 Project overview (14,000 files, 215,000 symbols):
@@ -171,11 +177,13 @@ Most extended (by implementation count):
   ...
 ```
 
-### `scalex search <query> [--kind K] [--verbose] [--limit N] [--exact] [--prefix] [--definitions-only]` — search symbols
+### `scalex search <query> [--kind K] [--verbose] [--limit N] [--exact] [--prefix] [--definitions-only] [--returns TYPE] [--takes TYPE]` — search symbols
 
-Fuzzy search by name, ranked: exact > prefix > substring > camelCase fuzzy. Supports camelCase abbreviation matching — e.g. `search "hms"` matches `HttpMessageService`, `search "usl"` matches `UserServiceLive`. Use `--kind` to filter by symbol type.
+Fuzzy search by name, ranked: exact > prefix > substring > camelCase fuzzy. Supports camelCase abbreviation matching — e.g. `search "hms"` matches `HttpMessageService`, `search "usl"` matches `UserServiceLive`. Use `--kind` to filter by symbol type. Results are ranked by import popularity — symbols from heavily-imported types surface first.
 
 Use `--exact` to only return symbols with exact name match (case-insensitive). Use `--prefix` to only return symbols whose name starts with the query. Both eliminate noise from substring/fuzzy matches on large codebases. Use `--definitions-only` to filter to class/trait/object/enum definitions only — excludes defs and vals whose name happens to match.
+
+Use `--returns TYPE` to filter to symbols whose return type contains TYPE. Use `--takes TYPE` to filter to symbols whose parameters contain TYPE. Both are substring matches on the signature.
 
 ```bash
 scalex search Service --kind trait --limit 10
@@ -183,6 +191,8 @@ scalex search hms       # finds HttpMessageService via camelCase matching
 scalex search Auth --prefix    # only exact + prefix matches, no substring/fuzzy
 scalex search Auth --exact     # only exact name matches
 scalex search Signal --definitions-only  # only class/trait/object/enum, no defs/vals
+scalex search find --returns Boolean     # methods named "find" returning Boolean
+scalex search process --takes String     # methods named "process" taking String
 ```
 
 ### `scalex file <query> [--limit N]` — find file
@@ -288,15 +298,17 @@ Overrides of findUser (in implementations of UserService) — 2 found:
     def findUser(id: String): Option[User]
 ```
 
-### `scalex explain <symbol> [--impl-limit N] [--expand N] [--no-tests] [--path PREFIX]` — composite summary
+### `scalex explain <symbol> [--verbose] [--impl-limit N] [--expand N] [--no-tests] [--path PREFIX]` — composite summary
 
-One-shot summary that eliminates 4-5 round-trips per type. Orchestrates: definition + scaladoc + members (top 10) + companion object/class + implementations (top N) + import count. Supports **package-qualified names** (e.g. `explain com.example.Cache`).
+One-shot summary that eliminates 4-5 round-trips per type. Orchestrates: definition + scaladoc + members (top 10) + companion object/class + implementations (top N) + import files. Supports **package-qualified names** (e.g. `explain com.example.Cache`) and **Owner.member dotted syntax** (e.g. `explain MyService.findUser`).
 
-`--impl-limit N` controls how many implementations to show (default: 5). `--expand N` recursively expands each implementation N levels deep, showing their members and sub-implementations — eliminates N follow-up explains. Auto-shows **companion** object/class with its members when applicable.
+`--verbose` shows member signatures instead of just names. `--impl-limit N` controls how many implementations to show (default: 5). `--expand N` recursively expands each implementation N levels deep, showing their members and sub-implementations — eliminates N follow-up explains. Auto-shows **companion** object/class with its members when applicable. When import count <= 10, the actual importing files are shown inline; otherwise shows count + hint.
 
 ```bash
 scalex explain UserService                  # full summary with companion
+scalex explain UserService --verbose        # member signatures inline
 scalex explain com.example.UserService      # package-qualified lookup
+scalex explain UserService.findUser         # Owner.member dotted syntax
 scalex explain UserService --impl-limit 10  # show more implementations
 scalex explain UserService --expand 1       # expand impls with their members
 ```
@@ -319,7 +331,10 @@ Explanation of trait UserService (com.example):
     class     UserServiceLive (com.example) — .../UserService.scala:8
     class     OldService (com.example) — .../Annotated.scala:4
 
-  Imported by: 3 files
+  Imported by (3 files):
+    src/.../ServiceModule.scala:2
+    src/.../AppModule.scala:5
+    src/.../TestHelper.scala:1
 ```
 
 ### `scalex deps <symbol> [--depth N]` — dependency graph
@@ -420,18 +435,21 @@ Package com.example (45 symbols):
     ...
 ```
 
-### `scalex api <package> [--kind K] [--no-tests] [--path PREFIX] [--limit N]` — public API surface
+### `scalex api <package> [--used-by PKG] [--kind K] [--no-tests] [--path PREFIX] [--limit N]` — public API surface
 
 Shows which symbols in a package are actually imported by other packages — the public API surface. Cross-references stored import data with the package's symbol list. Symbols sorted by external importer count (descending). Internal-only symbols (never imported externally) listed at the bottom.
+
+Use `--used-by PKG` to filter importers to only those from a specific package — answers "which types from package A are used by package B" (coupling analysis).
 
 Package name is fuzzy matched (same as `package` command): exact → suffix → substring. Zero index change — pure in-memory query.
 
 ```bash
-scalex api com.example                  # public API surface of com.example
-scalex api example                      # fuzzy match on package name
-scalex api com.example --kind trait     # only traits in the API surface
-scalex api com.example --no-tests       # exclude test symbols
-scalex api com.example --json           # structured JSON output
+scalex api com.example                              # public API surface of com.example
+scalex api example                                  # fuzzy match on package name
+scalex api com.example --used-by com.example.web    # coupling: what does web use from example?
+scalex api com.example --kind trait                 # only traits in the API surface
+scalex api com.example --no-tests                   # exclude test symbols
+scalex api com.example --json                       # structured JSON output
 ```
 ```
 API surface of com.example (8 of 15 symbols imported externally):
@@ -510,10 +528,11 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 | `--limit N` | Max results (default: 20) |
 | `--kind K` | Filter by kind: class, trait, object, def, val, type, enum, given, extension |
 | `--no-tests` | Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.) |
+| `--include-tests` | Override --no-tests default for overview command |
 | `--path PREFIX` | Restrict results to files under PREFIX (e.g. `compiler/src/`) |
 | `-C N` | Show N context lines around each reference (refs, grep) |
 | `-e PATTERN` | Grep: additional pattern (repeatable); combined with `\|` |
-| `--count` | Grep: output match/file count only, no full results |
+| `--count` | Grep/refs: show counts only, no full results |
 | `--exact` | Search: only exact name matches (case-insensitive) |
 | `--prefix` | Search: only exact + prefix matches |
 | `--in OWNER` | Body: restrict to members of the given enclosing type |
@@ -531,6 +550,9 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 | `--has-method NAME` | AST pattern: match types that have a method with NAME |
 | `--extends TRAIT` | AST pattern: match types that extend TRAIT |
 | `--body-contains PAT` | AST pattern: match types whose body contains PAT |
+| `--used-by PKG` | API: filter importers to only those from PKG |
+| `--returns TYPE` | Search: filter to symbols whose signature returns TYPE |
+| `--takes TYPE` | Search: filter to symbols whose signature takes TYPE |
 | `--json` | Output results as JSON — structured output for programmatic parsing |
 | `--timings` | Print per-phase timing breakdown to stderr |
 | `--version` | Print version and exit |
@@ -562,6 +584,14 @@ Most commands are self-explanatory from their name — `scalex def X`, `scalex m
 **"Find tests for X / show me tests about X"** → `scalex tests extractBody` — filter by name + show bodies inline in one command
 
 **"Is this function tested?"** → `scalex coverage extractBody` — refs in test files only, with count + locations
+
+**"How many places reference X?"** → `scalex refs X --count` — category counts without full file lists
+
+**"Navigate to a specific method"** → `scalex def MyService.findUser` — Owner.member dotted syntax, faster than `body --in`
+
+**"What from package A does package B use?"** → `scalex api com.example --used-by com.example.web` — coupling analysis
+
+**"Find methods that return/take a type"** → `scalex search process --returns Boolean` or `scalex search convert --takes String`
 
 **"I need structured output"** → append `--json` to any command
 

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -28,6 +28,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     case i => argList.lift(i + 1)
   val verbose = argList.contains("--verbose")
   val categorize = !argList.contains("--flat")
+  val includeTests = argList.contains("--include-tests")
   val noTests = argList.contains("--no-tests")
   val pathFilter: Option[String] = argList.indexOf("--path") match
     case -1 => None
@@ -88,11 +89,21 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(1)
   val brief = argList.contains("--brief")
   val strict = argList.contains("--strict")
+  val usedByFilter: Option[String] = argList.indexOf("--used-by") match
+    case -1 => None
+    case i => argList.lift(i + 1)
+  val returnsFilter: Option[String] = argList.indexOf("--returns") match
+    case -1 => None
+    case i => argList.lift(i + 1)
+  val takesFilter: Option[String] = argList.indexOf("--takes") match
+    case -1 => None
+    case i => argList.lift(i + 1)
   val timingsEnabled = argList.contains("--timings")
   Timings.enabled = timingsEnabled
 
   val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "-C", "-e", "--category",
-                           "--in", "--of", "--impl-limit", "--depth", "--has-method", "--extends", "--body-contains", "--focus-package", "--expand")
+                           "--in", "--of", "--impl-limit", "--depth", "--has-method", "--extends", "--body-contains", "--focus-package", "--expand",
+                           "--used-by", "--returns", "--takes")
   val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || a == "-e" || a == "-c" || {
     val prev = argList.indexOf(a) - 1
     prev >= 0 && flagsWithArgs.contains(argList(prev))
@@ -141,10 +152,11 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         |  --definitions-only    Search: only return class/trait/object/enum definitions
         |  --category CAT        Refs: filter to a single category (Definition/ExtendedBy/ImportedBy/UsedAsType/Usage/Comment)
         |  --no-tests            Exclude test files (test/, tests/, testing/, bench-*, *Spec.scala, etc.)
+        |  --include-tests       Override --no-tests default for overview command
         |  --path PREFIX         Restrict results to files under PREFIX (e.g. compiler/src/)
         |  -C N                  Show N context lines around each reference (refs, grep)
         |  -e PATTERN            Grep: additional pattern (combine multiple with |); repeatable
-        |  --count               Grep: show match/file count only, no full results
+        |  --count               Grep/refs: show counts only, no full results
         |  --exact               Search: only exact name matches
         |  --prefix              Search: only exact + prefix matches
         |  --json                Output results as JSON (structured output for programmatic use)
@@ -164,6 +176,9 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         |  --has-method NAME     AST pattern: match types that have a method with NAME
         |  --extends TRAIT       AST pattern: match types that extend TRAIT
         |  --body-contains PAT   AST pattern: match types whose body contains PAT
+        |  --used-by PKG         API: filter importers to only those from PKG
+        |  --returns TYPE        Search: filter to symbols whose signature returns TYPE
+        |  --takes TYPE          Search: filter to symbols whose signature takes TYPE
         |  --timings             Print per-phase timing breakdown to stderr
         |
         |All commands accept an optional [workspace] positional arg or -w flag (default: current directory).
@@ -185,7 +200,8 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         architecture = architecture, focusPackage = focusPackage,
         hasMethodFilter = hasMethodFilter, extendsFilter = extendsFilter,
         bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
-        brief = brief, strict = strict)
+        brief = brief, strict = strict,
+        usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter)
       val reader = BufferedReader(InputStreamReader(System.in))
       var line = reader.readLine()
       while line != null do
@@ -214,11 +230,14 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
                 case ws :: arg :: tail => (resolveWorkspace(ws), arg :: tail)
                 case Nil => (resolveWorkspace("."), Nil)
 
+      // overview defaults to --no-tests unless --include-tests is explicitly passed
+      val effectiveNoTests = if cmd == "overview" && !includeTests then true else noTests
+
       val bloomCmds = Set("refs", "imports", "coverage")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))
       idx.index()
       val ctx = CommandContext(idx = idx, workspace = workspace, limit = limit, verbose = verbose,
-        jsonOutput = jsonOutput, kindFilter = kindFilter, noTests = noTests, pathFilter = pathFilter,
+        jsonOutput = jsonOutput, kindFilter = kindFilter, noTests = effectiveNoTests, pathFilter = pathFilter,
         contextLines = contextLines, categorize = categorize, categoryFilter = categoryFilter,
         grepPatterns = grepPatterns, countOnly = countOnly, searchMode = searchMode,
         definitionsOnly = definitionsOnly, inOwner = inOwner, ofTrait = ofTrait, implLimit = implLimit,
@@ -226,6 +245,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         focusPackage = focusPackage,
         hasMethodFilter = hasMethodFilter, extendsFilter = extendsFilter,
         bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
-        brief = brief, strict = strict)
+        brief = brief, strict = strict,
+        usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter)
       runCommand(cmd, cmdRest, ctx)
       Timings.report()

--- a/src/commands/api.scala
+++ b/src/commands/api.scala
@@ -23,7 +23,7 @@ def cmdApi(args: List[String], ctx: CommandContext): CmdResult =
             s"""Package "$pkg" not found""",
             NotFoundHint(pkg, ctx.idx.fileCount, ctx.idx.parseFailures, "api", ctx.batchMode, false, pkgSuggestions))
         case Some(resolvedPkg) =>
-          val surface = ctx.idx.findApiSurface(resolvedPkg)
+          val surface = ctx.idx.findApiSurface(resolvedPkg, ctx.usedByFilter)
           // Apply kind/test/path filters to the symbols
           val filteredSymbols = filterSymbols(surface.map(_.symbol), ctx).toSet
           val filtered = surface.filter(e => filteredSymbols.contains(e.symbol))

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -13,7 +13,19 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
         val pathLen = ctx.workspace.relativize(s.file).toString.length
         (kindRank, testRank, pathLen)
       }
-      if results.isEmpty then
+      // If no results and symbol contains ".", try Owner.member resolution
+      if results.isEmpty && symbol.contains(".") then
+        resolveDottedMember(symbol, ctx) match
+          case Some(memberResults) =>
+            CmdResult.SymbolList(
+              header = s"""Definition of "$symbol":""",
+              symbols = memberResults,
+              total = memberResults.size)
+          case None =>
+            CmdResult.NotFound(
+              s"""Definition of "$symbol": not found""",
+              mkNotFoundWithSuggestions(symbol, ctx, "def"))
+      else if results.isEmpty then
         CmdResult.NotFound(
           s"""Definition of "$symbol": not found""",
           mkNotFoundWithSuggestions(symbol, ctx, "def"))
@@ -22,3 +34,30 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
           header = s"""Definition of "$symbol":""",
           symbols = results,
           total = results.size)
+
+/** Resolve Owner.member syntax: if Owner is a type, extract its members and filter to the member name */
+private def resolveDottedMember(symbol: String, ctx: CommandContext): Option[List[SymbolInfo]] = {
+  val lastDot = symbol.lastIndexOf('.')
+  if lastDot <= 0 then return None
+  val ownerName = symbol.substring(0, lastDot)
+  val memberName = symbol.substring(lastDot + 1)
+  val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+  val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
+  if ownerDefs.isEmpty then return None
+  val memberResults = ownerDefs.flatMap { owner =>
+    val simpleName = if ownerName.contains(".") then ownerName.substring(ownerName.lastIndexOf('.') + 1) else ownerName
+    val members = extractMembers(owner.file, simpleName)
+    members.filter(_.name.equalsIgnoreCase(memberName)).map { m =>
+      SymbolInfo(
+        name = m.name,
+        kind = m.kind,
+        file = owner.file,
+        line = m.line,
+        packageName = owner.packageName,
+        signature = m.signature,
+        annotations = m.annotations
+      )
+    }
+  }
+  if memberResults.nonEmpty then Some(memberResults) else None
+}

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -15,6 +15,14 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         val pathLen = ctx.workspace.relativize(s.file).toString.length
         (kindRank, testRank, pathLen)
       }
+      // If no results and symbol contains ".", try Owner.member resolution
+      if defs.isEmpty && symbol.contains(".") then
+        resolveDottedMember(symbol, ctx) match
+          case Some(memberResults) =>
+            val msym = memberResults.head
+            val doc = extractScaladoc(msym.file, msym.line)
+            return CmdResult.Explanation(msym, doc, Nil, Nil, Nil)
+          case None => ()
       if defs.isEmpty then
         CmdResult.NotFound(
           s"""No definition of "$symbol" found""",
@@ -47,9 +55,9 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         val expandedImpls =
           if ctx.expandDepth > 0 then expandImpls(impls, ctx, 1, Set(s"${sym.packageName}.${sym.name}".toLowerCase))
           else Nil
-        // Import count
-        val importCount = ctx.idx.findImports(simpleName, timeoutMs = 3000).size
-        CmdResult.Explanation(sym, doc, members, impls, importCount, companion, expandedImpls)
+        // Import refs
+        val importRefs = ctx.idx.findImports(simpleName, timeoutMs = 3000)
+        CmdResult.Explanation(sym, doc, members, impls, importRefs, companion, expandedImpls)
 
 private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,
                         depth: Int, visited: Set[String]): List[ExplainedImpl] =

--- a/src/commands/members.scala
+++ b/src/commands/members.scala
@@ -43,13 +43,28 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
         val sections = defs.map { s =>
           val members = extractMembers(s.file, symbol)
           val inherited = collectInherited(s)
+          // Companion lookup (same pattern as explain)
+          val companionKinds: Set[SymbolKind] = s.kind match
+            case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => Set(SymbolKind.Object)
+            case SymbolKind.Object => Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Enum)
+            case _ => Set.empty
+          val companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] =
+            if companionKinds.isEmpty then None
+            else
+              val allDefs = ctx.idx.findDefinition(symbol).filter(d => typeKinds.contains(d.kind))
+              allDefs.find(d => companionKinds.contains(d.kind) && d.packageName == s.packageName && d.file == s.file)
+                .map { compSym =>
+                  val compMembers = extractMembers(compSym.file, symbol)
+                  (sym = compSym, members = compMembers)
+                }
           MemberSectionData(
             file = s.file,
             ownerKind = s.kind,
             packageName = s.packageName,
             line = s.line,
             ownMembers = members,
-            inherited = inherited
+            inherited = inherited,
+            companion = companion
           )
         }
         CmdResult.MemberSections(symbol, sections)

--- a/src/commands/refs.scala
+++ b/src/commands/refs.scala
@@ -13,7 +13,17 @@ def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
             else
               (grouped.filter((cat, _) => cat.toString.toLowerCase == lower), None)
           case None => (grouped, None)
-      if ctx.categorize then
+      if ctx.countOnly then
+        val rawGrouped = ctx.idx.categorizeReferences(symbol, strict = ctx.strict).map((cat, refs) => (cat, filterRefs(refs, ctx)))
+        val counts = rawGrouped.toList.map((cat, refs) => (category = cat, count = refs.size)).filter(_.count > 0)
+          .sortBy { entry =>
+            val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
+                             RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
+            order.indexOf(entry.category)
+          }
+        val total = counts.map(_.count).sum
+        CmdResult.RefsSummary(symbol, counts, total, ctx.idx.timedOut)
+      else if ctx.categorize then
         val rawGrouped = ctx.idx.categorizeReferences(symbol, strict = ctx.strict).map((cat, refs) => (cat, filterRefs(refs, ctx)))
         val (grouped, stderrHint) = filterByCategory(rawGrouped)
         CmdResult.CategorizedRefs(symbol, grouped, targetPkgs, ctx.idx.timedOut, stderrHint)

--- a/src/commands/search.scala
+++ b/src/commands/search.scala
@@ -15,6 +15,29 @@ def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
       if ctx.definitionsOnly then
         val defKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
         results = results.filter(s => defKinds.contains(s.kind))
+      // Filter by return type: check if signature ends with ": <Type>" or "]: <Type>"
+      ctx.returnsFilter.foreach { rt =>
+        results = results.filter { s =>
+          val sig = s.signature
+          sig.nonEmpty && {
+            // Match ": Type" or "]: Type" patterns near the end of the signature
+            val colonIdx = sig.lastIndexOf(':')
+            colonIdx >= 0 && sig.substring(colonIdx + 1).trim.toLowerCase.contains(rt.toLowerCase)
+          }
+        }
+      }
+      // Filter by parameter type: check if signature's parameter section contains the type
+      ctx.takesFilter.foreach { tt =>
+        results = results.filter { s =>
+          val sig = s.signature
+          sig.nonEmpty && {
+            val parenStart = sig.indexOf('(')
+            val parenEnd = sig.lastIndexOf(')')
+            parenStart >= 0 && parenEnd > parenStart &&
+              sig.substring(parenStart, parenEnd + 1).toLowerCase.contains(tt.toLowerCase)
+          }
+        }
+      }
       results = filterSymbols(results, ctx)
       if results.isEmpty then
         CmdResult.NotFound(

--- a/src/format.scala
+++ b/src/format.scala
@@ -106,6 +106,7 @@ def render(result: CmdResult, ctx: CommandContext): Unit = {
     case r: Packages         => renderPackages(r, ctx)
     case r: PackageSymbols   => renderPackageSymbols(r, ctx)
     case r: ApiSurface       => renderApiSurface(r, ctx)
+    case r: RefsSummary      => renderRefsSummary(r, ctx)
     case r: NotFound         => renderNotFound(r, ctx)
     case r: UsageError       => println(r.message)
   }
@@ -293,7 +294,13 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
           s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(parentName)}","ownerKind":"inherited","package":"${jsonEscape(parentPackage)}","inherited":true}"""
         }
       }
-      ownMembers ++ inheritedMembers
+      val companionMembers = sec.companion.toList.flatMap { (compSym, compMembers) =>
+        val rel = jsonEscape(ctx.workspace.relativize(compSym.file).toString)
+        compMembers.map { m =>
+          s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(compSym.name)}","ownerKind":"companion","package":"${jsonEscape(compSym.packageName)}","inherited":false}"""
+        }
+      }
+      ownMembers ++ inheritedMembers ++ companionMembers
     }
     println(allMembers.take(ctx.limit).mkString("[", ",", "]"))
   } else {
@@ -324,6 +331,20 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
               println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
           }
           if pMembers.size > ctx.limit then println(s"    ... and ${pMembers.size - ctx.limit} more")
+        }
+        sec.companion.foreach { (compSym, compMembers) =>
+          val compRel = ctx.workspace.relativize(compSym.file)
+          println(s"\n  Companion ${compSym.kind.toString.toLowerCase} ${compSym.name} — $compRel:${compSym.line}:")
+          if compMembers.isEmpty then println("    (no members)")
+          else {
+            compMembers.take(ctx.limit).foreach { m =>
+              if !ctx.brief then
+                println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
+              else
+                println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
+            }
+            if compMembers.size > ctx.limit then println(s"    ... and ${compMembers.size - ctx.limit} more")
+          }
         }
       }
     }
@@ -598,7 +619,12 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       s"""{"definition":${jsonSymbol(ei.sym, ctx.workspace)},"members":$mJson,"subImplementations":$subJson}"""
     }
     val expandedJson = r.expandedImpls.map(explainedImplJson).mkString("[", ",", "]")
-    println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":$docJson,"members":$membersJson,"implementations":$implsJson,"importCount":${r.importCount},"companion":$companionJson,"expandedImplementations":$expandedJson}""")
+    val importCount = r.importRefs.size
+    val importRefsJson = if importCount <= 10 then
+      val arr = r.importRefs.map(ref => jsonRef(ref, ctx.workspace)).mkString("[", ",", "]")
+      s""","importFiles":$arr"""
+    else ""
+    println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":$docJson,"members":$membersJson,"implementations":$implsJson,"importCount":$importCount$importRefsJson,"companion":$companionJson,"expandedImplementations":$expandedJson}""")
   } else {
     println(s"Explanation of ${sym.kind.toString.toLowerCase} ${sym.name}$pkg:\n")
     println(s"  Definition: $rel:${sym.line}")
@@ -615,14 +641,20 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
     }
     if r.members.nonEmpty then {
       println(s"  Members (top ${r.members.size}):")
-      r.members.foreach(m => println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}"))
+      r.members.foreach { m =>
+        val label = if ctx.verbose then m.signature else m.name
+        println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
+      }
       println()
     }
     r.companion.foreach { (compSym, compMembers) =>
       val compRel = ctx.workspace.relativize(compSym.file)
       println(s"  Companion ${compSym.kind.toString.toLowerCase} ${compSym.name} — $compRel:${compSym.line}")
       if compMembers.nonEmpty then
-        compMembers.foreach(m => println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}"))
+        compMembers.foreach { m =>
+          val label = if ctx.verbose then m.signature else m.name
+          println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
+        }
       println()
     }
     if r.impls.nonEmpty then {
@@ -635,14 +667,24 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       def printExpanded(impls: List[ExplainedImpl], indent: String): Unit = {
         impls.foreach { ei =>
           println(s"$indent${ei.sym.kind.toString.toLowerCase} ${ei.sym.name} — ${ctx.workspace.relativize(ei.sym.file)}:${ei.sym.line}")
-          ei.members.foreach(m => println(s"$indent  ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}"))
+          ei.members.foreach { m =>
+            val label = if ctx.verbose then m.signature else m.name
+            println(s"$indent  ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
+          }
           if ei.subImpls.nonEmpty then printExpanded(ei.subImpls, indent + "  ")
         }
       }
       printExpanded(r.expandedImpls, "    ")
       println()
     }
-    println(s"  Imported by: ${r.importCount} files")
+    val importCount = r.importRefs.size
+    if importCount == 0 then
+      println("  Imported by: 0 files")
+    else if importCount <= 10 then
+      println(s"  Imported by ($importCount files):")
+      r.importRefs.foreach(ref => println(s"    ${ctx.workspace.relativize(ref.file)}:${ref.line}"))
+    else
+      println(s"  Imported by: $importCount files (use `scalex imports ${sym.name}` for full list)")
   }
 }
 
@@ -844,6 +886,27 @@ private def renderApiSurface(r: CmdResult.ApiSurface, ctx: CommandContext): Unit
         println(s"\n  Not imported externally (${r.internalOnly.size}): ${shown.mkString(", ")}$suffix")
       }
     }
+  }
+}
+
+private def renderRefsSummary(r: CmdResult.RefsSummary, ctx: CommandContext): Unit = {
+  if ctx.jsonOutput then {
+    val counts = r.categoryCounts.map((cat, count) => s""""${cat.toString}":$count""").mkString("{", ",", "}")
+    println(s"""{"symbol":"${jsonEscape(r.symbol)}","counts":$counts,"total":${r.total},"timedOut":${r.timedOut}}""")
+  } else {
+    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    val parts = r.categoryCounts.map { (cat, count) =>
+      val label = cat match {
+        case RefCategory.Definition => "definitions"
+        case RefCategory.ExtendedBy => "extensions"
+        case RefCategory.ImportedBy => "importers"
+        case RefCategory.UsedAsType => "type usages"
+        case RefCategory.Usage => "usages"
+        case RefCategory.Comment => "comments"
+      }
+      s"$count $label"
+    }
+    println(s"""References to "${r.symbol}" — ${r.total} total: ${parts.mkString(", ")}$suffix""")
   }
 }
 

--- a/src/index.scala
+++ b/src/index.scala
@@ -273,6 +273,23 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       aIdx.map((k, v) => k -> v.toList).toMap
     }
 
+  private lazy val symbolImportRank: Map[String, Int] =
+    Timings.phase("build-symbolImportRank") {
+      // Count how many files import each symbol name (by counting import lines mentioning it)
+      val counts = mutable.HashMap.empty[String, Int]
+      indexedFiles.foreach { idxFile =>
+        idxFile.imports.foreach { imp =>
+          parseImportTarget(imp).foreach { (_, names, _) =>
+            names.foreach { name =>
+              val lower = name.toLowerCase
+              counts(lower) = counts.getOrElse(lower, 0) + 1
+            }
+          }
+        }
+      }
+      counts.toMap
+    }
+
   private lazy val annotationIndex: Map[String, List[SymbolInfo]] =
     Timings.phase("build-annotationIndex") {
       val aByAnnot = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
@@ -427,15 +444,17 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       else if n.contains(lower) then contains += s
       else if camelCaseMatch(lower, s.name) then fuzzy += s
     }
-    def searchRank(s: SymbolInfo): (kindRank: Int, testRank: Int, pathLen: Int) =
+    def searchRank(s: SymbolInfo): (kindRank: Int, testRank: Int, importRank: Int, pathLen: Int) =
       val kindRank = s.kind match
         case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => 0
         case SymbolKind.Object => 1
         case SymbolKind.Def | SymbolKind.Val | SymbolKind.Type => 2
         case _ => 3
       val testRank = if isTestFile(s.file, workspace) then 1 else 0
+      // Symbols in heavily-imported types rank higher (lower importRank = better)
+      val importRank = -symbolImportRank.getOrElse(s.name.toLowerCase, 0)
       val pathLen = s.file.toString.length
-      (kindRank, testRank, pathLen)
+      (kindRank, testRank, importRank, pathLen)
     exact.toList.sortBy(searchRank) ++ prefix.toList.sortBy(searchRank) ++ contains.toList.sortBy(searchRank) ++ fuzzy.sortBy(_.name.length).toList
 
   def fileSymbols(path: String): List[SymbolInfo] =
@@ -630,7 +649,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   private def isIdentChar(c: Char): Boolean =
     c.isLetterOrDigit || c == '_' || c == '$'
 
-  def findApiSurface(targetPkg: String): List[(symbol: SymbolInfo, importerCount: Int)] =
+  def findApiSurface(targetPkg: String, filterToPkg: Option[String] = None): List[(symbol: SymbolInfo, importerCount: Int)] =
     Timings.phase("api-surface") {
       val targetSymNames = packageToSymbols.getOrElse(targetPkg, Set.empty)
       if targetSymNames.isEmpty then Nil
@@ -642,23 +661,29 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
 
       indexedFiles.foreach { idxFile =>
         val filePkg = filePackage(idxFile)
-        if filePkg != targetPkg then
-          idxFile.imports.foreach { imp =>
-            parseImportTarget(imp).foreach { (pkg, names, isWildcard) =>
-              if pkg == targetPkg then {
-                if isWildcard then
-                  // Credit all symbols in the package
-                  targetSymNames.foreach { symName =>
-                    importerCounts(symName).add(idxFile.relativePath)
-                  }
-                else
-                  names.foreach { name =>
-                    if importerCounts.contains(name) then
-                      importerCounts(name).add(idxFile.relativePath)
-                  }
+        if filePkg != targetPkg then {
+          // If --used-by filter is set, only count importers from matching packages
+          val matchesFilter = filterToPkg match
+            case Some(fpkg) => filePkg.toLowerCase.contains(fpkg.toLowerCase) || filePkg.equalsIgnoreCase(fpkg)
+            case None => true
+          if matchesFilter then
+            idxFile.imports.foreach { imp =>
+              parseImportTarget(imp).foreach { (pkg, names, isWildcard) =>
+                if pkg == targetPkg then {
+                  if isWildcard then
+                    // Credit all symbols in the package
+                    targetSymNames.foreach { symName =>
+                      importerCounts(symName).add(idxFile.relativePath)
+                    }
+                  else
+                    names.foreach { name =>
+                      if importerCounts.contains(name) then
+                        importerCounts(name).add(idxFile.relativePath)
+                    }
+                }
               }
             }
-          }
+        }
       }
 
       // Build result with SymbolInfo objects

--- a/src/model.scala
+++ b/src/model.scala
@@ -133,6 +133,9 @@ case class CommandContext(
   hasMethodFilter: Option[String] = None, extendsFilter: Option[String] = None,
   bodyContainsFilter: Option[String] = None,
   expandDepth: Int = 0,
+  usedByFilter: Option[String] = None,
+  returnsFilter: Option[String] = None,
+  takesFilter: Option[String] = None,
 ):
   val fmt: (SymbolInfo, Path) => String = if verbose then formatSymbolVerbose else formatSymbol
   val jRef: Reference => String =
@@ -149,7 +152,8 @@ case class NotFoundHint(symbol: String, fileCount: Int, parseFailures: Int, cmd:
 case class MemberSectionData(
   file: Path, ownerKind: SymbolKind, packageName: String, line: Int,
   ownMembers: List[MemberInfo],
-  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])]
+  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
+  companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] = None
 )
 
 case class DocEntryData(sym: SymbolInfo, doc: Option[String])
@@ -183,7 +187,7 @@ enum CmdResult:
   case CoverageReport(symbol: String, totalRefs: Int, testRefs: List[Reference], testFiles: List[String])
   case HierarchyResult(symbol: String, tree: HierarchyTree)
   case OverrideList(header: String, results: List[OverrideInfo])
-  case Explanation(sym: SymbolInfo, doc: Option[String], members: List[MemberInfo], impls: List[SymbolInfo], importCount: Int,
+  case Explanation(sym: SymbolInfo, doc: Option[String], members: List[MemberInfo], impls: List[SymbolInfo], importRefs: List[Reference],
     companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] = None,
     expandedImpls: List[ExplainedImpl] = Nil)
   case Dependencies(symbol: String, importDeps: List[DepInfo], bodyDeps: List[DepInfo])
@@ -194,5 +198,6 @@ enum CmdResult:
   case Packages(packages: List[String])
   case PackageSymbols(pkg: String, symbols: List[SymbolInfo])
   case ApiSurface(pkg: String, symbols: List[(symbol: SymbolInfo, importerCount: Int)], totalInPackage: Int, internalOnly: List[String])
+  case RefsSummary(symbol: String, categoryCounts: List[(category: RefCategory, count: Int)], total: Int, timedOut: Boolean)
   case NotFound(message: String, hint: NotFoundHint)
   case UsageError(message: String)


### PR DESCRIPTION
## Summary

Implements 9 features from #119 and #120 — the theme is **reduce round-trips: one call should answer the question.**

- **`overview` defaults to `--no-tests`** — production code is almost always the intent; `--include-tests` to opt in
- **`explain --verbose`** — show member signatures inline instead of just names
- **`explain` inlines imports** — file list shown when count ≤ 10, count + hint otherwise
- **`refs --count`** — category counts without full file lists (e.g. "12 importers, 4 extensions, 30 usages")
- **Companion-aware `members`** — auto-shows companion object/class members alongside the primary type
- **`Owner.member` dotted syntax** — `def MyService.findUser` resolves to the member directly (works for `def` and `explain`)
- **`api --used-by <package>`** — filter importers to a specific consumer package (coupling analysis)
- **`search` import ranking** — symbols from heavily-imported types surface first
- **`search --returns <Type>` / `--takes <Type>`** — filter search results by signature substring

## Test plan

- [x] All 210 existing tests pass (`scala-cli test src/ tests/`)
- [x] SKILL.md frontmatter validation passes (`scripts/check-skill-frontmatter.sh`)
- [x] Smoke tested each feature manually:
  - `scalex overview -w .` excludes test files by default
  - `scalex overview --include-tests -w .` includes test files
  - `scalex explain WorkspaceIndex --verbose -w .` shows signatures
  - `scalex refs SymbolInfo --count -w .` shows category summary
  - `scalex members SymbolKind -w .` shows companion
  - `scalex def WorkspaceIndex.search -w .` resolves member
  - `scalex explain WorkspaceIndex.search -w .` resolves member
  - `scalex search contains --returns Boolean -w .` filters by return type
  - `scalex search find --takes String -w .` filters by param type
  - `scalex refs SymbolInfo --count --json -w .` JSON output works

🤖 Generated with [Claude Code](https://claude.com/claude-code)