### PR TITLE
site: add sample prompt section below quickstart

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -687,6 +687,16 @@
     </div>
   </section>
 
+  <!-- Try it -->
+  <section class="reveal" style="text-align: center;">
+    <h2>Try this <span class="red">prompt.</span></h2>
+    <p class="section-sub" style="margin: 0 auto 2rem;">Copy-paste this into Claude Code in any Scala project and watch it work.</p>
+
+    <div class="install-code" style="max-width: 640px; margin: 0 auto; text-align: left; font-size: 0.9rem;">
+      use scalex to explore how this project works
+    </div>
+  </section>
+
   <!-- Footer -->
   <footer>
     <p>


### PR DESCRIPTION
## Summary
- Adds a "Try this prompt" section between the install/quickstart and footer on the landing page
- Sample prompt: "use scalex to explore how this project works" — generic enough to work on any Scala codebase

## Test plan
- [ ] Open `site/index.html` in browser and verify the new section renders correctly
- [ ] Verify scroll-reveal animation works on the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)