### PR TITLE
release: v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.25.0] — 2026-03-18
+
 ### Added
 - `members --body` / `explain --body` — inline method bodies into member listings; eliminates N follow-up `body --in` calls (#180)
 - `--max-lines N` flag — only inline bodies ≤ N lines (0 = unlimited); works with `members`, `overrides`, and `explain` (#180)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.24.0"
+val ScalexVersion = "1.25.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.25.0` in `src/model.scala`
- Move `[Unreleased]` section in `CHANGELOG.md` to `[1.25.0] — 2026-03-18`

## What's in 1.25.0

- `members --body` / `explain --body` / `overrides --body` — inline method bodies into output (#180)
- `--max-lines N` — only inline bodies ≤ N lines (#180)
- `body -C N` — context lines around body span (#180)
- `body --imports` — prepend file's import block (#180)
- `grep --in <symbol>` — scope grep to a class/method body (#180)
- SKILL.md restructured for progressive disclosure (693 → 404 lines)

## After merge

1. Tag `v1.25.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)