### PR TITLE
docs: link Why Scalex points to detailed sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 2. **Zero setup. Just works.** Install the skill, point it at any git repo, start navigating. No build files, no config, no "import build" dialog, no "connecting to build server". Clone a repo you've never seen and explore it in seconds.
 
-3. **Smarter than grep.** Categorized references with confidence ranking. Wildcard import resolution (finds 1,205 importers where grep finds 17). Transitive inheritance trees. Structural AST search. Things grep fundamentally cannot do.
+3. **Smarter than grep.** Categorized references with confidence ranking. Wildcard import resolution (finds 1,205 importers where grep finds 17). Transitive inheritance trees. Structural AST search. Things grep fundamentally cannot do. See the [honest comparison](#scalex-vs-grep--honest-comparison) for real examples.
 
-4. **One call, not five.** `explain` returns definition + scaladoc + members + implementations + import count in one shot. `refs --count` triages impact in one line. Designed to minimize tool calls — the biggest cost for AI agents isn't latency, it's the number of round trips.
+4. **One call, not five.** `explain` returns definition + scaladoc + members + implementations + import count in one shot. `refs --count` triages impact in one line. Designed to minimize tool calls — the biggest cost for AI agents isn't latency, it's the number of round trips. See [what makes it AI-friendly](#what-makes-it-ai-friendly) for the full picture.
 
 ---
 


### PR DESCRIPTION
## Summary
- "Smarter than grep" → links to [Scalex vs Grep — Honest Comparison](#scalex-vs-grep--honest-comparison)
- "One call, not five" → links to [What Makes It AI-Friendly](#what-makes-it-ai-friendly)

## Test plan
- [ ] Verify anchor links work on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)