### PR TITLE
feat: show copy-paste disambiguation commands in explain output (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Improved
+- `explain` disambiguation now shows copy-paste-ready commands with package-qualified names instead of generic "use --path to disambiguate" hint (#164)
+
 ## [1.21.0] — 2026-03-17
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,11 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Community feedback: agent experience (#164)
+
+- [x] `explain` copy-paste disambiguation — when multiple matches exist, show `scalex explain pkg.Name` commands instead of generic hint
+- [ ] Batch output size estimation — warn or auto-limit when a single query in a batch would produce >100KB output
+
 ### Community feedback: fuzzy not-found suggestions (#156)
 
 - [x] `search` reverse-suffix matching — queries like `ScalaJSClassEmitter` suggest `ClassEmitter`

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -637,6 +637,8 @@ Most commands are self-explanatory from their name — `scalex def X`, `scalex m
 
 **"I need to look up 3+ symbols"** → use `batch` to load the index once: `echo -e "def Foo\nimpl Foo\nrefs Foo" | scalex batch -w /project`
 
+**"Quick overview of multiple types"** → use `batch` with `explain --shallow --no-doc --members-limit 3`: `echo -e "explain --shallow --no-doc --members-limit 3 Foo\nexplain --shallow --no-doc --members-limit 3 Bar" | scalex batch -w /project`
+
 **"Search for a pattern in Scala files"** → `scalex grep "pattern"` — prefer this over the Grep tool for `.scala` files because it integrates with `--path` and `--no-tests`
 
 **"Show me the source code of method X"** → `scalex body X --in MyClass` — use `--in` when the name exists in multiple classes

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -44,8 +44,13 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
       else
         val sym = defs.head
         // Deduplicate by (name, package): trait+companion = 1 match, cross-package = distinct (see #8bd6b57)
-        val distinctByNamePkg = defs.map(s => (name = s.name.toLowerCase, pkg = s.packageName)).distinct.size
-        val otherMatches = distinctByNamePkg - 1
+        val shownKey = (name = sym.name.toLowerCase, pkg = sym.packageName)
+        val distinctKeys = defs.map(s => (name = s.name.toLowerCase, pkg = s.packageName)).distinct
+        val otherMatches = distinctKeys.size - 1
+        // Collect one representative def per distinct (name, package) for copy-paste disambiguation hints
+        val otherDefs = distinctKeys.filterNot(_ == shownKey).flatMap { k =>
+          defs.find(s => s.name.toLowerCase == k.name && s.packageName == k.pkg)
+        }
         // For qualified lookups, use the simple name for member/impl queries
         val simpleName = if symbol.contains(".") then symbol.substring(symbol.lastIndexOf('.') + 1) else symbol
         // Scaladoc
@@ -65,7 +70,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
           .map((s, ms) => (sym = s, members = ms.sortBy(memberKindRank).take(ctx.membersLimit)))
         if ctx.shallow then
           // Shallow mode: definition + members + companion only
-          CmdResult.Explanation(sym, doc, members, Nil, Nil, companion, Nil, otherMatches = otherMatches)
+          CmdResult.Explanation(sym, doc, members, Nil, Nil, companion, Nil, otherMatches = otherMatches, otherDefs = otherDefs)
         else
           // Implementations
           val allImpls = filterSymbols(ctx.idx.findImplementations(simpleName), ctx)
@@ -78,7 +83,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
           // Import refs (apply path/exclude/noTests filters)
           val importRefs = filterRefs(ctx.idx.findImports(simpleName, timeoutMs = 3000), ctx)
           CmdResult.Explanation(sym, doc, members, impls, importRefs, companion, expandedImpls,
-            otherMatches = otherMatches, totalImpls = totalImpls, inherited = inherited)
+            otherMatches = otherMatches, otherDefs = otherDefs, totalImpls = totalImpls, inherited = inherited)
 
 private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,
                         depth: Int, visited: Set[String]): List[ExplainedImpl] =

--- a/src/format.scala
+++ b/src/format.scala
@@ -637,7 +637,15 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       val arr = r.importRefs.map(ref => jsonRef(ref, ctx.workspace)).mkString("[", ",", "]")
       s""","importFiles":$arr"""
     else ""
-    val otherJson = if r.otherMatches > 0 then s""","otherMatches":${r.otherMatches}""" else ""
+    val otherJson = if r.otherDefs.nonEmpty then
+      val alts = r.otherDefs.map { s =>
+        val qualified = if s.packageName.nonEmpty then s"${s.packageName}.${s.name}" else s.name
+        val rel = ctx.workspace.relativize(s.file)
+        s"""{"name":"${jsonEscape(s.name)}","package":"${jsonEscape(s.packageName)}","qualifiedName":"${jsonEscape(qualified)}","file":"${jsonEscape(rel.toString)}","line":${s.line}}"""
+      }.mkString("[", ",", "]")
+      s""","otherMatches":${r.otherDefs.size},"alternatives":$alts"""
+    else if r.otherMatches > 0 then s""","otherMatches":${r.otherMatches}"""
+    else ""
     val totalImplJson = if r.totalImpls > r.impls.size then s""","totalImplementations":${r.totalImpls}""" else ""
     val inheritedJson = if r.inherited.nonEmpty then
       val groups = r.inherited.map { (parentName, parentFile, parentPackage, members) =>
@@ -732,7 +740,13 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
         r.importRefs.foreach(ref => println(s"    ${ctx.workspace.relativize(ref.file)}:${ref.line}"))
       else
         println(s"  Imported by: $importCount files (use `scalex imports ${sym.name}` for full list)")
-    if r.otherMatches > 0 then
+    if r.otherDefs.nonEmpty then
+      Console.err.println(s"(${r.otherDefs.size} other match${if r.otherDefs.size > 1 then "es" else ""} — try:)")
+      r.otherDefs.foreach { s =>
+        val qualified = if s.packageName.nonEmpty then s"${s.packageName}.${s.name}" else s.name
+        Console.err.println(s"  scalex explain $qualified")
+      }
+    else if r.otherMatches > 0 then
       Console.err.println(s"(${r.otherMatches} other match${if r.otherMatches > 1 then "es" else ""} — use package-qualified name or --path to disambiguate)")
   }
 }

--- a/src/model.scala
+++ b/src/model.scala
@@ -202,7 +202,7 @@ enum CmdResult:
   case Explanation(sym: SymbolInfo, doc: Option[String], members: List[MemberInfo], impls: List[SymbolInfo], importRefs: List[Reference],
     companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] = None,
     expandedImpls: List[ExplainedImpl] = Nil,
-    otherMatches: Int = 0, totalImpls: Int = 0,
+    otherMatches: Int = 0, otherDefs: List[SymbolInfo] = Nil, totalImpls: Int = 0,
     inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])] = Nil)
   case Dependencies(symbol: String, importDeps: List[DepInfo], bodyDeps: List[DepInfo])
   case Scopes(file: Path, line: Int, scopes: List[ScopeInfo])


### PR DESCRIPTION
When explain matches multiple packages, show `scalex explain pkg.Name`
commands instead of a generic "use --path to disambiguate" hint.
Also adds alternatives to JSON output and documents batch+shallow
explain workflow in SKILL.md.

https://claude.ai/code/session_01Fq35wHWSt1b8ksDvH25Ath