### PR TITLE
site: move sample prompt below Claude Code install

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -658,6 +658,11 @@
       /plugin install scalex@scalex-marketplace
     </div>
 
+    <p style="color: var(--text-dim); font-size: 0.9rem; margin-top: 1.5rem;">Then try this prompt in any Scala project:</p>
+    <div class="install-code" style="font-size: 0.9rem;">
+      use scalex to explore how this project works
+    </div>
+
     <h3 style="color: var(--red); margin-bottom: 0.5rem; margin-top: 3rem;">Other AI agents / manual install</h3>
     <p class="section-sub" style="margin-bottom: 1.5rem;">Download the binary to <code style="color: var(--green); font-family: var(--font-mono); font-size: 0.85rem;">~/.local/bin</code>, then grab the skill.</p>
 
@@ -684,16 +689,6 @@
       <span class="comment"># Download it and place it wherever your agent reads skills from.</span><br>
       mkdir -p scalex<br>
       curl -fsSL https://raw.githubusercontent.com/nguyenyou/scalex/main/plugin/skills/scalex/SKILL.md -o scalex/SKILL.md
-    </div>
-  </section>
-
-  <!-- Try it -->
-  <section class="reveal" style="text-align: center;">
-    <h2>Try this <span class="red">prompt.</span></h2>
-    <p class="section-sub" style="margin: 0 auto 2rem;">Copy-paste this into Claude Code in any Scala project and watch it work.</p>
-
-    <div class="install-code" style="max-width: 640px; margin: 0 auto; text-align: left; font-size: 0.9rem;">
-      use scalex to explore how this project works
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Moves the "try this prompt" directly below the Claude Code install block instead of being a separate section at the bottom
- Removes the standalone section — the prompt now flows naturally after the install instructions

## Test plan
- [ ] Open `site/index.html` and verify the prompt appears right after the Claude Code install commands
- [ ] Verify layout looks good on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)