### PR TITLE
Bump version to 1.38.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.38.0] — 2026-03-22
+
 ### Fixed
 - `grep` with POSIX-style `\|` alternation (e.g. `Optimizer\|IncOptimizer`) now correctly converts to Java regex alternation instead of silently matching literal pipe characters — previously returned zero results because `\|` is valid Java regex (literal `|`)
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.37.0"
+val ScalexVersion = "1.38.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `ScalexVersion` to `1.38.0` in `src/model.scala`
- Move `[Unreleased]` changelog to `[1.38.0] — 2026-03-22`

## What's in 1.38.0
- Fix `grep` POSIX `\|` alternation returning zero results

## Post-merge
Tag as `v1.38.0`, push tag — GitHub Actions builds native binaries + creates release. Then bump `EXPECTED_VERSION` + checksums in `plugins/scalex/skills/scalex/scripts/scalex-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)