### PR TITLE
release: v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.34.0] — 2026-03-19
+
 ### Fixed
 - Owner.Member dotted syntax (`Outer.Inner`) now works across all commands: `members`, `hierarchy`, `impl`, `def`, `explain`, and `body --in` (#239)
 - `def Outer.Inner` no longer duplicates results (#239)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.33.0"
+val ScalexVersion = "1.34.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.34.0`
- Move unreleased changelog entries to `[1.34.0] — 2026-03-19`

## Changes in this release
- **Fixed**: Owner.Member dotted syntax (`Outer.Inner`) now works across all commands (#239)
- **Fixed**: `def Outer.Inner` no longer duplicates results (#239)
- **Fixed**: `explain Outer.Inner` now includes members section (#239)

## Post-merge
- Tag `v1.34.0` and push — GitHub Actions builds native binaries + creates release
- Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
- Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)