### PR TITLE
release: v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.24.0] — 2026-03-18
+
+### Improved
+- Not-found hints now explain that scalex indexes top-level declarations only (local defs, parameters, and pattern bindings are not indexed) (#176)
+- Fallback suggestion now recommends `scalex grep` alongside Grep/Glob/Read tools (#176)
+- Batch mode not-found output includes "top-level only" note (#176)
+
 ## [1.23.0] — 2026-03-18
 
 ### Fixed

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.23.0"
+val ScalexVersion = "1.24.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to 1.24.0
- Add v1.24.0 changelog entry: improved not-found hints with indexing scope explanation and `scalex grep` fallback (#176)

🤖 Generated with [Claude Code](https://claude.com/claude-code)