### PR TITLE
Bump scalex-semanticdb marketplace version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Tu Nguyen"
       },


### PR DESCRIPTION
## Summary
- Bump scalex-semanticdb plugin version from 0.2.0 to 0.3.0 in `.claude-plugin/marketplace.json`

## Test plan
- [x] Verified only the version field changed in marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)