### PR TITLE
docs: update production monorepo benchmark numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Here's the architecture (generated with `scalex graph --render`):
 
 | Project | Files | Symbols | Cold Index | Warm Index |
 |---|---|---|---|---|
-| Production monorepo | 13,979 | 214,301 | 4.6s | 540ms |
+| Production monorepo | 14,219 | 170,094 | 5.3s | 445ms |
 | Scala 3 compiler | 18,485 | 144,211 | 2.7s | 349ms |
 
 ## Quick Start

--- a/site/index.html
+++ b/site/index.html
@@ -1299,10 +1299,10 @@
             <tbody>
               <tr>
                 <td>Production monorepo</td>
-                <td>13,979</td>
-                <td>214,301</td>
-                <td>4.6s</td>
-                <td class="fast">540ms</td>
+                <td>14,219</td>
+                <td>170,094</td>
+                <td>5.3s</td>
+                <td class="fast">445ms</td>
               </tr>
               <tr>
                 <td>Scala 3 compiler</td>


### PR DESCRIPTION
## Summary
- Re-ran scalex benchmarks on the latest production monorepo (14,219 files, 170k symbols)
- Updated performance table in README.md and site/index.html
- Warm index improved from 540ms → 445ms

## Test plan
- [ ] Verify README table renders correctly
- [ ] Verify site/index.html table displays updated numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)