### PR TITLE
release: v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.18.0] — 2026-03-17
+
 ### Fixed
 - `isTestFile` now detects root-level `test/`, `tests/`, and `testing/` directories (previously required a leading `/`) (#132–#135)
 - `explain` import refs now respect `--path` and `--exclude-path` filters (previously unfiltered) (#133, #134)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.17.0"
+val ScalexVersion = "1.18.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.18.0`
- Move `[Unreleased]` changelog to `[1.18.0] — 2026-03-17`

## After merge

1. Tag `v1.18.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)