### PR TITLE
release: v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.29.0] — 2026-03-18
+
 ### Added
 - `members`: `--limit 0` shows all members (no truncation); `--offset N` for pagination (#198)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.28.0"
+val ScalexVersion = "1.29.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.29.0`
- Move unreleased changelog entries to `[1.29.0] — 2026-03-18`

## What's in this release
- `members`: `--limit 0` shows all members; `--offset N` for pagination (#198)
- `body --in` now searches the owner's file when the symbol is indexed elsewhere (#197)

## Post-merge steps
1. Tag `v1.29.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.ai/code)