### PR TITLE
Release 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased]
 
+## [1.37.0] — 2026-03-22
+
 ### Fixed
 - `grep` no longer errors on invalid regex patterns (e.g. `MyRenderer(`) — auto-quotes them as literal strings instead of failing with "Invalid regex: Unclosed group"
 
 ### Changed
 - `tests --count` now reports dynamic test sites (string interpolation, concatenation) alongside literal test count; output format changed from `N suites, M tests` to `M tests (literal names only) across N suites` with dynamic site count when detected (#259)
+- Plugin directory reorganized: `plugin/` → `plugins/scalex/` and `plugins/scalex-intellij/` (separate plugin, v1.0.0)
 
 ## [1.36.0] — 2026-03-20
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.36.0"
+val ScalexVersion = "1.37.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.37.0`
- Move `[Unreleased]` changelog to `[1.37.0] — 2026-03-22`

### What's in 1.37.0
- **Fixed**: `grep` auto-quotes invalid regex patterns as literal strings instead of erroring
- **Changed**: `tests --count` reports dynamic test sites alongside literal count
- **Changed**: Plugin directory reorganized to `plugins/scalex/` + `plugins/scalex-intellij/` (v1.0.0)

## Test plan
- [x] Compiles with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)