### PR TITLE
release: v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.17.0] — 2026-03-17
+
 ### Fixed
 - `extractSymbols` no longer indexes local vals/defs/vars inside method bodies — traversal now stops at `Defn.Def`/`Val`/`Var`/`Given`/`GivenAlias` boundaries; matches SKILL.md documentation (#127)
 - `extractMembers` now includes case class constructor params as val members; regular class params only if marked `val`/`var` (#127)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.16.0"
+val ScalexVersion = "1.17.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.17.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.17.0] — 2026-03-17`

## Test plan
- [ ] Merge, then tag `v1.17.0` and push — GitHub Actions builds native binaries + creates release
- [ ] After release: bump `EXPECTED_VERSION` in plugin bootstrap script and `version` in `marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)