### PR TITLE
feat: add --no-doc flag to explain command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- `explain --no-doc` flag to suppress Scaladoc section — useful when exploring many types rapidly and doc dominates output (#157)
+
 ### Fixed
 - `search` now returns reverse-suffix matches — querying `ScalaJSClassEmitter` suggests `ClassEmitter` when no exact match exists (#156)
 - `explain` fuzzy auto-resolve now checks suffix matches — `explain ScalaJSClassEmitter` auto-shows `ClassEmitter` (#156)

--- a/README.md
+++ b/README.md
@@ -181,14 +181,15 @@ scalex entrypoints                         # Find @main, def main, extends App, 
 scalex def UserService --verbose           # Definition with signature
 scalex def UserService.findUser            # Owner.member dotted syntax
 scalex explain UserService --verbose       # One-shot: def + doc + signatures + impls
-scalex explain UserService --inherited    # Include inherited members from parents
+scalex explain UserService --inherited     # Include inherited members from parents
+scalex explain UserService --no-doc       # Skip Scaladoc section
 scalex members UserService --inherited     # Full API surface including parents
 scalex hierarchy UserService               # Inheritance tree (parents + children)
 
 # Navigate
 scalex refs UserService                    # Categorized references
 scalex refs UserService --count            # Summary: "12 importers, 4 extensions, ..."
-scalex refs UserService --top 10          # Top 10 files by reference count
+scalex refs UserService --top 10           # Top 10 files by reference count
 scalex impl UserService                    # Who extends this?
 scalex imports UserService                 # Who imports this?
 scalex grep "def.*process" --no-tests      # Regex content search

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@
 - [x] `explain` disambiguation hints — "(N other matches — use package-qualified name or --path to disambiguate)"
 - [x] `explain` package fallback — falls back to `summary` when symbol matches a package
 - [x] `explain --shallow` — skip implementations and import refs
+- [x] `explain --no-doc` — suppress Scaladoc section (#157)
 
 **Overview quality (#132, #133, #135):**
 - [x] Hub type casing — PascalCase preserved via `symbolsByName` lookup

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -302,11 +302,11 @@ Overrides of findUser (in implementations of UserService) — 2 found:
     def findUser(id: String): Option[User]
 ```
 
-### `scalex explain <symbol> [--verbose] [--shallow] [--inherited] [--impl-limit N] [--members-limit N] [--expand N] [--no-tests] [--path PREFIX] [--exclude-path PREFIX]` — composite summary
+### `scalex explain <symbol> [--verbose] [--shallow] [--no-doc] [--inherited] [--impl-limit N] [--members-limit N] [--expand N] [--no-tests] [--path PREFIX] [--exclude-path PREFIX]` — composite summary
 
 One-shot summary that eliminates 4-5 round-trips per type. Orchestrates: definition + scaladoc + members (top 10) + companion object/class + implementations (top N) + import files. Supports **package-qualified names** (e.g. `explain com.example.Cache`) and **Owner.member dotted syntax** (e.g. `explain MyService.findUser`).
 
-`--verbose` shows member signatures instead of just names. `--shallow` skips implementations and import refs entirely (definition + members + companion only — useful for understanding a type's API without output blowup). `--inherited` merges parent members into the output with provenance markers — shows the full API surface including inherited members. `--impl-limit N` controls how many implementations to show (default: 5); when more exist, shows "(showing N of M — use --impl-limit to adjust)". `--members-limit N` controls how many members to show per type (default: 10). Members are sorted by kind: classes/traits first, then defs, then vals, then types. `--expand N` recursively expands each implementation N levels deep, showing their members and sub-implementations — eliminates N follow-up explains. Auto-shows **companion** object/class with its members when applicable; companion members that duplicate primary members are collapsed. When import count <= 10, the actual importing files are shown inline; otherwise shows count + hint. If the exact symbol isn't found, `explain` tries a fuzzy match and auto-shows the best type match with a hint. If the symbol matches a package name instead, falls back to `summary` automatically. When multiple definitions match, a disambiguation hint is shown on stderr.
+`--verbose` shows member signatures instead of just names. `--shallow` skips implementations and import refs entirely (definition + members + companion only — useful for understanding a type's API without output blowup). `--no-doc` suppresses the Scaladoc section — useful when exploring many types rapidly and doc dominates output. `--inherited` merges parent members into the output with provenance markers — shows the full API surface including inherited members. `--impl-limit N` controls how many implementations to show (default: 5); when more exist, shows "(showing N of M — use --impl-limit to adjust)". `--members-limit N` controls how many members to show per type (default: 10). Members are sorted by kind: classes/traits first, then defs, then vals, then types. `--expand N` recursively expands each implementation N levels deep, showing their members and sub-implementations — eliminates N follow-up explains. Auto-shows **companion** object/class with its members when applicable; companion members that duplicate primary members are collapsed. When import count <= 10, the actual importing files are shown inline; otherwise shows count + hint. If the exact symbol isn't found, `explain` tries a fuzzy match and auto-shows the best type match with a hint. If the symbol matches a package name instead, falls back to `summary` automatically. When multiple definitions match, a disambiguation hint is shown on stderr.
 
 ```bash
 scalex explain UserService                  # full summary with companion
@@ -317,6 +317,7 @@ scalex explain UserService.findUser         # Owner.member dotted syntax
 scalex explain UserService --impl-limit 10  # show more implementations
 scalex explain UserService --expand 1       # expand impls with their members
 scalex explain UserService --inherited     # include inherited members from parents
+scalex explain UserService --no-doc       # skip Scaladoc section
 ```
 ```
 Explanation of trait UserService (com.example):
@@ -606,6 +607,7 @@ Normally not needed — every command auto-reindexes changed files. Use after ma
 | `--brief` | Members: show names only (default shows signatures) |
 | `--summary` | Symbols: grouped counts by kind instead of full listing |
 | `--strict` | Refs/imports: treat `_` and `$` as word characters (stricter matching) |
+| `--no-doc` | Explain: suppress Scaladoc section |
 | `--inherited` | Members/explain: include inherited members from parent types |
 | `--architecture` | Overview: show package dependency graph and hub types |
 | `--focus-package PKG` | Overview: scope dependency graph to a single package |

--- a/site/index.html
+++ b/site/index.html
@@ -568,7 +568,7 @@
       </div>
       <div class="cmd-card">
         <div class="cmd-name">scalex explain</div>
-        <div class="cmd-desc">One-shot summary: definition + scaladoc + members + companion + implementations + import count. Supports --expand N for recursive expansion, --inherited for parent members.</div>
+        <div class="cmd-desc">One-shot summary: definition + scaladoc + members + companion + implementations + import count. Supports --expand N for recursive expansion, --inherited for parent members, --no-doc to suppress scaladoc.</div>
       </div>
       <div class="cmd-card">
         <div class="cmd-name">scalex deps</div>

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -102,6 +102,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     case -1 => None
     case i => argList.lift(i + 1)
   val shallow = argList.contains("--shallow")
+  val noDoc = argList.contains("--no-doc")
   val excludePath: Option[String] = argList.indexOf("--exclude-path") match
     case -1 => None
     case i => argList.lift(i + 1).map(p => p.stripPrefix("/"))
@@ -179,6 +180,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         |  --in OWNER            Body: restrict to members of the given enclosing type
         |  --of TRAIT            Overrides: restrict to implementations of the given trait
         |  --shallow              Explain: skip implementations and import refs (definition + members only)
+        |  --no-doc               Explain: suppress Scaladoc section
         |  --impl-limit N        Explain: max implementations to show (default: 5)
         |  --members-limit N    Explain: max members to show per type (default: 10)
         |  --expand N            Explain: recursively expand implementations N levels deep
@@ -220,7 +222,7 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
         membersLimit = membersLimit, brief = brief, strict = strict,
         usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter,
-        shallow = shallow, excludePath = excludePath, summaryMode = summaryMode)
+        shallow = shallow, noDoc = noDoc, excludePath = excludePath, summaryMode = summaryMode)
       val reader = BufferedReader(InputStreamReader(System.in))
       var line = reader.readLine()
       while line != null do
@@ -266,6 +268,6 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
         membersLimit = membersLimit, brief = brief, strict = strict,
         usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter,
-        shallow = shallow, excludePath = excludePath, summaryMode = summaryMode)
+        shallow = shallow, noDoc = noDoc, excludePath = excludePath, summaryMode = summaryMode)
       runCommand(cmd, cmdRest, ctx)
       Timings.report()

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -21,7 +21,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         resolveDottedMember(symbol, ctx) match
           case Some(memberResults) =>
             val msym = memberResults.head
-            val doc = extractScaladoc(msym.file, msym.line)
+            val doc = if ctx.noDoc then None else extractScaladoc(msym.file, msym.line)
             return CmdResult.Explanation(msym, doc, Nil, Nil, Nil)
           case None => ()
       if defs.isEmpty then
@@ -65,7 +65,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         // For qualified lookups, use the simple name for member/impl queries
         val simpleName = if symbol.contains(".") then symbol.substring(symbol.lastIndexOf('.') + 1) else symbol
         // Scaladoc
-        val doc = extractScaladoc(sym.file, sym.line)
+        val doc = if ctx.noDoc then None else extractScaladoc(sym.file, sym.line)
         // Members (for types)
         val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
         val inheritResult = if typeKinds.contains(sym.kind) then collectInheritedMembers(sym, ctx)

--- a/src/model.scala
+++ b/src/model.scala
@@ -145,6 +145,7 @@ case class CommandContext(
   returnsFilter: Option[String] = None,
   takesFilter: Option[String] = None,
   shallow: Boolean = false,
+  noDoc: Boolean = false,
   excludePath: Option[String] = None,
   summaryMode: Boolean = false,
 ):


### PR DESCRIPTION
## Summary
- Add `--no-doc` flag to `explain` command that suppresses the Scaladoc section, skipping the file read entirely
- Useful when exploring many types rapidly where doc dominates output (150+ lines for heavily-documented types)
- `--shallow` exists but removes too much (impls + imports); `--no-doc` is a targeted suppression

## Test plan
- [x] All 255 existing tests pass (`scala-cli test src/ tests/`)
- [x] SKILL.md frontmatter validates (`./scripts/check-skill-frontmatter.sh`)
- [ ] Manual: `scalex explain <Type>` shows doc; `scalex explain <Type> --no-doc` omits it
- [ ] Manual: `scalex explain <Type> --no-doc --json` produces null doc field
- [ ] Manual: `--shallow --no-doc` combines correctly

Closes #157

🤖 Generated with [Claude Code](https://claude.ai/code)