### PR TITLE
fix: body --in searches owner file when symbol indexed elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `body --in` now also searches the owner's file when the symbol is indexed in a different file (#197)
+
 ## [1.28.0] — 2026-03-18
 
 ### Fixed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,10 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Bug fix: body --in owner file search (#197)
+
+- [x] When `--in Owner` is specified and the symbol is indexed in a different file, also search the owner's file for nested defs
+
 ### Community feedback: overview dedup & onboarding flow (#192)
 
 - [x] `overview --architecture` dedup — skip "Most extended" section when `--architecture` is active; "Hub types" already covers the same `parentIndex` data with identical sorting; applies to both text and JSON output

--- a/plugin/skills/scalex/SKILL.md
+++ b/plugin/skills/scalex/SKILL.md
@@ -191,7 +191,7 @@ scalex grep "ctx.settings" --in Run.compileUnits  # search within a specific met
 
 Extracts the full source body of a def, val, var, type, class, trait, object, or enum from the file using Scalameta spans. Eliminates ~50% of follow-up Read calls by giving the agent the actual source code inline.
 
-Use `--in <owner>` to restrict to members of a specific enclosing type — essential when the same method name exists in multiple classes. Use `-C N` to show N lines of context above and below the body span. Use `--imports` to prepend the file's import block.
+Use `--in <owner>` to restrict to members of a specific enclosing type — essential when the same method name exists in multiple classes. `--in` matches the **immediate enclosing type** (class/trait/object/enum); it finds nested defs at any method depth within that type, but does NOT cross into inner classes. For inner class members, use `--in InnerClass` directly. Use `-C N` to show N lines of context above and below the body span. Use `--imports` to prepend the file's import block.
 
 **Also works with test cases** — pass the exact test name string to extract a test body. Matches `test("name")`, `it("name")`, `describe("name")`, `"name" in { }`, and `"name" >> { }` patterns. Use `--in SuiteName` to scope to a specific suite.
 

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -3,18 +3,22 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
     case None => CmdResult.UsageError("Usage: scalex body <symbol> [--in <owner>]")
     case Some(symbol) =>
       // Find files containing the symbol
