### PR TITLE
release: v1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.22.0] — 2026-03-17
+
 ### Added
 - `explain --brief` flag — condensed output with definition + top 3 members only; no doc, companion, inherited, impls, or imports (#164)
 - `explain` disambiguation now prints copy-paste `scalex explain pkg.Name` commands on stderr instead of just a count + generic hint (#164)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.21.0"
+val ScalexVersion = "1.22.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.22.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.22.0] — 2026-03-17`

### What's in 1.22.0

- `explain --brief` — condensed output: definition + top 3 members only (#164)
- `explain` disambiguation prints copy-paste `scalex explain pkg.Name` commands (#164)
- `otherMatches` JSON changed from integer to string array (#164)

## Test plan

- [x] All 276 tests pass
- [ ] After merge: tag `v1.22.0`, push tag to trigger release workflow
- [ ] After release: bump `EXPECTED_VERSION` in plugin bootstrap script

🤖 Generated with [Claude Code](https://claude.com/claude-code)