### PR TITLE
fix: add missing changelog entries for v1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 - `members` companion section no longer duplicates the primary type's members — each side now shows only its own members (#184)
+- `members` now uses simple name for `extractMembers` lookup instead of fully qualified name
+- `explain` now respects `--kind` filter; fixed vacuous test assertion
 
 ## [1.26.0] — 2026-03-18
 


### PR DESCRIPTION
## Summary
- Add two missing fixes to the v1.27.0 changelog:
  - `members` simple name fix for `extractMembers` lookup (431a2d7)
  - `explain` now respects `--kind` filter + fixed vacuous test assertion (be6a799)

🤖 Generated with [Claude Code](https://claude.com/claude-code)