### PR TITLE
docs: update grep comparison numbers to current results

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ scalex def Compiler --kind class
   class  Compiler (dotty.tools.pc) — .../CompletionValue.scala:127
 ```
 
-**Grep** — 1 call, **24 results**: `class Compiler|trait Compiler|object Compiler` matches `CompilerOptions`, `CompilerHang`, `CompilerTest`, `CompilerCommand` (substring noise). No package info, no kind filtering. Agent must write follow-up regex to exclude substrings.
+**Grep** — 1 call, **23 results**: `class Compiler|trait Compiler|object Compiler` matches `CompilerSearchVisitor`, `CompilerCachingSuite`, `CompilerTest`, `CompilerCommand` (substring noise). No package info, no kind filtering. Agent must write follow-up regex to exclude substrings.
 
 **Why scalex wins**: Exact name matching + `--kind` filter + package disambiguation. One call, done.
 


### PR DESCRIPTION
## Summary
- Reran all 4 comparison cases (`def`, `hierarchy`, `refs`, `imports`) against the scala3 benchmark
- Grep def count: 24 → 23
- Updated false positive names: `CompilerOptions`, `CompilerHang` → `CompilerSearchVisitor`, `CompilerCachingSuite` (actual current matches)
- All other numbers unchanged: refs 283, imports 1,205 vs 17, hierarchy tree identical

## Test plan
- [ ] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)