### PR TITLE
feat: add memory profiling layer to benchmark skill

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark
-description: "Run scalex performance benchmarks, profiling, and timing analysis. Use this skill whenever the user asks to benchmark scalex, measure performance, profile index/query times, compare before/after performance of a change, investigate bottlenecks, or mentions \"benchmark\", \"perf\", \"how fast\", \"timing\", \"hyperfine\", \"profile\", \"flame graph\", \"profiling\", \"--timings\", \"slow\", \"bottleneck\", \"regression\". Also use proactively after implementing performance improvements to verify gains. Covers 5 layers: built-in --timings, hyperfine benchmarks, async-profiler flame graphs, JFR recording, and microbenchmarks."
+description: "Run scalex performance benchmarks, profiling, and timing analysis. Use this skill whenever the user asks to benchmark scalex, measure performance, profile index/query times, compare before/after performance of a change, investigate bottlenecks, or mentions \"benchmark\", \"perf\", \"how fast\", \"timing\", \"hyperfine\", \"profile\", \"flame graph\", \"profiling\", \"--timings\", \"slow\", \"bottleneck\", \"regression\", \"memory\", \"heap\", \"GC\", \"allocation\". Also use proactively after implementing performance improvements to verify gains. Covers 6 layers: built-in --timings, hyperfine benchmarks, async-profiler flame graphs, JFR recording, microbenchmarks, and memory profiling."
 ---
 
 ## Overview
@@ -14,6 +14,7 @@ Scalex has a multi-layered profiling and benchmarking system. Pick the right lay
 | 3. async-profiler | `profiling/profile.sh` | Deep CPU/alloc/lock flame graphs to find hotspots | JVM only |
 | 4. JFR | `profiling/scalex.jfc` | GC pressure, file I/O patterns, thread utilization | JVM only |
 | 5. Microbenchmarks | `src/bench.scala` | Isolate per-function cost with warmup + statistics | JVM only |
+| 6. Memory profiling | `bench.sh memory` | Heap usage, GC pressure, peak memory across scenarios | JVM only |
 
 ## Decision guide
 
@@ -28,6 +29,10 @@ Scalex has a multi-layered profiling and benchmarking system. Pick the right lay
 **"Is there GC pressure?"** → JFR (Layer 4)
 
 **"How fast is extractSymbols on one file?"** → Microbenchmark (Layer 5)
+
+**"How much memory does indexing use?"** → Memory profiling (Layer 6)
+
+**"Is there a memory leak or GC regression?"** → Memory profiling before/after (Layer 6)
 
 ---
 
