### PR TITLE
site: remove Lines of Code stat from hero

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -433,10 +433,6 @@
         <div class="stat-label">Warm Query</div>
       </div>
       <div class="stat">
-        <div class="stat-value">~3,100</div>
-        <div class="stat-label">Lines of Code</div>
-      </div>
-      <div class="stat">
         <div class="stat-value">0</div>
         <div class="stat-label">Dependencies on Build Server</div>
       </div>


### PR DESCRIPTION
## Summary
- Remove the "~3,100 Lines of Code" stat from the landing page hero section

## Test plan
- [ ] Verify the landing page renders correctly with 3 remaining stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)