### PR TITLE
Fix release-semanticdb: find artifacts dynamically

### DIFF
--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -52,20 +52,23 @@ jobs:
         with:
           path: artifacts
 
-      - name: Make binary executable
-        run: chmod +x artifacts/scalex-sdb/scalex-sdb
+      - name: Locate artifacts
+        run: find artifacts -type f | sort
 
-      - name: Generate checksum
+      - name: Prepare release files
         run: |
-          shasum -a 256 artifacts/scalex-sdb/scalex-sdb | sed 's|.*/||' > checksums.txt
-          echo "Generated checksums.txt:"
-          cat checksums.txt
+          # Find the binary wherever download-artifact placed it
+          SDB=$(find artifacts -name "scalex-sdb" -not -name "*.sha256" -type f)
+          echo "Found binary at: $SDB"
+          chmod +x "$SDB"
+          # Copy to workspace root for predictable paths
+          cp "$SDB" scalex-sdb
+          cp "${SDB}.sha256" scalex-sdb.sha256 2>/dev/null || shasum -a 256 scalex-sdb > scalex-sdb.sha256
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
-          subject-path: |
-            artifacts/scalex-sdb/scalex-sdb
+          subject-path: scalex-sdb
 
       - name: Extract changelog
         id: changelog
@@ -80,7 +83,6 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
-            artifacts/scalex-sdb/scalex-sdb
-            artifacts/scalex-sdb/scalex-sdb.sha256
-            checksums.txt
+            scalex-sdb
+            scalex-sdb.sha256
           body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
download-artifact v8 layout is unpredictable — sometimes `artifacts/name/file`, sometimes flat. Use `find` to locate the binary and copy to workspace root.

Also adds a debug step to print the actual artifact layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)