### PR TITLE
fix: replace per-file parse failure warnings with single summary line (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Parse failure warnings no longer flood stderr — replaced per-file `scalex: parse failed: <path>` messages with a single summary line; use `scalex index --verbose` to list individual files (#163)
+
 ## [1.21.0] — 2026-03-17
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,11 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Parse failure warning noise (#163)
+
+- [x] Replace per-file `scalex: parse failed:` stderr messages with single summary line
+- [x] `scalex index --verbose` still lists individual failed files
+
 ### Community feedback: fuzzy not-found suggestions (#156)
 
 - [x] `search` reverse-suffix matching — queries like `ScalaJSClassEmitter` suggest `ClassEmitter`

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -243,7 +243,6 @@ def extractSymbolsFromSource(source: String, filePath: String): List[DiffSymbol]
         input.parse[Source].get
       } catch {
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $filePath")
           return Nil
       }
   }

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -187,7 +187,6 @@ def extractSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomF
         input.parse[Source].get
       catch
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $file")
           return (Nil, Some(bloom), Nil, Map.empty, true)
 
   val (imports, aliases) = extractImports(tree)
@@ -211,7 +210,6 @@ def parseFile(path: Path): Option[Source] =
         Some(input.parse[Source].get)
       catch
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $path")
           None
 
 // ── Member extraction ───────────────────────────────────────────────────────

--- a/src/index.scala
+++ b/src/index.scala
@@ -373,6 +373,8 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       case f if f.parseFailed => f.relativePath
     }
     parseFailures = parseFailedFiles.size
+    if parseFailures > 0 then
+      System.err.println(s"scalex: $parseFailures file(s) failed to parse (run `scalex index --verbose` to list them)")
     indexTimeMs = (System.nanoTime() - t0) / 1_000_000
 
     if parsedCount > 0 then


### PR DESCRIPTION
On large codebases (e.g. scala3 with ~14k files), individual
`scalex: parse failed: <path>` messages flooded stderr with 100+ lines.
Now emits one summary line; `scalex index --verbose` still lists files.

https://claude.ai/code/session_01R9KxzbS57bsZEzGF3y6F85