### PR TITLE
security: harden binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -27,15 +29,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # v1
         with:
           java-version: '21'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: VirtusLab/scala-cli-setup@v1
+      - uses: VirtusLab/scala-cli-setup@59e308800210b0414d2d7190068c80021e1b3e5d # v1
         with:
           power: true
           jvm: graalvm-java21
@@ -54,7 +56,7 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ matrix.artifact }}
           path: |
@@ -65,14 +67,30 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
       - name: Make binaries executable
         run: chmod +x artifacts/*/scalex-macos-* artifacts/*/scalex-linux-*
+
+      - name: Generate combined checksums
+        run: |
+          cd artifacts
+          shasum -a 256 */scalex-macos-arm64 */scalex-macos-x64 */scalex-linux-x64 | sed 's|[^/]*/||' > ../checksums.txt
+          cd ..
+          echo "Generated checksums.txt:"
+          cat checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            artifacts/*/scalex-macos-arm64
+            artifacts/*/scalex-macos-x64
+            artifacts/*/scalex-linux-x64
 
       - name: Extract changelog
         id: changelog
@@ -84,8 +102,9 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
             artifacts/*/scalex-*
+            checksums.txt
           body: ${{ steps.changelog.outputs.body }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,9 @@ The bootstrap script `scalex-cli` contains `EXPECTED_VERSION` that must be bumpe
 
 ### Step 3: Plugin version bump
 5. Bump `EXPECTED_VERSION` in `plugin/skills/scalex/scripts/scalex-cli`
-6. Bump `version` in `.claude-plugin/marketplace.json` (plugin version is only managed here, not in `plugin/.claude-plugin/plugin.json`)
-7. Commit, push to main
+6. Update `CHECKSUM_scalex_*` values in `scalex-cli` — get hashes from `checksums.txt` or individual `.sha256` release assets (`gh release download vX.Y.Z -p checksums.txt -O -`)
+7. Bump `version` in `.claude-plugin/marketplace.json` (plugin version is only managed here, not in `plugin/.claude-plugin/plugin.json`)
+8. Commit, push to main
 
 Note: `marketplace.json` is at the repo root (`.claude-plugin/marketplace.json`), NOT inside `plugin/`.
 
@@ -160,3 +161,4 @@ When adding or changing commands/flags in `src/cli.scala`:
 - **`refs`/`imports` use text search**: They use bloom filters to shortlist candidate files, then do word-boundary text matching. They are NOT index-based and have a 20-second timeout.
 - **Scala 3 indentation in `WorkspaceIndex`**: Deeply nested code can break method boundaries — use brace syntax for nested blocks
 - **Test fixture file counts**: Tests hardcode file counts — adding/removing fixtures requires updating all count assertions
+- **GitHub Actions SHA pinning**: All actions in `release.yml` are pinned to commit SHAs. To verify/update: `git ls-remote --refs https://github.com/<owner>/<repo>.git refs/tags/<tag>`. Never trust SHAs from memory or LLM output without verifying.

--- a/plugin/skills/scalex/scripts/scalex-cli
+++ b/plugin/skills/scalex/scripts/scalex-cli
@@ -10,6 +10,11 @@ set -euo pipefail
 EXPECTED_VERSION="1.34.0"
 REPO="nguyenyou/scalex"
 
+# Expected SHA-256 checksums for each artifact (updated each release alongside EXPECTED_VERSION)
+CHECKSUM_scalex_macos_arm64="76f993d9ebb000ab2d518c6d51d2225144392f1e98de1f7a2cc04fc6949e3738"
+CHECKSUM_scalex_macos_x64="8fabf84f291b28114a138a1199c7f17632fbcba3812266de21f15099ddc4bf08"
+CHECKSUM_scalex_linux_x64="c2124fe1558215da7e8d13154c322aa64613ec33a095abb9b8b88b8a88cd574c"
+
 # Cache location: follow XDG spec (like Mill uses ~/.cache/mill/download/)
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex"
 
@@ -42,6 +47,20 @@ curl -f -L -o "$TMP" "${BASE_URL}/${ARTIFACT}" || {
   echo "scalex: download failed. Visit https://github.com/${REPO}/releases" >&2
   exit 1
 }
+
+# Verify checksum
+CHECKSUM_VAR="CHECKSUM_${ARTIFACT//-/_}"
+EXPECTED_HASH="${!CHECKSUM_VAR}"
+if [ -n "$EXPECTED_HASH" ]; then
+  ACTUAL_HASH=$(shasum -a 256 "$TMP" | awk '{print $1}')
+  if [ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]; then
+    echo "scalex: checksum verification FAILED" >&2
+    echo "  expected: $EXPECTED_HASH" >&2
+    echo "  actual:   $ACTUAL_HASH" >&2
+    echo "  The downloaded binary may have been tampered with." >&2
+    exit 1
+  fi
+fi
 
 # Install atomically
 chmod +x "$TMP"


### PR DESCRIPTION
## Summary

- Pin all 8 GitHub Actions in `release.yml` to commit SHAs (verified via `git ls-remote`), preventing tag-mutation attacks like the tj-actions compromise
- Add SLSA build provenance attestation (`actions/attest-build-provenance@v2`) so users can verify with `gh attestation verify`
- Generate combined `checksums.txt` uploaded as a release asset alongside individual `.sha256` files
- Add SHA-256 checksum verification in the bootstrap script (`scalex-cli`) — aborts with clear error if downloaded binary doesn't match expected hash
- Update `CLAUDE.md` release workflow docs and gotchas for the new checksum + SHA-pinning steps

## Test plan

- [x] `grep -c '@[0-9a-f]\{40\}' .github/workflows/release.yml` returns 8
- [x] `bash -n plugin/skills/scalex/scripts/scalex-cli` passes syntax check
- [x] Checksum verification logic: correct hash passes, wrong hash aborts
- [ ] Next tag push exercises full pipeline (attestation + checksums.txt generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)