### PR TITLE
fix: Java parser crash, batch --path ignored, body local defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- Java parser crash: `parseJavaSource` now catches `Error` (not just `Exception`) — fixes `NoSuchFieldError` crash from JavaParser on certain Java files (#172)
+- `body` command fallback owner lookup now applies `filterSymbols` — `--path`, `--no-tests`, `--exclude-path` are respected when searching for the `--in` owner's files (#172)
+- `body` command now finds nested local defs inside methods (e.g. `body runPhases --in Run` finds a `def runPhases` inside `compileUnits`) — tree walker now recurses into def bodies and general AST nodes (#172)
+- Batch mode now parses per-line flags (`--path`, `--no-tests`, `--in`, etc.) — previously all per-line flags were ignored and only top-level flags applied (#172)
+
+### Changed
+- Extracted `parseFlags` / `flagsToContext` helpers from `main` — eliminates flag-parsing duplication between batch loop and single-command path (#172)
+
 ## [1.22.0] — 2026-03-17
 
 ### Added

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -13,13 +13,33 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     case ws :: a :: _ => Some((resolveWorkspace(ws), a))
     case _ => None
 
-@main def main(args: String*): Unit =
-  val argList = args.toList
+// ── Flag parsing (shared by main + batch) ─────────────────────────────────
 
-  if argList.contains("--version") then
-    println(ScalexVersion)
-    return
+case class ParsedFlags(
+  limit: Int = 20, kindFilter: Option[String] = None, verbose: Boolean = false,
+  categorize: Boolean = true, includeTests: Boolean = false, noTests: Boolean = false,
+  pathFilter: Option[String] = None, contextLines: Int = 0, jsonOutput: Boolean = false,
+  countOnly: Boolean = false, searchMode: Option[String] = None, definitionsOnly: Boolean = false,
+  categoryFilter: Option[String] = None, grepPatterns: List[String] = Nil,
+  explicitWorkspace: Option[String] = None,
+  inOwner: Option[String] = None, ofTrait: Option[String] = None,
+  implLimit: Int = 5, goUp: Boolean = true, goDown: Boolean = true, maxDepth: Int = -1,
+  inherited: Boolean = false, architecture: Boolean = false,
+  hasMethodFilter: Option[String] = None, extendsFilter: Option[String] = None,
+  bodyContainsFilter: Option[String] = None, focusPackage: Option[String] = None,
+  expandDepth: Int = 0, membersLimit: Int = 10, brief: Boolean = false, strict: Boolean = false,
+  usedByFilter: Option[String] = None, returnsFilter: Option[String] = None,
+  takesFilter: Option[String] = None, shallow: Boolean = false, noDoc: Boolean = false,
+  excludePath: Option[String] = None, topN: Option[Int] = None, summaryMode: Boolean = false,
+  timingsEnabled: Boolean = false,
+  cleanArgs: List[String] = Nil,
+)
 
+private val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "--exclude-path", "-C", "-e", "--category",
+                         "--in", "--of", "--impl-limit", "--depth", "--has-method", "--extends", "--body-contains", "--focus-package", "--expand",
+                         "--members-limit", "--used-by", "--returns", "--takes", "--top")
+
+def parseFlags(argList: List[String]): ParsedFlags =
   val limit = argList.indexOf("--limit") match
     case -1 => 20
     case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(20)
@@ -54,8 +74,6 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     val shortIdx = argList.indexOf("-w")
     val idx = if longIdx >= 0 then longIdx else shortIdx
     if idx >= 0 then argList.lift(idx + 1) else None
-
-  // New flags for new commands
   val inOwner: Option[String] = argList.indexOf("--in") match
     case -1 => None
     case i => argList.lift(i + 1)
@@ -111,17 +129,46 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
     case i => argList.lift(i + 1).flatMap(_.toIntOption)
   val summaryMode = argList.contains("--summary")
   val timingsEnabled = argList.contains("--timings")
-  Timings.enabled = timingsEnabled
 
-  val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "--exclude-path", "-C", "-e", "--category",
-                           "--in", "--of", "--impl-limit", "--depth", "--has-method", "--extends", "--body-contains", "--focus-package", "--expand",
-                           "--members-limit", "--used-by", "--returns", "--takes", "--top")
   val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || a == "-e" || a == "-c" || {
     val prev = argList.indexOf(a) - 1
     prev >= 0 && flagsWithArgs.contains(argList(prev))
   })
 
-  cleanArgs match
+  ParsedFlags(limit, kindFilter, verbose, categorize, includeTests, noTests, pathFilter,
+    contextLines, jsonOutput, countOnly, searchMode, definitionsOnly, categoryFilter, grepPatterns,
+    explicitWorkspace, inOwner, ofTrait, implLimit, goUp, goDown, maxDepth, inherited, architecture,
+    hasMethodFilter, extendsFilter, bodyContainsFilter, focusPackage, expandDepth, membersLimit,
+    brief, strict, usedByFilter, returnsFilter, takesFilter, shallow, noDoc, excludePath, topN,
+    summaryMode, timingsEnabled, cleanArgs)
+
+private def flagsToContext(f: ParsedFlags, idx: WorkspaceIndex, workspace: Path,
+                           batchMode: Boolean = false, effectiveNoTests: Option[Boolean] = None): CommandContext =
+  val noTests = effectiveNoTests.getOrElse(f.noTests)
+  CommandContext(idx = idx, workspace = workspace, limit = f.limit, verbose = f.verbose,
+    jsonOutput = f.jsonOutput, batchMode = batchMode, kindFilter = f.kindFilter, noTests = noTests,
+    pathFilter = f.pathFilter, contextLines = f.contextLines, categorize = f.categorize,
+    categoryFilter = f.categoryFilter, grepPatterns = f.grepPatterns, countOnly = f.countOnly,
+    topN = f.topN, searchMode = f.searchMode, definitionsOnly = f.definitionsOnly,
+    inOwner = f.inOwner, ofTrait = f.ofTrait, implLimit = f.implLimit,
+    goUp = f.goUp, goDown = f.goDown, maxDepth = f.maxDepth, inherited = f.inherited,
+    architecture = f.architecture, focusPackage = f.focusPackage,
+    hasMethodFilter = f.hasMethodFilter, extendsFilter = f.extendsFilter,
+    bodyContainsFilter = f.bodyContainsFilter, expandDepth = f.expandDepth,
+    membersLimit = f.membersLimit, brief = f.brief, strict = f.strict,
+    usedByFilter = f.usedByFilter, returnsFilter = f.returnsFilter, takesFilter = f.takesFilter,
+    shallow = f.shallow, noDoc = f.noDoc, excludePath = f.excludePath, summaryMode = f.summaryMode)
+
+@main def main(args: String*): Unit =
+  val f = parseFlags(args.toList)
+
+  if args.contains("--version") then
+    println(ScalexVersion)
+    return
+
+  Timings.enabled = f.timingsEnabled
+
+  f.cleanArgs match
     case Nil | List("help") =>
       println("""Scalex — Scala code intelligence for AI agents
         |
@@ -207,38 +254,29 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
         |""".stripMargin)
 
     case "batch" :: rest =>
-      val workspace = resolveWorkspace(explicitWorkspace.orElse(rest.headOption).getOrElse("."))
+      val workspace = resolveWorkspace(f.explicitWorkspace.orElse(rest.headOption).getOrElse("."))
       val idx = WorkspaceIndex(workspace, needBlooms = true)
       idx.index()
       Timings.report()
-      val ctx = CommandContext(idx = idx, workspace = workspace, limit = limit, verbose = verbose,
-        jsonOutput = jsonOutput, batchMode = true, kindFilter = kindFilter, noTests = noTests,
-        pathFilter = pathFilter, contextLines = contextLines, categorize = categorize,
-        categoryFilter = categoryFilter, grepPatterns = grepPatterns, countOnly = countOnly, topN = topN,
-        searchMode = searchMode, definitionsOnly = definitionsOnly, inOwner = inOwner, ofTrait = ofTrait,
-        implLimit = implLimit, goUp = goUp, goDown = goDown, maxDepth = maxDepth, inherited = inherited,
-        architecture = architecture, focusPackage = focusPackage,
-        hasMethodFilter = hasMethodFilter, extendsFilter = extendsFilter,
-        bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
-        membersLimit = membersLimit, brief = brief, strict = strict,
-        usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter,
-        shallow = shallow, noDoc = noDoc, excludePath = excludePath, summaryMode = summaryMode)
+      val baseCtx = flagsToContext(f, idx, workspace, batchMode = true)
       val reader = BufferedReader(InputStreamReader(System.in))
       var line = reader.readLine()
       while line != null do
         val parts = line.trim.split("\\s+").toList
         if parts.nonEmpty && parts.head.nonEmpty then
           val batchCmd = parts.head
-          val batchRest = parts.tail
+          // Parse per-line flags so each batch line can override --path, --no-tests, etc.
+          val lineFlags = parseFlags(parts.tail)
+          val lineCtx = flagsToContext(lineFlags, idx, workspace, batchMode = true)
           println(s">>> $line")
           Timings.reset()
-          runCommand(batchCmd, batchRest, ctx)
+          runCommand(batchCmd, lineFlags.cleanArgs, lineCtx)
           Timings.report()
           println()
         line = reader.readLine()
 
     case cmd :: rest =>
-      val (workspace, cmdRest) = explicitWorkspace match
+      val (workspace, cmdRest) = f.explicitWorkspace match
         case Some(ws) =>
           (resolveWorkspace(ws), rest)
         case None =>
@@ -252,22 +290,11 @@ def parseWorkspaceAndArg(rest: List[String]): Option[(workspace: Path, arg: Stri
                 case Nil => (resolveWorkspace("."), Nil)
 
       // overview defaults to --no-tests unless --include-tests is explicitly passed
-      val effectiveNoTests = if cmd == "overview" && !includeTests then true else noTests
+      val effectiveNoTests = if cmd == "overview" && !f.includeTests then true else f.noTests
 
       val bloomCmds = Set("refs", "imports", "coverage")
       val idx = WorkspaceIndex(workspace, needBlooms = bloomCmds.contains(cmd))
       idx.index()
-      val ctx = CommandContext(idx = idx, workspace = workspace, limit = limit, verbose = verbose,
-        jsonOutput = jsonOutput, kindFilter = kindFilter, noTests = effectiveNoTests, pathFilter = pathFilter,
-        contextLines = contextLines, categorize = categorize, categoryFilter = categoryFilter,
-        grepPatterns = grepPatterns, countOnly = countOnly, topN = topN, searchMode = searchMode,
-        definitionsOnly = definitionsOnly, inOwner = inOwner, ofTrait = ofTrait, implLimit = implLimit,
-        goUp = goUp, goDown = goDown, maxDepth = maxDepth, inherited = inherited, architecture = architecture,
-        focusPackage = focusPackage,
-        hasMethodFilter = hasMethodFilter, extendsFilter = extendsFilter,
-        bodyContainsFilter = bodyContainsFilter, expandDepth = expandDepth,
-        membersLimit = membersLimit, brief = brief, strict = strict,
-        usedByFilter = usedByFilter, returnsFilter = returnsFilter, takesFilter = takesFilter,
-        shallow = shallow, noDoc = noDoc, excludePath = excludePath, summaryMode = summaryMode)
+      val ctx = flagsToContext(f, idx, workspace, effectiveNoTests = Some(effectiveNoTests))
       runCommand(cmd, cmdRest, ctx)
       Timings.report()

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -10,9 +10,11 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
         // If not found directly, search all files for member bodies
         ctx.inOwner match
           case Some(owner) =>
-            ctx.idx.findDefinition(owner).filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
+            filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
+              .filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
           case None =>
-            ctx.idx.symbols.filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
+            filterSymbols(ctx.idx.symbols.filter(s => typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
+              .map(_.file).distinct
       }
       // Collect (file, body) pairs
       val blocks = filesToSearch.flatMap { f =>

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -413,12 +413,15 @@ private def extractScalaBody(file: Path, symbolName: String, ownerName: Option[S
 
       def extractFromTree(t: Tree, currentOwner: String): Unit = {
         t match
-          case d: Defn.Def if d.name.value == symbolName =>
-            if ownerName.isEmpty || ownerName.contains(currentOwner) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
+          case d: Defn.Def =>
+            if d.name.value == symbolName then
+              if ownerName.isEmpty || ownerName.contains(currentOwner) then
+                val sl = d.pos.startLine
+                val el = d.pos.endLine
+                val body = (sl to el).map(lines(_)).mkString("\n")
+                buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
+            // Recurse into def body to find nested local defs
+            d.body.children.foreach(c => extractFromTree(c, currentOwner))
           case d: Defn.Val =>
             d.pats.foreach {
               case Pat.Var(name) if name.value == symbolName =>
@@ -495,7 +498,10 @@ private def extractScalaBody(file: Path, symbolName: String, ownerName: Option[S
             infix.children.foreach(c => extractFromTree(c, currentOwner))
           case p: Pkg =>
             p.stats.foreach(s => extractFromTree(s, currentOwner))
-          case _ =>
+          case other =>
+            // Recurse into all other nodes (Term.Block, Term.If, etc.)
+            // to find nested local defs, vals, and vars
+            other.children.foreach(c => extractFromTree(c, currentOwner))
       }
 
       tree.children.foreach(c => extractFromTree(c, ""))
@@ -555,7 +561,7 @@ private def parseJavaSource(source: String, path: Path): Option[JavaCU] =
     if result.isSuccessful then Some(result.getResult.get())
     else None
   catch
-    case _: Exception => None
+    case _: Exception | _: Error => None
 
 private def parseJavaFile(path: Path): Option[JavaCU] =
   val source = try Files.readString(path) catch

--- a/tests/cli.test.scala
+++ b/tests/cli.test.scala
@@ -1479,6 +1479,148 @@ class CliSuite extends ScalexTestBase:
     assert(output.contains("No body found"), s"Should NOT find body when path is excluded: $output")
   }
 
+  // ── #172: body command — nested local defs + filter fixes ───────────
+
+  test("body --in finds nested local def via command") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val output = captureOut {
+      runCommand("body", List("runSteps"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("Pipeline")))
+    }
+    assert(output.contains("def runSteps"), s"Should find local def runSteps: $output")
+    assert(output.contains("Pipeline"), s"Should mention Pipeline: $output")
+  }
+
+  test("body --in with --path filter on fallback restricts to matching files") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // Pipeline is in src/main/ — use --path to include it
+    val output = captureOut {
+      runCommand("body", List("runSteps"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("Pipeline"),
+          pathFilter = Some("src/main/")))
+    }
+    assert(output.contains("def runSteps"), s"Should find runSteps with matching --path: $output")
+    // Now exclude it via path
+    val excluded = captureOut {
+      runCommand("body", List("runSteps"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("Pipeline"),
+          pathFilter = Some("src/test/")))
+    }
+    assert(excluded.contains("No body found"), s"Should NOT find runSteps when --path excludes it: $excluded")
+  }
+
+  test("body --in with --no-tests on fallback owner lookup") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // testFindUser is a method in UserServiceSpec (src/test/). With --in and --no-tests,
+    // the owner lookup should exclude test files.
+    val output = captureOut {
+      runCommand("body", List("testFindUser"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("UserServiceSpec"),
+          noTests = true))
+    }
+    assert(output.contains("No body found"), s"Should NOT find testFindUser when --no-tests excludes owner: $output")
+  }
+
+  test("body finds local def nested inside synchronized/wrapper call") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val output = captureOut {
+      runCommand("body", List("processBatch"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("Scheduler")))
+    }
+    assert(output.contains("def processBatch"), s"Should find local def inside synchronized: $output")
+    assert(output.contains("batch.size"), s"Should contain body: $output")
+  }
+
+  test("body on Java file does not crash with parser error") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // BrokenRecord.java may trigger JavaParser internal errors.
+    // The command should return gracefully, not throw.
+    val output = captureOut {
+      runCommand("body", List("Ok"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("BrokenRecord")))
+    }
+    // Either finds the result or says "No body found" — must not crash
+    assert(output.nonEmpty, s"Should produce output, not crash: $output")
+  }
+
+  // ── #172: parseFlags + batch per-line flag parsing ─────────────────
+
+  test("parseFlags extracts --path from arg list") {
+    val flags = parseFlags(List("Parser", "--verbose", "--no-tests", "--path", "compiler/src/"))
+    assertEquals(flags.pathFilter, Some("compiler/src/"))
+    assert(flags.verbose)
+    assert(flags.noTests)
+    assertEquals(flags.cleanArgs, List("Parser"))
+  }
+
+  test("parseFlags strips leading / from --path") {
+    val flags = parseFlags(List("Foo", "--path", "/src/main/"))
+    assertEquals(flags.pathFilter, Some("src/main/"))
+  }
+
+  test("parseFlags extracts --in owner") {
+    val flags = parseFlags(List("runPhases", "--in", "Run", "--no-tests"))
+    assertEquals(flags.inOwner, Some("Run"))
+    assert(flags.noTests)
+    assertEquals(flags.cleanArgs, List("runPhases"))
+  }
+
+  test("parseFlags with no flags returns defaults and full cleanArgs") {
+    val flags = parseFlags(List("UserService"))
+    assertEquals(flags.pathFilter, None)
+    assertEquals(flags.inOwner, None)
+    assert(!flags.noTests)
+    assert(!flags.verbose)
+    assertEquals(flags.cleanArgs, List("UserService"))
+  }
+
+  test("batch per-line flags override: --path applied to per-line context") {
+    // Simulate what the batch loop does: parse per-line flags and build context
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val lineArgs = List("UserService", "--path", "src/main/scala/com/example/")
+    val lineFlags = parseFlags(lineArgs)
+    val ctx = flagsToContext(lineFlags, idx, workspace, batchMode = true)
+    assertEquals(ctx.pathFilter, Some("src/main/scala/com/example/"))
+    assert(ctx.batchMode)
+    // Run command with per-line context — should find UserService in that path
+    val output = captureOut { runCommand("def", lineFlags.cleanArgs, ctx) }
+    assert(output.contains("UserService"), s"Should find UserService with per-line --path: $output")
+  }
+
+  test("batch per-line --path excludes non-matching results") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // Registry exists in both com/example/ and com/other/
+    val lineArgs = List("Registry", "--path", "src/main/scala/com/other/")
+    val lineFlags = parseFlags(lineArgs)
+    val ctx = flagsToContext(lineFlags, idx, workspace, batchMode = true)
+    val output = captureOut { runCommand("def", lineFlags.cleanArgs, ctx) }
+    assert(output.contains("com.other"), s"Should find com.other.Registry: $output")
+    assert(!output.contains("com.example"), s"Should NOT find com.example.Registry: $output")
+  }
+
+  test("batch per-line --no-tests applied independently") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // Without --no-tests, UserServiceSpec (in src/test/) should appear
+    val withTests = parseFlags(List("UserServiceSpec"))
+    val ctxWith = flagsToContext(withTests, idx, workspace, batchMode = true)
+    val outWith = captureOut { runCommand("def", withTests.cleanArgs, ctxWith) }
+    assert(outWith.contains("UserServiceSpec"), s"Should find test class without --no-tests: $outWith")
+    // With --no-tests, it should be filtered out
+    val noTests = parseFlags(List("UserServiceSpec", "--no-tests"))
+    val ctxNo = flagsToContext(noTests, idx, workspace, batchMode = true)
+    val outNo = captureOut { runCommand("def", noTests.cleanArgs, ctxNo) }
+    assert(!outNo.contains("UserServiceSpec") || outNo.contains("not found"),
+      s"Should NOT find test class with --no-tests: $outNo")
+  }
+
   test("entrypoints --no-tests excludes test suites from results") {
     val idx = WorkspaceIndex(workspace)
     idx.index()

--- a/tests/extraction.test.scala
+++ b/tests/extraction.test.scala
@@ -687,3 +687,59 @@ class ExtractionSuite extends ScalexTestBase:
     assert(names.contains("findById"), s"Dispatch should work for Java: $names")
     assert(names.contains("findAll"), s"Dispatch should work for Java: $names")
   }
+
+  // ── #172: Java parser crash (Error not caught) ─────────────────────────
+
+  test("extractBody on Java file with parser error returns empty, does not crash") {
+    // BrokenRecord.java uses sealed interface + record syntax that may trigger
+    // JavaParser internal errors (NoSuchFieldError). The fix catches Error, not just Exception.
+    val file = workspace.resolve("src/main/java/com/example/BrokenRecord.java")
+    val results = extractBody(file, "Ok", None)
+    // Whether it parses or not, it must not throw — either returns results or empty
+    assert(results.size >= 0, "Should return a list (possibly empty), not crash")
+  }
+
+  test("extractSymbols on Java file with parser error does not crash") {
+    val file = workspace.resolve("src/main/java/com/example/BrokenRecord.java")
+    val (syms, _, _, _, _) = extractSymbols(file)
+    // Must not throw — either finds symbols or returns empty
+    assert(syms.size >= 0, "Should return a list (possibly empty), not crash")
+  }
+
+  // ── #172: Body finds nested local defs ─────────────────────────────────
+
+  test("extractBody finds local def nested inside a method") {
+    val file = workspace.resolve("src/main/scala/com/example/Pipeline.scala")
+    val results = extractBody(file, "runSteps", Some("Pipeline"))
+    assert(results.nonEmpty, "Should find local def runSteps inside Pipeline.execute")
+    val body = results.head
+    assert(body.sourceText.contains("def runSteps"), s"Should contain def keyword: ${body.sourceText}")
+    assert(body.sourceText.contains("remaining match"), s"Should contain body: ${body.sourceText}")
+    assert(body.ownerName == "Pipeline", s"Owner should be Pipeline: ${body.ownerName}")
+  }
+
+  test("extractBody finds local def in a different method of same class") {
+    val file = workspace.resolve("src/main/scala/com/example/Pipeline.scala")
+    val results = extractBody(file, "checkStep", Some("Pipeline"))
+    assert(results.nonEmpty, "Should find local def checkStep inside Pipeline.validate")
+    val body = results.head
+    assert(body.sourceText.contains("def checkStep"), s"Should contain def keyword: ${body.sourceText}")
+    assert(body.sourceText.contains("step.nonEmpty"), s"Should contain body: ${body.sourceText}")
+  }
+
+  test("extractBody finds local def without --in owner") {
+    val file = workspace.resolve("src/main/scala/com/example/Pipeline.scala")
+    val results = extractBody(file, "runSteps", None)
+    assert(results.nonEmpty, "Should find runSteps without owner filter")
+  }
+
+  test("extractBody finds local def nested inside wrapper call (synchronized, etc.)") {
+    // Scheduler.schedule wraps its body in synchronized { ... }
+    // The local def processBatch is nested inside that Term.Apply wrapper
+    val file = workspace.resolve("src/main/scala/com/example/Scheduler.scala")
+    val results = extractBody(file, "processBatch", Some("Scheduler"))
+    assert(results.nonEmpty, "Should find local def processBatch inside synchronized block")
+    val body = results.head
+    assert(body.sourceText.contains("def processBatch"), s"Should contain def keyword: ${body.sourceText}")
+    assert(body.sourceText.contains("batch.size"), s"Should contain body: ${body.sourceText}")
+  }

--- a/tests/index.test.scala
+++ b/tests/index.test.scala
@@ -8,7 +8,7 @@ class IndexSuite extends ScalexTestBase:
 
   test("gitLsFiles finds all .scala files") {
     val files = gitLsFiles(workspace)
-    assertEquals(files.size, 21)
+    assertEquals(files.size, 24)
     assert(files.exists(_.path.toString.contains("UserService.scala")))
     assert(files.exists(_.path.toString.contains("Model.scala")))
     assert(files.exists(_.path.toString.contains("Database.scala")))
@@ -36,7 +36,7 @@ class IndexSuite extends ScalexTestBase:
     val idx = WorkspaceIndex(workspace)
     idx.index()
 
-    assert(idx.fileCount == 21)
+    assert(idx.fileCount == 24)
     assert(idx.symbols.size > 10)
     assert(idx.packages.contains("com.example"))
     assert(idx.packages.contains("com.other"))
@@ -208,13 +208,13 @@ class IndexSuite extends ScalexTestBase:
     // First index — cold
     val idx1 = WorkspaceIndex(workspace)
     idx1.index()
-    assert(idx1.parsedCount == 21, s"Cold index should parse all 21 files, got ${idx1.parsedCount}")
+    assert(idx1.parsedCount == 24, s"Cold index should parse all 24 files, got ${idx1.parsedCount}")
 
     // Second index — warm (all cached)
     val idx2 = WorkspaceIndex(workspace)
     idx2.index()
     assert(idx2.cachedLoad, "Second index should load from cache")
-    assert(idx2.skippedCount == 21, s"Warm index should skip all 21 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 24, s"Warm index should skip all 24 files, got ${idx2.skippedCount}")
     assert(idx2.parsedCount == 0, s"Warm index should parse 0 files, got ${idx2.parsedCount}")
 
     // Symbols should be identical
@@ -238,7 +238,7 @@ class IndexSuite extends ScalexTestBase:
     idx2.index()
     assert(idx2.cachedLoad)
     assert(idx2.parsedCount == 1, s"Should re-parse 1 file, got ${idx2.parsedCount}")
-    assert(idx2.skippedCount == 20, s"Should skip 20 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 23, s"Should skip 23 files, got ${idx2.skippedCount}")
   }
 
   // ── Binary format ─────────────────────────────────────────────────────

--- a/tests/test-base.test.scala
+++ b/tests/test-base.test.scala
@@ -303,6 +303,60 @@ abstract class ScalexTestBase extends FunSuite:
         |}
         |""".stripMargin)
 
+    // File with nested local defs inside methods (#172)
+    writeFile("src/main/scala/com/example/Pipeline.scala",
+      """package com.example
+        |
+        |class Pipeline(steps: List[String]) {
+        |  def execute(): Unit = {
+        |    var count = 0
+        |    def runSteps(remaining: List[String]): Unit = {
+        |      remaining match {
+        |        case head :: tail =>
+        |          count += 1
+        |          runSteps(tail)
+        |        case Nil => ()
+        |      }
+        |    }
+        |    runSteps(steps)
+        |  }
+        |
+        |  def validate(): Boolean = {
+        |    def checkStep(step: String): Boolean = step.nonEmpty
+        |    steps.forall(checkStep)
+        |  }
+        |}
+        |
+        |object Pipeline {
+        |  def create(steps: String*): Pipeline = Pipeline(steps.toList)
+        |}
+        |""".stripMargin)
+
+    // Scala file with local def nested inside a wrapper call (#172)
+    writeFile("src/main/scala/com/example/Scheduler.scala",
+      """package com.example
+        |
+        |object Scheduler {
+        |  def schedule(tasks: List[String]): Unit = synchronized {
+        |    def processBatch(batch: List[String]): Int = {
+        |      batch.size
+        |    }
+        |    processBatch(tasks)
+        |  }
+        |}
+        |""".stripMargin)
+
+    // Java file with syntax that may trigger parser errors (#172)
+    writeFile("src/main/java/com/example/BrokenRecord.java",
+      """package com.example;
+        |
+        |// This sealed interface + record pattern can trigger JavaParser errors
+        |public sealed interface BrokenRecord permits BrokenRecord.Ok, BrokenRecord.Err {
+        |    record Ok(String value) implements BrokenRecord {}
+        |    record Err(String message) implements BrokenRecord {}
+        |}
+        |""".stripMargin)
+
     // Initialize git repo
     run("git", "init")
     run("git", "add", ".")


### PR DESCRIPTION
## Summary

Fixes four bugs reported in #172 while exploring the scala3 compiler codebase (~14k files):

- **Java parser crash**: `parseJavaSource` now catches `Error` (not just `Exception`) — fixes `NoSuchFieldError` from JavaParser on sealed interface/record syntax
- **`body` fallback ignoring filters**: Owner lookup fallback now applies `filterSymbols` so `--path`, `--no-tests`, `--exclude-path` are respected when resolving `--in` owner files
- **`body` can't find local defs**: Tree walker now recurses into def bodies and general AST nodes (`Term.Block`, `Term.Apply`, etc.) — finds nested local defs like `runPhases` inside `compileUnits`
- **Batch mode ignores per-line flags**: Each batch line now parses its own flags via `parseFlags` — previously `--path`, `--no-tests`, `--in`, etc. on batch lines were silently ignored and only top-level flags applied

Also refactors flag parsing into shared `parseFlags`/`flagsToContext` helpers, eliminating duplication between single-command and batch paths.

## Test plan

- [x] 18 new tests covering all four fixes (6 extraction + 12 CLI)
- [x] All 294 tests pass
- [x] Verified on scala3 benchmark: `body runPhases --in Run` finds local def at line 364
- [x] Verified on scala3 benchmark: `echo "explain Parser --path compiler/src/" | scalex batch` returns compiler Parser, not library Parser


🤖 Generated with [Claude Code](https://claude.com/claude-code)