### PR TITLE
release: bump version to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## [Unreleased]
 
+## [1.30.0] — 2026-03-18
+
 ### Added
 - `graph` command: render directed graphs as ASCII/Unicode art and parse diagrams back into structured data
   - `graph --render "A->B, B->C"` — Sugiyama-style layered layout
   - `graph --parse` — extract boxes, edges, labels from ASCII art (stdin)
   - Flags: `--unicode`/`--no-unicode`, `--vertical`/`--horizontal`, `--rounded`, `--double`, `--json`
   - Ported from [ascii-graphs](https://github.com/scalameta/ascii-graphs) (45 Scala 2 files consolidated into 11 Scala 3.8 files)
+- `docs/ARCHITECTURE.md` — project architecture documented with `scalex graph`-generated diagrams
+
+### Fixed
+- Replace deprecated Scalameta `.stats` with `.body.stats` on `Pkg` and `Template` (9 call sites) (#210)
 
 ## [1.29.0] — 2026-03-18
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.29.0"
+val ScalexVersion = "1.30.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.30.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.30.0] — 2026-03-18`

### What's in 1.30.0

**Added:**
- `graph` command — render directed graphs as ASCII/Unicode art (`--render`) and parse diagrams back into structured data (`--parse`)
- `docs/ARCHITECTURE.md` — project architecture documented with `scalex graph`-generated diagrams

**Fixed:**
- Replace deprecated Scalameta `.stats` with `.body.stats` on `Pkg` and `Template` (9 call sites) (#210)

## Test plan

- [x] `scala-cli compile src/` — zero warnings
- [x] All 385 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)