### PR TITLE
release: v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.28.0] — 2026-03-18
+
 ### Fixed
 - `overview --architecture` no longer shows duplicate "Most extended" section — hub types supersedes it (#192)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.27.0"
+val ScalexVersion = "1.28.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.28.0`
- Move `[Unreleased]` changelog entry to `[1.28.0] — 2026-03-18`

## Test plan
- [ ] Merge, tag `v1.28.0`, push tag — GitHub Actions builds native binaries + creates release
- [ ] Bump `EXPECTED_VERSION` in plugin bootstrap script post-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)