### PR TITLE
fix: silence per-file parse warnings, rename extractScaladoc to extractDoc

### DIFF
--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -243,7 +243,6 @@ def extractSymbolsFromSource(source: String, filePath: String): List[DiffSymbol]
         input.parse[Source].get
       } catch {
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $filePath")
           return Nil
       }
   }

--- a/src/commands/doc.scala
+++ b/src/commands/doc.scala
@@ -9,6 +9,6 @@ def cmdDoc(args: List[String], ctx: CommandContext): CmdResult =
           mkNotFoundWithSuggestions(symbol, ctx, "doc"))
       else
         val entries = defs.map { s =>
-          DocEntryData(s, extractScaladoc(s.file, s.line))
+          DocEntryData(s, extractDoc(s.file, s.line))
         }
         CmdResult.DocEntries(symbol, entries)

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -9,7 +9,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         resolveDottedMember(symbol, ctx) match
           case Some(memberResults) =>
             val msym = memberResults.head
-            val doc = if ctx.noDoc then None else extractScaladoc(msym.file, msym.line)
+            val doc = if ctx.noDoc then None else extractDoc(msym.file, msym.line)
             return CmdResult.Explanation(msym, doc, Nil, Nil, Nil)
           case None => ()
       if defs.isEmpty then
@@ -49,7 +49,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
         // For qualified lookups, use the simple name for member/impl queries
         val simpleName = if symbol.contains(".") then symbol.substring(symbol.lastIndexOf('.') + 1) else symbol
         // Scaladoc
-        val doc = if ctx.noDoc then None else extractScaladoc(sym.file, sym.line)
+        val doc = if ctx.noDoc then None else extractDoc(sym.file, sym.line)
         // Members (for types)
         val inheritResult = if typeKinds.contains(sym.kind) then collectInheritedMembers(sym, ctx)
           else (inherited = Nil: List[(parentName: String, parentFile: Option[java.nio.file.Path], parentPackage: String, members: List[MemberInfo])], parentMemberKeys = Set.empty[(name: String, kind: SymbolKind)])

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -187,7 +187,6 @@ def extractSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomF
         input.parse[Source].get
       catch
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $file")
           return (Nil, Some(bloom), Nil, Map.empty, true)
 
   val (imports, aliases) = extractImports(tree)
@@ -211,7 +210,6 @@ def parseFile(path: Path): Option[Source] =
         Some(input.parse[Source].get)
       catch
         case _: Exception =>
-          System.err.println(s"scalex: parse failed: $path")
           None
 
 // ── Member extraction ───────────────────────────────────────────────────────
@@ -301,9 +299,9 @@ def extractMembers(file: Path, symbolName: String): List[MemberInfo] =
       findAndExtract(tree)
       buf.toList
 
-// ── Scaladoc extraction ─────────────────────────────────────────────────────
+// ── Doc extraction (Scaladoc / Javadoc) ─────────────────────────────────────
 
-def extractScaladoc(file: Path, targetLine: Int): Option[String] =
+def extractDoc(file: Path, targetLine: Int): Option[String] =
   val lines = try Files.readAllLines(file).asScala.toArray catch
     case _: java.io.IOException => return None
   // targetLine is 1-indexed, array is 0-indexed

--- a/tests/analysis.test.scala
+++ b/tests/analysis.test.scala
@@ -129,8 +129,8 @@ class AnalysisSuite extends ScalexTestBase:
     val defs = idx.findDefinition("PaymentService")
     assert(defs.nonEmpty, "Should find PaymentService definition")
     val sym = defs.head
-    // extractScaladoc
-    val doc = extractScaladoc(sym.file, sym.line)
+    // extractDoc
+    val doc = extractDoc(sym.file, sym.line)
     assert(doc.isDefined, "Should find scaladoc for PaymentService")
     assert(doc.get.contains("processing payments"))
     // extractMembers

--- a/tests/extraction.test.scala
+++ b/tests/extraction.test.scala
@@ -477,7 +477,7 @@ class ExtractionSuite extends ScalexTestBase:
   // ── doc ──────────────────────────────────────────────────────────────
 
   test("doc extracts multi-line scaladoc") {
-    val doc = extractScaladoc(
+    val doc = extractDoc(
       workspace.resolve("src/main/scala/com/example/Documented.scala"),
       7 // trait PaymentService is on line 7
     )
@@ -488,7 +488,7 @@ class ExtractionSuite extends ScalexTestBase:
   }
 
   test("doc extracts single-line scaladoc") {
-    val doc = extractScaladoc(
+    val doc = extractDoc(
       workspace.resolve("src/main/scala/com/example/Documented.scala"),
       9 // def processPayment is on line 9
     )
@@ -497,7 +497,7 @@ class ExtractionSuite extends ScalexTestBase:
   }
 
   test("doc returns None when no scaladoc") {
-    val doc = extractScaladoc(
+    val doc = extractDoc(
       workspace.resolve("src/main/scala/com/example/Documented.scala"),
       10 // def refund on line 10 — no doc
     )


### PR DESCRIPTION
## Summary

- Remove per-file `System.err.println("scalex: parse failed: ...")` calls from `extractScalaSymbols`, `parseFile`, and `extractSymbolsFromSource` that flood stderr on large codebases (1147 lines on scala3 repo). The `parseFailed` flag already tracks failures and the `index` command surfaces the count via summary.
- Rename `extractScaladoc` → `extractDoc` to be language-neutral, preparing for future Javadoc support.

Closes #163

## Test plan

- [x] All 255 tests pass
- [x] Verified on scala3 benchmark (18.5k files): zero parse noise on cold `scalex def Main` query

🤖 Generated with [Claude Code](https://claude.ai/code)