### PR TITLE
chore: release v1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.33.0] — 2026-03-19
+
 ### Fixed
 - `explain --related` no longer resolves stdlib/language type names (e.g. `Option`, `List`, `String`, `Future`) to unrelated project types (#228)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.32.0"
+val ScalexVersion = "1.33.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to 1.33.0
- Move Unreleased changelog entries to [1.33.0] — 2026-03-19

## Test plan
- [ ] Merge, tag `v1.33.0`, push tag to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)