### PR TITLE
release: v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.21.0] — 2026-03-17
+
 ### Added
 - `explain --no-doc` flag to suppress Scaladoc section — useful when exploring many types rapidly and doc dominates output (#157)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.20.0"
+val ScalexVersion = "1.21.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.21.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.21.0] — 2026-03-17`

## Post-merge steps
1. Tag `v1.21.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.ai/code)