### PR TITLE
release: v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.32.0] — 2026-03-18
+
 ### Added
 - `explain --related` — show project-defined types referenced in member signatures as "Related types" section (#221)
 - `package --explain` — composite mode: brief explain per type with definition, top 3 members, and impl count (#221)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.31.0"
+val ScalexVersion = "1.32.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` to `1.32.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[1.32.0] — 2026-03-18`

## After merge

1. Tag `v1.32.0` and push — GitHub Actions builds native binaries + creates release
2. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)