### PR TITLE
fix: stop indexing local vals + extract case class constructor params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `extractSymbols` no longer indexes local vals/defs/vars inside method bodies — traversal now stops at `Defn.Def`/`Val`/`Var`/`Given`/`GivenAlias` boundaries; matches SKILL.md documentation (#127)
+- `extractMembers` now includes case class constructor params as val members; regular class params only if marked `val`/`var` (#127)
+
 ### Added
 - `package --definitions-only` — filter to class/trait/object/enum only, same as `search --definitions-only` (#121)
 - `overview` hub types filter stdlib — `mostExtended` and `hubTypes` now skip scala/java base types (object, serializable, anyval, matchable, etc.) to surface real domain types (#121)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,11 @@
 
 ## Completed
 
+### Extraction fixes (#127)
+
+- Stop indexing local vals/defs inside method bodies — traversal skips `Defn.Def`/`Val`/`Var`/`Given`/`GivenAlias` bodies
+- Case class constructor params in `extractMembers` — case class params are public vals; regular class params only if marked `val`/`var`
+
 ### Signal vs noise (#121)
 
 - `package --definitions-only` — filter out vals/defs, show only class/trait/object/enum

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -171,7 +171,9 @@ def extractSymbols(file: Path): (symbols: List[SymbolInfo], bloom: BloomFilter[C
 
   def traverse(t: Tree): Unit =
     visit(t)
-    t.children.foreach(traverse)
+    t match
+      case _: Defn.Def | _: Defn.Val | _: Defn.Var | _: Defn.Given | _: Defn.GivenAlias => ()
+      case _ => t.children.foreach(traverse)
 
   traverse(tree)
   (buf.toList, bloom, imports, aliases, false)
@@ -259,7 +261,19 @@ def extractMembers(file: Path, symbolName: String): List[MemberInfo] =
         }
 
       def findAndExtract(t: Tree): Unit = t match
-        case d: Defn.Class if d.name.value == symbolName => extractFromTemplate(d.templ)
+        case d: Defn.Class if d.name.value == symbolName =>
+          // Constructor params: case class params are public vals; regular class params only if marked val/var
+          val isCaseClass = d.mods.exists(_.isInstanceOf[Mod.Case])
+          d.ctor.paramClauses.foreach { clause =>
+            clause.values.foreach { p =>
+              val isVal = isCaseClass || p.mods.exists(m => m.isInstanceOf[Mod.ValParam] || m.isInstanceOf[Mod.VarParam])
+              if isVal then
+                val tpe = p.decltpe.map(t => s": ${t.toString}").getOrElse("")
+                val kind = if p.mods.exists(_.isInstanceOf[Mod.VarParam]) then SymbolKind.Var else SymbolKind.Val
+                buf += MemberInfo(p.name.value, kind, p.pos.startLine + 1, s"val ${p.name.value}$tpe")
+            }
+          }
+          extractFromTemplate(d.templ)
         case d: Defn.Trait if d.name.value == symbolName => extractFromTemplate(d.templ)
         case d: Defn.Object if d.name.value == symbolName => extractFromTemplate(d.templ)
         case d: Defn.Enum if d.name.value == symbolName => extractFromTemplate(d.templ)

--- a/tests/extraction.test.scala
+++ b/tests/extraction.test.scala
@@ -180,6 +180,56 @@ class ExtractionSuite extends ScalexTestBase:
     assert(imports != null)
   }
 
+  // ── Local vals NOT indexed ──────────────────────────────────────────
+
+  test("extractSymbols does NOT index local vals inside def bodies") {
+    val file = workspace.resolve("src/main/scala/local_vals.scala")
+    Files.createDirectories(file.getParent)
+    Files.writeString(file,
+      """package com.example
+        |
+        |object MyService {
+        |  def process(data: String): String = {
+        |    val temp = data.trim
+        |    val result = temp.toUpperCase
+        |    result
+        |  }
+        |  val publicVal: Int = 42
+        |}
+        |""".stripMargin)
+
+    val (syms, _, _, _, _) = extractSymbols(file)
+    val names = syms.map(_.name).toSet
+    assert(names.contains("MyService"), "Should find top-level object")
+    assert(names.contains("process"), "Should find top-level def")
+    assert(names.contains("publicVal"), "Should find top-level val in object body")
+    assert(!names.contains("temp"), s"Should NOT index local val 'temp': $names")
+    assert(!names.contains("result"), s"Should NOT index local val 'result': $names")
+
+    Files.delete(file)
+  }
+
+  // ── Case class constructor params in members ──────────────────────
+
+  test("extractMembers returns case class constructor params") {
+    val members = extractMembers(
+      workspace.resolve("src/main/scala/com/example/Model.scala"),
+      "User"
+    )
+    val names = members.map(_.name).toSet
+    assert(names.contains("id"), s"Should contain case class param 'id': $names")
+    assert(names.contains("name"), s"Should contain case class param 'name': $names")
+  }
+
+  test("extractMembers does NOT return regular class constructor params without val/var") {
+    val members = extractMembers(
+      workspace.resolve("src/main/scala/com/example/UserService.scala"),
+      "UserServiceLive"
+    )
+    val names = members.map(_.name).toSet
+    assert(!names.contains("db"), s"Should NOT contain regular param 'db': $names")
+  }
+
   // ── Scala 2 dialect fallback ────────────────────────────────────────
 
   test("extractSymbols parses Scala 2 procedure syntax") {


### PR DESCRIPTION
## Summary
- **Stop indexing local vals**: `extractSymbols` traversal now stops at `Defn.Def`/`Val`/`Var`/`Given`/`GivenAlias` boundaries — local variables inside method bodies are no longer indexed, matching SKILL.md documentation (#127)
- **Case class constructor params**: `extractMembers` now extracts case class params as val members; regular class params only if marked `val`/`var` (#127)
- 3 new tests covering both fixes

## Test plan
- [x] All 213 tests pass (0 failures)
- [ ] Verify `scalex overview -w .` shows dramatically fewer vals
- [ ] Verify `scalex explain User -w .` shows `id` and `name` members
- [ ] Verify `scalex symbols src/extraction.scala -w .` no longer shows local vals like `bloom`, `buf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)