### PR TITLE
release: v1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.27.0] — 2026-03-18
+
 ### Fixed
 - `members` companion section no longer duplicates the primary type's members — each side now shows only its own members (#184)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.26.0"
+val ScalexVersion = "1.27.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.27.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.27.0] — 2026-03-18`

## Post-merge
1. Tag `v1.27.0` and push → GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli` and `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)