-      var defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
+      val defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
+      val ownerFiles = ctx.inOwner match
+        case Some(owner) =>
+          filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
+            .filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
+        case None => Nil
       val filesToSearch = if defs.nonEmpty then {
-        defs.map(_.file).distinct
+        // When --in is specified, also include the owner's files — the symbol may
+        // be indexed in a different file but also exist as a nested def in the owner
+        (defs.map(_.file).distinct ++ ownerFiles).distinct
       } else {
-        // If not found directly, search all files for member bodies
-        ctx.inOwner match
-          case Some(owner) =>
-            filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
-              .filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
-          case None =>
-            filterSymbols(ctx.idx.symbols.filter(s => typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
-              .map(_.file).distinct
+        // If not found directly, search owner files or all type files
+        if ownerFiles.nonEmpty then ownerFiles
+        else
+          filterSymbols(ctx.idx.symbols.filter(s => typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
+            .map(_.file).distinct
       }
       // Collect (file, body) pairs
       val blocks = filesToSearch.flatMap { f =>

--- a/tests/cli.test.scala
+++ b/tests/cli.test.scala
@@ -1632,6 +1632,23 @@ class CliSuite extends ScalexTestBase:
     assert(output.contains("batch.size"), s"Should contain body: $output")
   }
 
+  // ── #197: body --in finds nested def when same name is indexed elsewhere ──
+
+  test("body --in finds nested def when same name is indexed in a different file") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    // "create" is indexed as a top-level def in Pipeline.scala (Pipeline.create).
+    // It also exists as a local def inside Assembler.build().
+    // body create --in Assembler must search the owner's file, not just the indexed file.
+    val output = captureOut {
+      runCommand("body", List("create"),
+        CommandContext(idx = idx, workspace = workspace, inOwner = Some("Assembler")))
+    }
+    assert(output.contains("def create"), s"Should find local def create in Assembler: $output")
+    assert(output.contains("toUpperCase"), s"Should contain the body: $output")
+    assert(output.contains("Assembler"), s"Should mention Assembler as owner: $output")
+  }
+
   test("body on Java file does not crash with parser error") {
     val idx = WorkspaceIndex(workspace)
     idx.index()

--- a/tests/index.test.scala
+++ b/tests/index.test.scala
@@ -8,7 +8,7 @@ class IndexSuite extends ScalexTestBase:
 
   test("gitLsFiles finds all .scala files") {
     val files = gitLsFiles(workspace)
-    assertEquals(files.size, 24)
+    assertEquals(files.size, 25)
     assert(files.exists(_.path.toString.contains("UserService.scala")))
     assert(files.exists(_.path.toString.contains("Model.scala")))
     assert(files.exists(_.path.toString.contains("Database.scala")))
@@ -36,7 +36,7 @@ class IndexSuite extends ScalexTestBase:
     val idx = WorkspaceIndex(workspace)
     idx.index()
 
-    assert(idx.fileCount == 24)
+    assert(idx.fileCount == 25)
     assert(idx.symbols.size > 10)
     assert(idx.packages.contains("com.example"))
     assert(idx.packages.contains("com.other"))
@@ -208,13 +208,13 @@ class IndexSuite extends ScalexTestBase:
     // First index — cold
     val idx1 = WorkspaceIndex(workspace)
     idx1.index()
-    assert(idx1.parsedCount == 24, s"Cold index should parse all 24 files, got ${idx1.parsedCount}")
+    assert(idx1.parsedCount == 25, s"Cold index should parse all 25 files, got ${idx1.parsedCount}")
 
     // Second index — warm (all cached)
     val idx2 = WorkspaceIndex(workspace)
     idx2.index()
     assert(idx2.cachedLoad, "Second index should load from cache")
-    assert(idx2.skippedCount == 24, s"Warm index should skip all 24 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 25, s"Warm index should skip all 25 files, got ${idx2.skippedCount}")
     assert(idx2.parsedCount == 0, s"Warm index should parse 0 files, got ${idx2.parsedCount}")
 
     // Symbols should be identical
@@ -238,7 +238,7 @@ class IndexSuite extends ScalexTestBase:
     idx2.index()
     assert(idx2.cachedLoad)
     assert(idx2.parsedCount == 1, s"Should re-parse 1 file, got ${idx2.parsedCount}")
-    assert(idx2.skippedCount == 23, s"Should skip 23 files, got ${idx2.skippedCount}")
+    assert(idx2.skippedCount == 24, s"Should skip 24 files, got ${idx2.skippedCount}")
   }
 
   // ── Binary format ─────────────────────────────────────────────────────

--- a/tests/test-base.test.scala
+++ b/tests/test-base.test.scala
@@ -357,6 +357,23 @@ abstract class ScalexTestBase extends FunSuite:
         |}
         |""".stripMargin)
 
+    // #197: Symbol indexed in one file, also exists as nested def in a different class
+    // "create" is already indexed as Pipeline.create. This file adds a class
+    // whose method has a local def also named "create" — body --in Assembler
+    // must find it even though "create" is indexed elsewhere.
+    writeFile("src/main/scala/com/example/Assembler.scala",
+      """package com.example
+        |
+        |class Assembler(parts: List[String]) {
+        |  def build(): String = {
+        |    def create(part: String): String = {
+        |      part.toUpperCase
+        |    }
+        |    parts.map(create).mkString(", ")
+        |  }
+        |}
+        |""".stripMargin)
+
     // Initialize git repo
     run("git", "init")
     run("git", "add", ".")


### PR DESCRIPTION
## Summary

- When `--in Owner` is specified and the symbol name is also indexed in a different file, `body` now includes the owner's file in the search set — previously it only searched the indexed file, missing nested defs in the owner
- Clarified `--in` scoping behavior in SKILL.md: matches immediate enclosing type, unlimited depth through methods, does not cross inner class boundaries
- Regression test verifying the fix against the exact scenario (symbol indexed in one file, nested def in a different owner class)

Closes #197

## Test plan

- [x] New test: `body --in finds nested def when same name is indexed in a different file` — verified it fails on old code (at `toUpperCase` assertion) and passes with the fix
- [x] All 347 existing tests pass
- [x] Zero compiler warnings
- [x] Validated against real Scala.js codebase: `body genBody --in JSCodePhase` now works

🤖 Generated with [Claude Code](https://claude.ai/code)