### PR TITLE
Add sdb-v0.1.0 checksum to bootstrap script

### DIFF
--- a/plugins/scalex-semanticdb/skills/scalex-sdb/scripts/scalex-sdb-cli
+++ b/plugins/scalex-semanticdb/skills/scalex-sdb/scripts/scalex-sdb-cli
@@ -12,7 +12,7 @@ REPO="nguyenyou/scalex"
 ARTIFACT="scalex-sdb"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_scalex_sdb=""
+CHECKSUM_scalex_sdb="fb8cf80d83951d56b0034b6a7c7df4427614d4c6596fcaf5e408f9598bc62e4f"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
Adds SHA-256 checksum for the sdb-v0.1.0 release binary to `scalex-sdb-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)