### PR TITLE
Bump scalex-sdb bootstrap to v0.2.0

### DIFF
--- a/plugins/scalex-semanticdb/skills/scalex-sdb/scripts/scalex-sdb-cli
+++ b/plugins/scalex-semanticdb/skills/scalex-sdb/scripts/scalex-sdb-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.1.0"
+EXPECTED_VERSION="0.2.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="scalex-sdb"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_scalex_sdb="fb8cf80d83951d56b0034b6a7c7df4427614d4c6596fcaf5e408f9598bc62e4f"
+CHECKSUM_scalex_sdb="ee0efee0e4959536acdf2125ab669d413f693b4fa517193faf26c15e81302e01"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
Post-release step: update `EXPECTED_VERSION` and `CHECKSUM_scalex_sdb` in the bootstrap script to point to the `sdb-v0.2.0` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)