@@ -99,6 +104,7 @@ Reproducible, statistical benchmarks using [hyperfine](https://github.com/sharkd
 .claude/skills/benchmark/scripts/bench.sh query
 .claude/skills/benchmark/scripts/bench.sh diverse    # miss, heavy refs, fuzzy, grep, hierarchy
 .claude/skills/benchmark/scripts/bench.sh timings    # --timings output for cold/warm/refs
+.claude/skills/benchmark/scripts/bench.sh memory     # heap usage, GC pressure (JVM only)
 
 # Custom runs/binary
 BENCH_RUNS=10 SCALEX_BIN=./target/scalex .claude/skills/benchmark/scripts/bench.sh
@@ -236,6 +242,90 @@ scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3 --w
 | `index-cold` | Full cold index including map building |
 
 Reports: mean, median, p99, stddev, min, max per benchmark.
+
+---
+
+## Layer 6: Memory profiling (`bench.sh memory`)
+
+Measures heap usage, GC pressure, and peak memory across three scenarios: cold index (full parse), warm index (cache load), and refs query. Uses JVM GC logging via `-Xlog:gc*` — requires scala-cli (JVM mode), not native binary.
+
+### Running
+
+```bash
+# Full memory profile (cold + warm + refs)
+.claude/skills/benchmark/scripts/bench.sh memory
+```
+
+No prerequisites beyond scala-cli. Does not require hyperfine or native binary.
+
+### Output
+
+Reports per-scenario: phase timings (from `--timings`), then memory stats:
+
+```
+--- Cold index (full parse, ~17.7k files) ---
+  git-ls-files            60.7 ms  ( 1%)
+  parse                 5576.5 ms  (94%)
+  cache-save             228.7 ms  ( 4%)
+  total                 5952.2 ms
+
+  Peak pre-GC heap:        790 MB
+  Heap at exit (used):     676 MB
+  Heap at exit (committed): 1184 MB
+  GC pauses:               34
+  Total GC pause time:     185.3 ms
+```
+
+Ends with a summary table:
+
+```
+=== Memory Summary ===
+
+Scenario             Peak Heap      Exit Used    Exit Commit     GC #
+--------             ---------      ---------    -----------     ----
+Cold index              790 MB       676.2 MB      1184.0 MB       34
+Warm index              256 MB       271.8 MB       584.0 MB        2
+refs Phase               53 MB        29.7 MB        56.0 MB        0
+```
+
+### Reading the output
+
+- **Peak pre-GC heap**: Highest live heap before any GC — the true high-water mark. This is the number that determines minimum `-Xmx` for constrained environments.
+- **Heap at exit (used)**: Retained heap at process exit — the steady-state footprint of the loaded index + results.
+- **Heap at exit (committed)**: OS-committed memory — what the JVM actually reserved. Higher than "used" because G1 keeps headroom.
+- **GC pauses**: Number of young-gen collections. High count during cold index is normal (Scalameta ASTs are short-lived).
+- **Total GC pause time**: Sum of all GC pauses. Should be small relative to wall time (<5%).
+
+### What to watch for
+
+- **Cold peak > 1 GB**: `parallelStream` is creating too many concurrent ASTs. Consider batching files in chunks.
+- **Warm used > 400 MB**: Index deserialization is holding too much data. Check if lazy maps are working.
+- **Refs used > 100 MB**: Text search is accumulating results. Check if bloom filtering is effective.
+- **GC time > 10% of wall time**: GC pressure is impacting performance. Look at allocation hotspots (async-profiler alloc, Layer 3).
+
+### Baseline ranges (scala3 corpus, 17.7k files, ~38k symbols)
+
+| Scenario | Peak Heap | Exit Used | GC Pauses |
+|----------|-----------|-----------|-----------|
+| Cold index | 700-900 MB | 600-700 MB | 30-70 |
+| Warm index | 200-300 MB | 250-300 MB | 1-3 |
+| refs query | 30-60 MB | 25-35 MB | 0-1 |
+
+### Ad-hoc memory profiling
+
+For one-off measurements without the script:
+
+```bash
+# Run any scalex command with GC logging to a temp file
+scala-cli run src/ \
+  --java-opt "-Xlog:gc*=info:file=/tmp/scalex-gc.log" \
+  -- overview benchmark/scala3
+
+# Check peak heap
+grep -o '[0-9]*M->' /tmp/scalex-gc.log | sed 's/M->//' | sort -n | tail -1
+# Check exit heap
+grep "garbage-first" /tmp/scalex-gc.log | tail -1
+```
 
 ---
 

--- a/.claude/skills/benchmark/scripts/bench.sh
+++ b/.claude/skills/benchmark/scripts/bench.sh
@@ -129,6 +129,85 @@ run_query_diverse() {
   echo ""
 }
 
+# ── Memory profiling (JVM only) ────────────────────────────────────────────
+
+run_memory() {
+  echo "=== Memory Profiling (JVM mode via scala-cli) ==="
+  echo ""
+  echo "Note: Runs via scala-cli (not native binary) to access JVM GC logs."
+  echo ""
+
+  local HEAP_LOG
+  HEAP_LOG=$(mktemp /tmp/scalex-gc-XXXXXX.log)
+
+  parse_gc_stats() {
+    local log="$1" label="$2"
+    local peak exit_used_k exit_committed_k gc_count gc_time_ms
+    peak=$(grep -o '[0-9]*M->' "$log" | sed 's/M->//' | sort -n | tail -1)
+    exit_used_k=$(grep "garbage-first" "$log" | grep -o 'used [0-9]*K' | sed 's/[^0-9]//g' | tail -1)
+    exit_committed_k=$(grep "garbage-first" "$log" | grep -o 'committed [0-9]*K' | sed 's/[^0-9]//g' | tail -1)
+    gc_count=$(grep -c "Pause Young" "$log" 2>/dev/null || echo "0")
+    gc_time_ms=$(grep "Pause Young" "$log" | grep -oE '[0-9]+\.[0-9]+ms$' | sed 's/ms//' | awk '{s+=$1} END {printf "%.1f", s}')
+    local exit_used_mb exit_committed_mb
+    exit_used_mb=$(echo "scale=1; ${exit_used_k:-0} / 1024" | bc)
+    exit_committed_mb=$(echo "scale=1; ${exit_committed_k:-0} / 1024" | bc)
+
+    printf "  %-26s %s\n" "Peak pre-GC heap:" "${peak:-n/a} MB"
+    printf "  %-26s %s\n" "Heap at exit (used):" "${exit_used_mb} MB"
+    printf "  %-26s %s\n" "Heap at exit (committed):" "${exit_committed_mb} MB"
+    printf "  %-26s %s\n" "GC pauses:" "${gc_count}"
+    printf "  %-26s %s\n" "Total GC pause time:" "${gc_time_ms} ms"
+
+    # Store for summary table
+    eval "${label}_PEAK=\"${peak:-n/a}\""
+    eval "${label}_USED=\"${exit_used_mb}\""
+    eval "${label}_COMMITTED=\"${exit_committed_mb}\""
+    eval "${label}_GC=\"${gc_count}\""
+  }
+
+  # --- Cold index (full parse) ---
+  echo "--- Cold index (full parse, ~17.7k files) ---"
+  rm -rf "$SCALA3_DIR/.scalex"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "COLD"
+  echo ""
+
+  # --- Warm index (cache load) ---
+  echo "--- Warm index (cache load) ---"
+  > "$HEAP_LOG"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "WARM"
+  echo ""
+
+  # --- Refs query (text search across files) ---
+  echo "--- refs Phase (warm cache, text search) ---"
+  > "$HEAP_LOG"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings refs "$SCALA3_DIR" Phase 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "REFS"
+  echo ""
+
+  # --- Summary table ---
+  echo "=== Memory Summary ==="
+  echo ""
+  printf "%-20s %14s %14s %14s %8s\n" "Scenario" "Peak Heap" "Exit Used" "Exit Commit" "GC #"
+  printf "%-20s %14s %14s %14s %8s\n" "--------" "---------" "---------" "-----------" "----"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "Cold index" "$COLD_PEAK" "$COLD_USED" "$COLD_COMMITTED" "$COLD_GC"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "Warm index" "$WARM_PEAK" "$WARM_USED" "$WARM_COMMITTED" "$WARM_GC"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "refs Phase" "$REFS_PEAK" "$REFS_USED" "$REFS_COMMITTED" "$REFS_GC"
+  echo ""
+
+  rm -f "$HEAP_LOG"
+}
+
 # ── Timings breakdown ───────────────────────────────────────────────────────
 
 run_timings() {
@@ -154,6 +233,7 @@ case "$MODE" in
   query)   run_query ;;
   diverse) run_query_diverse ;;
   timings) run_timings ;;
+  memory)  run_memory ;;
   all)
     run_cold
     run_warm
@@ -163,7 +243,7 @@ case "$MODE" in
     report_index_size
     ;;
   *)
-    echo "Usage: $0 [cold|warm|query|diverse|timings|all]"
+    echo "Usage: $0 [cold|warm|query|diverse|timings|memory|all]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- Add `bench.sh memory` mode that profiles heap usage, GC pressure, and peak memory across 3 scenarios (cold index, warm index, refs query) using JVM GC logging (`-Xlog:gc*`)
- Add Layer 6 documentation to SKILL.md with baselines, warning thresholds, and ad-hoc profiling commands
- Trigger keywords: "memory", "heap", "GC", "allocation"

## Test plan
- [x] Ran `bench.sh memory` end-to-end on scala3 corpus (17.7k files) — produces correct summary table
- [ ] Verify skill triggers on memory-related queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)