### PR TITLE
chore: bump version to 1.19.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.19.0] — 2026-03-17
+
 ### Added
 - `entrypoints` command — find `@main` annotated, `def main(...)` methods, `extends App`, and test suites in one call; supports `--no-tests`, `--path`, `--json` (#141)
 - Override markers on `members --inherited` and `explain --inherited` — own members that shadow parent members are annotated with `[override]` in text output and `"isOverride":true` in JSON (#141)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.18.0"
+val ScalexVersion = "1.19.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` in `src/model.scala` from 1.18.0 to 1.19.0
- Move unreleased changelog entries into `[1.19.0] — 2026-03-17`

## After merge
1. Tag: `git tag v1.19.0 && git push origin v1.19.0`
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)