### PR TITLE
docs: update README example prompt to use generic domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Installs the binary + skill (teaches Claude when and how to use scalex) in one s
 
 Then try:
 
-> *"use scalex to explore how Signal propagation works in this codebase"*
+> *"use scalex to explore how authentication works in this codebase"*
 
 ### Other AI agents / manual install
 


### PR DESCRIPTION
## Summary
- Replace "Signal propagation" with "authentication" in the README's example prompt for a more universally relatable getting-started example

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)