### PR TITLE
fix: add explicit width/height to mascot img to prevent layout shift

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -941,6 +941,8 @@
     <section class="slide title-slide" data-slide="0">
       <div class="slide-content">
         <img
+          width="127"
+          height="180"
           src="Kestrel.png"
           alt="Scalex Kestrel"
           class="mascot-img reveal"


### PR DESCRIPTION
## Summary
- Add explicit `width="127"` and `height="180"` attributes to the Kestrel mascot `<img>` in `site/index.html`
- Prevents Cumulative Layout Shift (CLS) by reserving space before the image loads

## Test plan
- [ ] Open the site and verify the mascot image renders correctly
- [ ] Confirm no layout shift when the page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)