### PR TITLE
refactor: extract shared helpers to eliminate duplication

### DIFF
--- a/src/command-helpers.scala
+++ b/src/command-helpers.scala
@@ -63,9 +63,11 @@ def filterRefs(refs: List[Reference], ctx: CommandContext): List[Reference] =
   ctx.excludePath.foreach { p => r = r.filter(ref => !matchesPath(ref.file, p, ctx.workspace)) }
   r
 
-// ── Inherited member collection (shared by members + explain) ──────────────
+// ── Shared constants ─────────────────────────────────────────────────────────
 
-private val inheritableKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+val typeKinds: Set[SymbolKind] = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+
+// ── Inherited member collection (shared by members + explain) ──────────────
 
 def collectInheritedMembers(sym: SymbolInfo, ctx: CommandContext): (
   inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
@@ -82,7 +84,7 @@ def collectInheritedMembers(sym: SymbolInfo, ctx: CommandContext): (
     parentNames.foreach { pName =>
       if !visited.contains(pName.toLowerCase) then {
         visited += pName.toLowerCase
-        val parentDefs = ctx.idx.findDefinition(pName).filter(s => inheritableKinds.contains(s.kind))
+        val parentDefs = ctx.idx.findDefinition(pName).filter(s => typeKinds.contains(s.kind))
         parentDefs.headOption.foreach { pd =>
           val parentMembers = extractMembers(pd.file, pd.name)
           parentMembers.foreach(m => allParentKeys += ((name = m.name, kind = m.kind)))
@@ -97,3 +99,44 @@ def collectInheritedMembers(sym: SymbolInfo, ctx: CommandContext): (
   walk(sym.parents)
   (inherited = result.toList, parentMemberKeys = allParentKeys.toSet)
 }
+
+// ── Ranking / sorting ────────────────────────────────────────────────────────
+
+def rankSymbols(symbols: List[SymbolInfo], workspace: Path): List[SymbolInfo] =
+  symbols.sortBy { s =>
+    val kindRank = s.kind match
+      case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+      case SymbolKind.Type | SymbolKind.Given => 1
+      case _ => 2
+    val testRank = if isTestFile(s.file, workspace) then 1 else 0
+    val pathLen = workspace.relativize(s.file).toString.length
+    (kindRank = kindRank, testRank = testRank, pathLen = pathLen)
+  }
+
+def memberKindRank(m: MemberInfo): Int = m.kind match
+  case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
+  case SymbolKind.Def => 1
+  case SymbolKind.Val | SymbolKind.Var => 2
+  case SymbolKind.Type => 3
+  case _ => 4
+
+// ── Companion lookup ─────────────────────────────────────────────────────────
+
+def findCompanion(sym: SymbolInfo, symbol: String, defs: List[SymbolInfo]): Option[(sym: SymbolInfo, members: List[MemberInfo])] =
+  val companionKinds: Set[SymbolKind] = sym.kind match
+    case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => Set(SymbolKind.Object)
+    case SymbolKind.Object => Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Enum)
+    case _ => Set.empty
+  if companionKinds.isEmpty then None
+  else
+    defs.find(d => companionKinds.contains(d.kind) && d.packageName == sym.packageName && d.file == sym.file)
+      .map { compSym =>
+        val compMembers = extractMembers(compSym.file, symbol)
+        (sym = compSym, members = compMembers)
+      }
+
+// ── Package helpers ──────────────────────────────────────────────────────────
+
+def symbolsInPackage(pkg: String, symbols: List[SymbolInfo]): List[SymbolInfo] =
+  val prefix = pkg + "."
+  symbols.filter(s => s.packageName == pkg || s.packageName.startsWith(prefix))

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -3,12 +3,7 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
     case None => CmdResult.UsageError("Usage: scalex body <symbol> [--in <owner>]")
     case Some(symbol) =>
       // Find files containing the symbol
-      var defs = ctx.idx.findDefinition(symbol)
-      if ctx.noTests then defs = defs.filter(s => !isTestFile(s.file, ctx.workspace))
-      ctx.pathFilter.foreach { p => defs = defs.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-      ctx.excludePath.foreach { p => defs = defs.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
-      // Also look in type definitions for member bodies
-      val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+      var defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
       val filesToSearch = if defs.nonEmpty then {
         defs.map(_.file).distinct
       } else {

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -3,16 +3,7 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
     case None => CmdResult.UsageError("Usage: scalex def <symbol>")
     case Some(symbol) =>
       var results = filterSymbols(ctx.idx.findDefinition(symbol), ctx)
-      // Rank: class/trait/object/enum > type/given > def/val/var, non-test > test, shorter path first
-      results = results.sortBy { s =>
-        val kindRank = s.kind match
-          case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
-          case SymbolKind.Type | SymbolKind.Given => 1
-          case _ => 2
-        val testRank = if isTestFile(s.file, ctx.workspace) then 1 else 0
-        val pathLen = ctx.workspace.relativize(s.file).toString.length
-        (kindRank, testRank, pathLen)
-      }
+      results = rankSymbols(results, ctx.workspace)
       // If no results and symbol contains ".", try Owner.member resolution
       if results.isEmpty && symbol.contains(".") then
         resolveDottedMember(symbol, ctx) match
@@ -41,7 +32,6 @@ private def resolveDottedMember(symbol: String, ctx: CommandContext): Option[Lis
   if lastDot <= 0 then return None
   val ownerName = symbol.substring(0, lastDot)
   val memberName = symbol.substring(lastDot + 1)
-  val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
   val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
   if ownerDefs.isEmpty then return None
   val memberResults = ownerDefs.flatMap { owner =>

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -2,20 +2,8 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex explain <symbol>")
     case Some(symbol) =>
-      var defs = ctx.idx.findDefinition(symbol)
-      if ctx.noTests then defs = defs.filter(s => !isTestFile(s.file, ctx.workspace))
-      ctx.pathFilter.foreach { p => defs = defs.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-      ctx.excludePath.foreach { p => defs = defs.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
-      // Rank: class/trait/object/enum first (same as def command)
-      defs = defs.sortBy { s =>
-        val kindRank = s.kind match
-          case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
-          case SymbolKind.Type | SymbolKind.Given => 1
-          case _ => 2
-        val testRank = if isTestFile(s.file, ctx.workspace) then 1 else 0
-        val pathLen = ctx.workspace.relativize(s.file).toString.length
-        (kindRank, testRank, pathLen)
-      }
+      var defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
+      defs = rankSymbols(defs, ctx.workspace)
       // If no results and symbol contains ".", try Owner.member resolution
       if defs.isEmpty && symbol.contains(".") then
         resolveDottedMember(symbol, ctx) match
@@ -26,11 +14,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
           case None => ()
       if defs.isEmpty then
         // Fuzzy fallback: try search and auto-show best match if unambiguous
-        val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
-        var fuzzyResults = ctx.idx.search(symbol).filter(s => typeKinds.contains(s.kind))
-        if ctx.noTests then fuzzyResults = fuzzyResults.filter(s => !isTestFile(s.file, ctx.workspace))
-        ctx.pathFilter.foreach { p => fuzzyResults = fuzzyResults.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-        ctx.excludePath.foreach { p => fuzzyResults = fuzzyResults.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
+        var fuzzyResults = filterSymbols(ctx.idx.search(symbol).filter(s => typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
         // Auto-use if exactly one strong match by name (exact case-insensitive, prefix, or suffix)
         val lower = symbol.toLowerCase
         val strongMatches = fuzzyResults.filter { s =>
@@ -67,7 +51,6 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         // Scaladoc
         val doc = if ctx.noDoc then None else extractScaladoc(sym.file, sym.line)
         // Members (for types)
-        val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
         val inheritResult = if typeKinds.contains(sym.kind) then collectInheritedMembers(sym, ctx)
           else (inherited = Nil: List[(parentName: String, parentFile: Option[java.nio.file.Path], parentPackage: String, members: List[MemberInfo])], parentMemberKeys = Set.empty[(name: String, kind: SymbolKind)])
         val inherited = inheritResult.inherited
@@ -78,18 +61,8 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
           }.sortBy(memberKindRank).take(ctx.membersLimit)
         else Nil
         // Companion lookup
-        val companionKinds: Set[SymbolKind] = sym.kind match
-          case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => Set(SymbolKind.Object)
-          case SymbolKind.Object => Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Enum)
-          case _ => Set.empty
-        val companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] =
-          if companionKinds.isEmpty then None
-          else
-            defs.find(d => companionKinds.contains(d.kind) && d.packageName == sym.packageName && d.file == sym.file)
-              .map { compSym =>
-                val compMembers = extractMembers(compSym.file, simpleName).sortBy(memberKindRank).take(ctx.membersLimit)
-                (sym = compSym, members = compMembers)
-              }
+        val companion = findCompanion(sym, simpleName, defs)
+          .map((s, ms) => (sym = s, members = ms.sortBy(memberKindRank).take(ctx.membersLimit)))
         if ctx.shallow then
           // Shallow mode: definition + members + companion only
           CmdResult.Explanation(sym, doc, members, Nil, Nil, companion, Nil, otherMatches = otherMatches)
@@ -111,7 +84,6 @@ private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,
                         depth: Int, visited: Set[String]): List[ExplainedImpl] =
   if depth > ctx.expandDepth then Nil
   else
-    val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
     impls.filter(s => typeKinds.contains(s.kind)).take(ctx.implLimit).map { impl =>
       val key = s"${impl.packageName}.${impl.name}".toLowerCase
       if visited.contains(key) then ExplainedImpl(impl, Nil, Nil)
@@ -122,9 +94,3 @@ private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,
         ExplainedImpl(impl, members, expanded)
     }
 
-private def memberKindRank(m: MemberInfo): Int = m.kind match
-  case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Object | SymbolKind.Enum => 0
-  case SymbolKind.Def => 1
-  case SymbolKind.Val | SymbolKind.Var => 2
-  case SymbolKind.Type => 3
-  case _ => 4

--- a/src/commands/members.scala
+++ b/src/commands/members.scala
@@ -2,7 +2,6 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex members <Symbol>")
     case Some(symbol) =>
-      val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
       val defs = filterSymbols(ctx.idx.findDefinition(symbol).filter(s => typeKinds.contains(s.kind)), ctx)
 
       if defs.isEmpty then
@@ -17,20 +16,8 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
           val members = extractMembers(s.file, symbol).map { m =>
             if ctx.inherited && parentKeys.contains((name = m.name, kind = m.kind)) then m.copy(isOverride = true) else m
           }
-          // Companion lookup (same pattern as explain)
-          val companionKinds: Set[SymbolKind] = s.kind match
-            case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => Set(SymbolKind.Object)
-            case SymbolKind.Object => Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Enum)
-            case _ => Set.empty
-          val companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] =
-            if companionKinds.isEmpty then None
-            else
-              val allDefs = ctx.idx.findDefinition(symbol).filter(d => typeKinds.contains(d.kind))
-              allDefs.find(d => companionKinds.contains(d.kind) && d.packageName == s.packageName && d.file == s.file)
-                .map { compSym =>
-                  val compMembers = extractMembers(compSym.file, symbol)
-                  (sym = compSym, members = compMembers)
-                }
+          // Companion lookup
+          val companion = findCompanion(s, symbol, ctx.idx.findDefinition(symbol).filter(d => typeKinds.contains(d.kind)))
           MemberSectionData(
             file = s.file,
             ownerKind = s.kind,

--- a/src/commands/overview.scala
+++ b/src/commands/overview.scala
@@ -15,10 +15,7 @@ private def recoverSignature(lower: String, symbolsByName: Map[String, List[Symb
   symbolsByName.get(lower).flatMap(_.headOption).map(_.signature).getOrElse("")
 
 def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
-  var allSymbols = if ctx.noTests then ctx.idx.symbols.filter(s => !isTestFile(s.file, ctx.workspace))
-                   else ctx.idx.symbols
-  ctx.pathFilter.foreach { p => allSymbols = allSymbols.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-  ctx.excludePath.foreach { p => allSymbols = allSymbols.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
+  var allSymbols = filterSymbols(ctx.idx.symbols, ctx)
 
   val symbolsByKind = allSymbols.groupBy(_.kind).toList.sortBy(-_._2.size)
   val topPackages: List[(pkg: String, syms: List[SymbolInfo])] = allSymbols.groupBy(_.packageName)
@@ -29,13 +26,7 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
     .filter((name, _) => ctx.idx.symbolsByName.contains(name) && !isStdlibParent(name))
     .filter((name, _) => recoverName(name, ctx.idx.symbolsByName).length > 1) // exclude single-char names
     .map { (name, impls) =>
-      val filtered = {
-        var r = if ctx.noTests then impls.filter(s => !isTestFile(s.file, ctx.workspace)) else impls
-        // Apply path filters to impls too
-        ctx.pathFilter.foreach { p => r = r.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-        ctx.excludePath.foreach { p => r = r.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
-        r
-      }
+      val filtered = filterSymbols(impls, ctx)
       val distinctPkgs = filtered.map(_.packageName).distinct.size
       (name = name, impls = filtered, distinctPkgs = distinctPkgs)
     }
@@ -87,9 +78,7 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
     ctx.idx.parentIndex.foreach { (name, impls) =>
       if ctx.idx.symbolsByName.contains(name) && !isStdlibParent(name) &&
          recoverName(name, ctx.idx.symbolsByName).length > 1 then
-        var filtered = if ctx.noTests then impls.filter(s => !isTestFile(s.file, ctx.workspace)) else impls
-        ctx.pathFilter.foreach { p => filtered = filtered.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-        ctx.excludePath.foreach { p => filtered = filtered.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
+        val filtered = filterSymbols(impls, ctx)
         if filtered.nonEmpty then
           refCounts(name) = (count = filtered.size, distinctPkgs = filtered.map(_.packageName).distinct.size)
     }

--- a/src/commands/package-cmd.scala
+++ b/src/commands/package-cmd.scala
@@ -10,6 +10,5 @@ def cmdPackage(args: List[String], ctx: CommandContext): CmdResult =
         case Some(resolvedPkg) =>
           var symbols = filterSymbols(ctx.idx.symbols.filter(_.packageName == resolvedPkg), ctx)
           if ctx.definitionsOnly then
-            val defKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
-            symbols = symbols.filter(s => defKinds.contains(s.kind))
+            symbols = symbols.filter(s => typeKinds.contains(s.kind))
           CmdResult.PackageSymbols(resolvedPkg, symbols)

--- a/src/commands/search.scala
+++ b/src/commands/search.scala
@@ -13,8 +13,7 @@ def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
         case _ => ()
       }
       if ctx.definitionsOnly then
-        val defKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
-        results = results.filter(s => defKinds.contains(s.kind))
+        results = results.filter(s => typeKinds.contains(s.kind))
       // Filter by return type: check if signature ends with ": <Type>" or "]: <Type>"
       ctx.returnsFilter.foreach { rt =>
         results = results.filter { s =>

--- a/src/commands/summary.scala
+++ b/src/commands/summary.scala
@@ -10,12 +10,7 @@ def cmdSummary(args: List[String], ctx: CommandContext): CmdResult =
         case Some(resolvedPkg) =>
           val prefix = resolvedPkg + "."
           // Collect all packages that start with resolvedPkg (including itself)
-          var allSymbols = ctx.idx.symbols.filter { s =>
-            s.packageName == resolvedPkg || s.packageName.startsWith(prefix)
-          }
-          if ctx.noTests then allSymbols = allSymbols.filter(s => !isTestFile(s.file, ctx.workspace))
-          ctx.pathFilter.foreach { p => allSymbols = allSymbols.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-          ctx.excludePath.foreach { p => allSymbols = allSymbols.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
+          var allSymbols = filterSymbols(symbolsInPackage(resolvedPkg, ctx.idx.symbols), ctx)
 
           // Group by sub-package relative to resolvedPkg
           val grouped = allSymbols.groupBy { s =>

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -57,6 +57,11 @@ private def buildSignature(name: String, kind: String, parents: List[String], tp
   val ext = if parents.nonEmpty then s" extends ${parents.mkString(" with ")}" else ""
   s"$kind $name$tps$ext"
 
+private def formatParamClauses(paramClauses: Seq[Term.ParamClause]): String =
+  paramClauses.map(_.values.map(p =>
+    s"${p.name.value}: ${p.decltpe.map(_.toString()).getOrElse("?")}"
+  ).mkString(", ")).mkString("(", ")(", ")")
+
 private def extractAnnotations(mods: List[Mod]): List[String] =
   mods.collect { case Mod.Annot(init) =>
     init.tpe match
@@ -133,7 +138,7 @@ def extractRawSymbols(tree: Tree): (symbols: List[RawSymbol], packageName: Strin
       val annots = extractAnnotations(d.mods)
       buf += RawSymbol(d.name.value, SymbolKind.Type, d.pos.startLine + 1, Nil, Nil, sig, annots)
     case d: Defn.Def =>
-      val params = d.paramClauses.map(_.values.map(p => s"${p.name.value}: ${p.decltpe.map(_.toString()).getOrElse("?")}").mkString(", ")).mkString("(", ")(", ")")
+      val params = formatParamClauses(d.paramClauses)
       val ret = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
       val sig = s"def ${d.name.value}$params$ret"
       val annots = extractAnnotations(d.mods)
@@ -220,7 +225,7 @@ def extractMembers(file: Path, symbolName: String): List[MemberInfo] =
       def extractFromTemplate(templ: Template): Unit =
         templ.stats.foreach {
           case d: Defn.Def =>
-            val params = d.paramClauses.map(_.values.map(p => s"${p.name.value}: ${p.decltpe.map(_.toString()).getOrElse("?")}").mkString(", ")).mkString("(", ")(", ")")
+            val params = formatParamClauses(d.paramClauses)
             val ret = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
             val annots = extractAnnotations(d.mods)
             buf += MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots)
@@ -244,7 +249,7 @@ def extractMembers(file: Path, symbolName: String): List[MemberInfo] =
             val annots = extractAnnotations(d.mods)
             buf += MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value} = ${d.body.toString().take(60)}", annots)
           case d: Decl.Def =>
-            val params = d.paramClauses.map(_.values.map(p => s"${p.name.value}: ${p.decltpe.map(_.toString()).getOrElse("?")}").mkString(", ")).mkString("(", ")(", ")")
+            val params = formatParamClauses(d.paramClauses)
             val ret = s": ${d.decltpe.toString()}"
             val annots = extractAnnotations(d.mods)
             buf += MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots)


### PR DESCRIPTION
## Summary

- Consolidate 6+ local `typeKinds` redefinitions into a single shared constant in `command-helpers.scala`
- Extract `rankSymbols`, `memberKindRank`, `findCompanion`, `symbolsInPackage` as shared helpers
- Extract `formatParamClauses` in `extraction.scala` (3 identical inline expressions)
- Update 8 command files to use shared helpers: explain, def, members, body, summary, overview, search, package
- Net result: -32 lines, no behavior change

## Test plan

- [x] All 255 tests pass (`scala-cli test src/ tests/`)
- [x] Self-review caught and fixed: `filterSymbols` adding unintended `--kind` filter to `explain`/`body` (fixed via `ctx.copy(kindFilter = None)`)
- [x] Self-review caught and fixed: unnamed tuple in `rankSymbols` (CLAUDE.md requires named tuples)
- [x] Self-review caught and fixed: dead `ctx` parameter in `findCompanion`

🤖 Generated with [Claude Code](https://claude.ai/code)