### PR TITLE
chore: bump version to 1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.35.0] — 2026-03-19
+
 ### Added
 - `overview --concise` — fixed-size summary (~60 lines) regardless of codebase size; compact header, inline symbols, top packages, dep stats (not full graph), hub types, and drill-down hints; implies `--architecture` (#248)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.34.0"
+val ScalexVersion = "1.35.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `ScalexVersion` in `src/model.scala` to `1.35.0`
- Move `[Unreleased]` section in `CHANGELOG.md` to `[1.35.0] — 2026-03-19`

After merge: tag as `v1.35.0`, push tag to trigger release workflow, then bump plugin `EXPECTED_VERSION` + checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)