### PR TITLE
docs: shorten Try It Now example prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Clone a project and ask Claude to explore it:
 
 | Project | Clone | Prompt |
 |---|---|---|
-| **Scala 3 compiler** | `git clone --depth 1 https://github.com/scala/scala3.git` | *"Use scalex to explain how the Scala 3 compiler works. Start with an overview, find the main compilation phases, and trace how a source file gets transformed into bytecode."* |
-| **Scala.js** | `git clone --depth 1 https://github.com/scala-js/scala-js.git` | *"Use scalex to explore how Scala.js turns Scala code into JavaScript. Find the IR generation phases, trace how a Scala class becomes a JS object, and explain the linker pipeline."* |
+| **Scala 3 compiler** | `git clone --depth 1 https://github.com/scala/scala3.git` | *"Use scalex to explore how the Scala 3 compiler turns source file into bytecode."* |
+| **Scala.js** | `git clone --depth 1 https://github.com/scala-js/scala-js.git` | *"Use scalex to explore how Scala.js turns Scala code into JavaScript."* |
 
 Scalex will index the codebase in seconds, then navigate definitions, trace implementations, and explore the architecture — all without a build server or compilation. See [Quick Start](#quick-start) for installation details.
 


### PR DESCRIPTION
## Summary
- Shortened the Scala 3 compiler and Scala.js example prompts in the "Try It Now" table for clarity and scannability

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)