### PR TITLE
chore: release 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.36.0] — 2026-03-20
+
 ### Added
 - `--max-output N` — global character budget that truncates any command's output at N characters with a pagination hint; works on all commands including batch mode (#252)
 - `--in-package PKG` — filter symbols and references to files whose package matches PKG prefix; cheaper than `--path` for cross-compiled projects where package != directory (#252)

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.35.0"
+val ScalexVersion = "1.36.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.36.0` in `src/model.scala`
- Move unreleased changelog entries under `[1.36.0] — 2026-03-20`

## New in 1.36.0
- `--max-output N` — global character budget for output truncation
- `--in-package PKG` — filter symbols/refs by package prefix
- `grep --in <Type> --each-method` — grep each method body of a type

## Post-merge
- [ ] Tag `v1.36.0` and push — triggers GitHub Actions release
- [ ] Bump `EXPECTED_VERSION` + checksums in `plugin/skills/scalex/scripts/scalex-cli`
- [ ] Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)