### PR TITLE
Simplify install docs for other coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,21 @@ Then try:
 
 > *"use scalex to explore how authentication works in this codebase"*
 
-### Other coding agents / manual install
+### Other coding agents
 
-**1. Install the binary** to `~/.local/bin`:
+Copy the skill folder to wherever your agent reads skills — that's it. The included bootstrap script auto-downloads and caches the native binary on first run.
+
+```bash
+# Clone and copy the skill folder
+git clone --depth 1 https://github.com/nguyenyou/scalex.git /tmp/scalex
+cp -r /tmp/scalex/plugins/scalex/skills/scalex /path/to/your/agent/skills/
+```
+
+The skill folder contains everything: `SKILL.md` (teaches the agent when and how to use scalex), reference docs, and a bootstrap script that downloads the correct binary for your platform.
+
+### Manual binary install
+
+If you prefer to install the binary yourself:
 
 ```bash
 mkdir -p ~/.local/bin
@@ -163,15 +175,6 @@ curl -fsSL https://github.com/nguyenyou/scalex/releases/latest/download/scalex-m
 # Linux x64
 curl -fsSL https://github.com/nguyenyou/scalex/releases/latest/download/scalex-linux-x64 -o ~/.local/bin/scalex && chmod +x ~/.local/bin/scalex
 ```
-
-**2. Download the skill** (teaches your coding agent how to use scalex):
-
-```bash
-mkdir -p scalex
-curl -fsSL https://raw.githubusercontent.com/nguyenyou/scalex/main/plugins/scalex/skills/scalex/SKILL.md -o scalex/SKILL.md
-```
-
-Place the `scalex/` folder wherever your agent reads skills from.
 
 ### Run without installing
 

--- a/site/index.html
+++ b/site/index.html
@@ -1424,16 +1424,19 @@
         </div>
         <div class="install-block reveal">
           <span class="comment"
-            ># Manual install — native binary, no JVM needed</span
+            ># Other coding agents — just copy the skill folder</span
           ><br />
           <span class="t-cmd"
-            >curl -fsSL
-            https://github.com/nguyenyou/scalex/releases/latest/download/scalex-macos-arm64
-            \</span
+            >git clone --depth 1
+            https://github.com/nguyenyou/scalex.git /tmp/scalex</span
           ><br />
           <span class="t-cmd"
-            >&nbsp;&nbsp;-o ~/.local/bin/scalex && chmod +x
-            ~/.local/bin/scalex</span
+            >cp -r /tmp/scalex/plugins/scalex/skills/scalex
+            /path/to/your/agent/skills/</span
+          ><br />
+          <br />
+          <span class="comment"
+            ># Bootstrap script auto-downloads the binary on first run</span
           >
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Rewrote the "Other coding agents" section in README.md: just copy the skill folder, bootstrap script handles the binary
- Updated site/index.html install block to show the same `git clone` + `cp -r` workflow instead of manual `curl`
- Kept manual binary install as a separate fallback section in README

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify site/index.html looks correct locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)