### PR TITLE
release: v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.20.0] — 2026-03-17
+
 ### Changed
 - `identifierBloom` field is now `Option[BloomFilter]` — eliminates null sentinel; index format bumped to v8 (old caches auto-rebuild) (#148)
 - Exception catches narrowed from `Exception` to `java.io.IOException` for file I/O; parse fallbacks log to stderr: `scalex: parse failed: <path>` (#148)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.19.0"
+val ScalexVersion = "1.20.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.20.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.20.0] — 2026-03-17`

## After merge

1. Tag `v1.20.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)