### PR TITLE
Rename scalex-sdb to sdbx

### DIFF
--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -25,22 +25,22 @@ jobs:
           power: true
 
       - name: Build assembly JAR
-        run: ./build-native-semanticdb.sh scalex-sdb
+        run: ./build-native-semanticdb.sh sdbx
 
       - name: Test binary
         run: |
-          ./scalex-sdb --help
-          ./scalex-sdb --version
+          ./sdbx --help
+          ./sdbx --version
 
       - name: Generate checksum
-        run: shasum -a 256 scalex-sdb > scalex-sdb.sha256
+        run: shasum -a 256 sdbx > sdbx.sha256
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: scalex-sdb
+          name: sdbx
           path: |
-            scalex-sdb
-            scalex-sdb.sha256
+            sdbx
+            sdbx.sha256
 
   release:
     needs: build
@@ -58,17 +58,17 @@ jobs:
       - name: Prepare release files
         run: |
           # Find the binary wherever download-artifact placed it
-          SDB=$(find artifacts -name "scalex-sdb" -not -name "*.sha256" -type f)
+          SDB=$(find artifacts -name "sdbx" -not -name "*.sha256" -type f)
           echo "Found binary at: $SDB"
           chmod +x "$SDB"
           # Copy to workspace root for predictable paths
-          cp "$SDB" scalex-sdb
-          cp "${SDB}.sha256" scalex-sdb.sha256 2>/dev/null || shasum -a 256 scalex-sdb > scalex-sdb.sha256
+          cp "$SDB" sdbx
+          cp "${SDB}.sha256" sdbx.sha256 2>/dev/null || shasum -a 256 sdbx > sdbx.sha256
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
-          subject-path: scalex-sdb
+          subject-path: sdbx
 
       - name: Extract changelog
         id: changelog
@@ -83,6 +83,6 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
-            scalex-sdb
-            scalex-sdb.sha256
+            sdbx
+            sdbx.sha256
           body: ${{ steps.changelog.outputs.body }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ scalex-workspace/
 /scalex
 /scalex-before
 /scalex-after
-/scalex-sdb
+/sdbx
 
 # Profiling artifacts
 profiling/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ scala-cli test scalex-semanticdb/src/ scalex-semanticdb/tests/
 ```
 
 ### Mill-only discovery
-scalex-sdb auto-discovers `.semanticdb` files from Mill's `out/` directory only. It finds `semanticDbDataDetailed.dest/data/META-INF/semanticdb/` directories and walks them in parallel. No sbt/Bloop/generic fallback — other build tools are not supported yet. See `docs/MILL-SEMANTICDB.md` for the full `out/` layout.
+sdbx auto-discovers `.semanticdb` files from Mill's `out/` directory only. It finds `semanticDbDataDetailed.dest/data/META-INF/semanticdb/` directories and walks them in parallel. No sbt/Bloop/generic fallback — other build tools are not supported yet. See `docs/MILL-SEMANTICDB.md` for the full `out/` layout.
 
 ### Daemon mode
 The `daemon` command keeps the index hot in memory so queries take <10ms instead of ~3.2s. Coding agents launch it as a subprocess and communicate via stdin/stdout JSON-lines.

--- a/README.md
+++ b/README.md
@@ -443,10 +443,10 @@ Scalex reads source text. `scalex-semanticdb` reads the compiler's output. The t
 ### How it works
 
 ```
-Scala compiler (-Xsemanticdb) → .semanticdb protobuf files → scalex-sdb indexes → query
+Scala compiler (-Xsemanticdb) → .semanticdb protobuf files → sdbx indexes → query
 ```
 
-The Scala compiler emits `.semanticdb` files containing every symbol definition, every reference with its resolved target, and full type information. `scalex-sdb` indexes this data into `.scalex/semanticdb.bin` and exposes it through 15 commands.
+The Scala compiler emits `.semanticdb` files containing every symbol definition, every reference with its resolved target, and full type information. `sdbx` indexes this data into `.scalex/semanticdb.bin` and exposes it through 15 commands.
 
 **Generate .semanticdb files** (Mill only — other build tools coming later):
 
@@ -459,9 +459,9 @@ The Scala compiler emits `.semanticdb` files containing every symbol definition,
 | | Pros | Cons |
 |---|---|---|
 | **scalex** | Zero setup, works on any git repo. Fast cold start (~3s). Grep, AST patterns, body extraction, scaladoc, test discovery. | No type info. References are text-based (false positives). No call graph. |
-| **scalex-sdb** | Compiler-precise refs. Call graphs (callers/callees/flow). Resolved types. Related symbols. | Requires compilation with SemanticDB. Slower cold start (~50s). No source body extraction, grep, or scaladoc. |
+| **sdbx** | Compiler-precise refs. Call graphs (callers/callees/flow). Resolved types. Related symbols. | Requires compilation with SemanticDB. Slower cold start (~50s). No source body extraction, grep, or scaladoc. |
 
-Use both together: scalex for fast exploration, scalex-sdb for precision queries.
+Use both together: scalex for fast exploration, sdbx for precision queries.
 
 ### Install
 
@@ -485,7 +485,7 @@ If IntelliJ IDEA is already open with your project, you can tap into its compile
 
 **Requirements:** IntelliJ IDEA **2026.1 RC** or later, MCP Server enabled (Settings → Tools → MCP Server). Needs `curl` and `jq`.
 
-| | **scalex** | **scalex-sdb** | **scalex-intellij** |
+| | **scalex** | **sdbx** | **scalex-intellij** |
 |---|---|---|---|
 | **Setup** | Just a binary + git repo | Mill + compiled `.semanticdb` files | IntelliJ running with MCP Server |
 | **Precision** | Source-level | Compiler-level | Compiler-level + IDE features |

--- a/build-native-semanticdb.sh
+++ b/build-native-semanticdb.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-OUT="${1:-$SCRIPT_DIR/scalex-sdb}"
+OUT="${1:-$SCRIPT_DIR/sdbx}"
 
 echo "Building scalex-semanticdb assembly JAR..."
 scala-cli package --assembly \

--- a/docs/DAEMON-SAFETY.md
+++ b/docs/DAEMON-SAFETY.md
@@ -1,6 +1,6 @@
 # Daemon Safety: Research & Design
 
-Research on safe daemon management across the Scala/JVM ecosystem and beyond, applied to scalex-sdb's daemon mode.
+Research on safe daemon management across the Scala/JVM ecosystem and beyond, applied to sdbx's daemon mode.
 
 ---
 
@@ -60,14 +60,14 @@ Adopted by:
 |------|---------|-------|
 | gopls | 1 min | Shortest — aggressive for shared daemon |
 | sbt server | 5 min | `serverIdleTimeout` setting |
-| scalex-sdb | 5 min | Our current default |
+| sdbx | 5 min | Our current default |
 | Gradle | **3 hours** | Too long — the root cause of many daemon accumulation bugs |
 
 **Lesson**: Shorter is better. A 5-minute idle timeout means at most 5 minutes of wasted memory after the agent session ends. Gradle's 3-hour timeout is directly responsible for their daemon proliferation problems.
 
 ### 2.4 Max Lifetime Cap
 
-Unique to scalex-sdb among the tools surveyed. Most daemons rely only on idle timeout, which fails when:
+Unique to sdbx among the tools surveyed. Most daemons rely only on idle timeout, which fails when:
 - A buggy client sends periodic heartbeats but never actually uses the daemon
 - The agent session runs for hours with sporadic queries (idle timer keeps resetting)
 
@@ -102,7 +102,7 @@ From [Guido Flohr's analysis](https://www.guido-flohr.net/never-delete-your-pid-
 - **Race condition**: Two processes can hold file descriptors to different files with the same name, both acquiring exclusive locks
 - **Correct pattern**: Open and lock; never delete; let kernel reclaim on exit
 
-**For scalex-sdb**: We don't use PID files, which is correct. stdin/stdout pipes are strictly superior for our use case.
+**For sdbx**: We don't use PID files, which is correct. stdin/stdout pipes are strictly superior for our use case.
 
 ---
 
@@ -239,7 +239,7 @@ Every termination layer must have a dedicated test. The daemon is useless if it 
 | **Parent PID exit** | Daemon exits when monitored parent exits | Start with parent PID of a short-lived process, assert daemon exits after it |
 | **Heap pressure** | Daemon exits under memory pressure | (Hard to unit test; integration test with `-Xmx32m` and large index) |
 | **Startup timeout** | Daemon exits if build hangs | (Mock/fault injection on index build) |
-| **Orphan check** | No zombies after test suite | After all tests, `pgrep -f scalex-sdb` finds zero processes |
+| **Orphan check** | No zombies after test suite | After all tests, `pgrep -f sdbx` finds zero processes |
 
 ### 5.2 Implementation Pattern
 
@@ -298,7 +298,7 @@ class DaemonLifecycleTest extends munit.FunSuite:
 
   // After all tests: verify no orphan daemons
   override def afterAll(): Unit =
-    val result = ProcessBuilder("pgrep", "-f", "scalex-sdb.*daemon")
+    val result = ProcessBuilder("pgrep", "-f", "sdbx.*daemon")
       .start().waitFor()
     assertEquals(result, 1, "Orphan daemon processes detected after test suite!")
 ```
@@ -322,9 +322,9 @@ Add to CI pipeline:
 # After running daemon tests:
 - name: Check for orphan processes
   run: |
-    if pgrep -f 'scalex-sdb.*daemon'; then
+    if pgrep -f 'sdbx.*daemon'; then
       echo "FAIL: Orphan daemon processes found"
-      pkill -f 'scalex-sdb.*daemon'
+      pkill -f 'sdbx.*daemon'
       exit 1
     fi
 ```
@@ -354,7 +354,7 @@ Things we must **never** add to the daemon:
 
 ### Comparison Matrix
 
-| Feature | scalex-sdb | sbt server | Bloop | Metals | Gradle | gopls | rust-analyzer |
+| Feature | sdbx | sbt server | Bloop | Metals | Gradle | gopls | rust-analyzer |
 |---------|-----------|------------|-------|--------|--------|-------|---------------|
 | stdin EOF detection | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Parent PID monitoring | ✅ | ❌ | ❌ | ✅ (fixed) | ❌ | ❌ | ❌ |
@@ -365,7 +365,7 @@ Things we must **never** add to the daemon:
 | Heap monitoring | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | N/A |
 | Lifecycle tests | ✅ | ❌ | Partial | Partial | Partial | ❌ | ❌ |
 
-scalex-sdb has more termination layers (8) than any tool surveyed, with full lifecycle test coverage.
+sdbx has more termination layers (8) than any tool surveyed, with full lifecycle test coverage.
 
 ---
 

--- a/docs/MILL-SEMANTICDB.md
+++ b/docs/MILL-SEMANTICDB.md
@@ -1,6 +1,6 @@
 # Mill SemanticDB Layout
 
-How Mill produces `.semanticdb` files and how scalex-sdb discovers them.
+How Mill produces `.semanticdb` files and how sdbx discovers them.
 
 ## Generating SemanticDB files
 
@@ -55,7 +55,7 @@ out/
 ### Key facts
 
 - **One dest per module**: `out/<module-path>/semanticDbDataDetailed.dest/`
-- **Two copies**: `.semanticdb` files appear in both `data/` and `classes/` — scalex-sdb only reads `data/` (skips `classes/` entirely)
+- **Two copies**: `.semanticdb` files appear in both `data/` and `classes/` — sdbx only reads `data/` (skips `classes/` entirely)
 - **Source-relative paths**: Files under `META-INF/semanticdb/` mirror the source tree relative to the workspace root
 - **Persistent**: Mill marks the task `persistent = true` — SemanticDB files survive failed compilations
 - **Incremental**: Only modified sources get new `.semanticdb` files. Mill cleans stale ones whose source was deleted
@@ -70,12 +70,12 @@ out/modules/foo/jvm/jvmSharedSources.dest/com/example/Shared.scala
 modules/foo/shared/src/com/example/Shared.scala        ← the real source
 ```
 
-scalex-sdb detects these generated-source markers and keeps only the real source:
+sdbx detects these generated-source markers and keeps only the real source:
 - `jsSharedSources.dest/`
 - `jvmSharedSources.dest/`
 - `nativeSharedSources.dest/`
 
-## How scalex-sdb discovers files
+## How sdbx discovers files
 
 Discovery uses a fast targeted search of `out/`:
 
@@ -96,7 +96,7 @@ Discovery uses a fast targeted search of `out/`:
 
 ### Staleness detection
 
-After the first discovery, scalex-sdb saves a manifest of discovered `semanticDbDataDetailed.dest` directories at `.scalex/semanticdb-dirs.txt`. On subsequent runs:
+After the first discovery, sdbx saves a manifest of discovered `semanticDbDataDetailed.dest` directories at `.scalex/semanticdb-dirs.txt`. On subsequent runs:
 
 1. Check if any manifest directory has a newer mtime than the cache
 2. If stale: re-discover and incrementally rebuild (only parse changed files)
@@ -111,7 +111,7 @@ Each `.semanticdb` file is a protobuf `TextDocuments` message containing:
 - **SymbolInformation**: Every symbol defined in the source file — class, method, field, type, etc. Includes fully-qualified name, kind, properties (abstract, sealed, etc.), resolved type signature, parent types, and annotations
 - **SymbolOccurrence**: Every reference and definition site — exact position (line, column, end line, end column), the symbol's FQN, and role (DEFINITION or REFERENCE)
 
-scalex-sdb parses these into `SemSymbol` and `SemOccurrence` records, builds reverse indexes (occurrencesBySymbol, memberIndex, subtypeIndex, definitionRanges), and persists to `.scalex/semanticdb.bin`.
+sdbx parses these into `SemSymbol` and `SemOccurrence` records, builds reverse indexes (occurrencesBySymbol, memberIndex, subtypeIndex, definitionRanges), and persists to `.scalex/semanticdb.bin`.
 
 ## Forcing a clean rebuild
 
@@ -119,8 +119,8 @@ scalex-sdb parses these into `SemSymbol` and `SemOccurrence` records, builds rev
 # Regenerate all SemanticDB data
 ./mill __.semanticDbData
 
-# Force scalex-sdb to re-index (ignores cache)
-scalex-sdb index -w /project
+# Force sdbx to re-index (ignores cache)
+sdbx index -w /project
 ```
 
 If `.semanticdb` files seem stale after refactoring, run both commands.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -165,7 +165,7 @@
 - ~~`scalex sealed <trait>`~~ — `hierarchy --down --depth 1` already serves this use case; marginal
 - ~~Smarter default limits~~ — auto-summarize is hard to get right universally; better to give users explicit flags (`--members-limit`, `--definitions-only`)
 
-### scalex-sdb: noise filtering for flow/callees/callers
+### sdbx: noise filtering for flow/callees/callers
 
 - [x] `--no-accessors` flag — filter val/var field accessors from flow/callees
 - [x] `--exclude "p1,p2,..."` flag — filter symbols by FQN or file path from flow/callees/callers
@@ -174,7 +174,7 @@
 - [x] `resolveSymbol` prefers source over generated code in ranking
 - [x] `batch` command — run multiple queries in one invocation
 
-### scalex-sdb: agent UX improvements (#303)
+### sdbx: agent UX improvements (#303)
 
 - [x] Fix `batch` FQN quoting — strip surrounding quotes in `runBatch()`
 - [x] `--in <scope>` flag — scope symbol resolution by owner, FQN, or file without full FQN
@@ -184,7 +184,7 @@
 - [x] `lookup` shows `[object]`/`[class/trait]` annotations for method/field members
 - [x] FQN resolution `#`↔`.` fallback with stderr hint
 
-### scalex-sdb: reduce noise in members/lookup output (#307)
+### sdbx: reduce noise in members/lookup output (#307)
 
 - [x] `members` synthetic filtering — hide compiler-generated case class members (`_N`, `copy`, `copy$default$N`, `productElement`, `productPrefix`, `canEqual`, `apply`, `unapply`) by default; show with `--verbose`. Note: `hashCode`/`toString`/`equals` are not filtered because Scala 3 SemanticDB only emits them when user-overridden.
 - [x] `--smart` on `members` — consistent with `--smart` on flow/callees/callers; filters synthetic case class methods + val accessors, showing only user-declared members
@@ -192,7 +192,7 @@
 - [x] `explain` subtypes — add `subtypes: N` line + first 3 names for traits/abstract classes; new field in `ExplainResult`, `findSubtypes()` call, formatter update
 - Discarded: SKILL.md daemon nudge — already documented with decision tree (lines 374-382) recommending daemon for 3+ queries and exploratory sessions
 
-### scalex-sdb: daemon mode & Mill-only discovery
+### sdbx: daemon mode & Mill-only discovery
 
 - [x] `daemon` command — stdin/stdout JSON-lines server, keeps index hot in memory (<10ms queries vs ~1.5s CLI)
 - [x] 8 defensive termination layers: stdin EOF, parent PID monitoring, idle timeout, max lifetime, shutdown command, per-query timeout, heap pressure, shutdown hook

--- a/plugins/scalex-semanticdb/skills/sdbx/SKILL.md
+++ b/plugins/scalex-semanticdb/skills/sdbx/SKILL.md
@@ -1,44 +1,44 @@
 ---
-name: scalex-sdb
-description: "Compiler-precise Scala code intelligence from SemanticDB data. Call graph analysis (callers, callees, flow), precise references with zero false positives, resolved type signatures, related symbol discovery. Requires compiled .semanticdb files (Scala 2/3). Triggers: \"who calls X\", \"what does X call\", \"trace the call flow from X\", \"what calls this method\", \"precise references of X\", \"what type does X return\", \"show callers of X\", \"call graph of X\", \"what symbols are related to X\", \"what methods does this class have with types\", \"trace execution flow\", \"trace the service layers\", \"how does A reach B\", \"find call path from X to Y\", \"explain this method\", or when you need compiler-precise (not text-based) code intelligence. Use this over scalex when you need call graphs, type information, or zero-false-positive references. Use scalex for zero-setup exploration; use scalex-sdb when the project has been compiled with SemanticDB enabled. Daemon mode: <10ms queries."
+name: sdbx
+description: "Compiler-precise Scala code intelligence from SemanticDB data. Call graph analysis (callers, callees, flow), precise references with zero false positives, resolved type signatures, related symbol discovery. Requires compiled .semanticdb files (Scala 2/3). Triggers: \"who calls X\", \"what does X call\", \"trace the call flow from X\", \"what calls this method\", \"precise references of X\", \"what type does X return\", \"show callers of X\", \"call graph of X\", \"what symbols are related to X\", \"what methods does this class have with types\", \"trace execution flow\", \"trace the service layers\", \"how does A reach B\", \"find call path from X to Y\", \"explain this method\", or when you need compiler-precise (not text-based) code intelligence. Use this over scalex when you need call graphs, type information, or zero-false-positive references. Use scalex for zero-setup exploration; use sdbx when the project has been compiled with SemanticDB enabled. Daemon mode: <10ms queries."
 ---
 
-You have access to `scalex-sdb`, a compiler-precise Scala code intelligence CLI. It reads `.semanticdb` files produced by the Scala compiler and provides capabilities that source-text parsing fundamentally cannot:
+You have access to `sdbx`, a compiler-precise Scala code intelligence CLI. It reads `.semanticdb` files produced by the Scala compiler and provides capabilities that source-text parsing fundamentally cannot:
 
 - **Reverse call graph** (`callers`) — "who calls this method?" resolved to the exact enclosing method, not just the file. No scalex equivalent.
-- **Zero-false-positive references** (`refs`) — the compiler resolves each reference to its exact fully-qualified symbol. `refs Config` in scalex matches every `Config` across all packages; scalex-sdb resolves each to its exact FQN.
+- **Zero-false-positive references** (`refs`) — the compiler resolves each reference to its exact fully-qualified symbol. `refs Config` in scalex matches every `Config` across all packages; sdbx resolves each to its exact FQN.
 - **Exhaustive subtypes** (`subtypes`) — compiler-verified, catches everything scalex's text-based `impl` might miss.
 - **Forward call graph** (`callees`, `flow`) — what does a method call? `callees` gives a flat list; `flow` gives a recursive tree. Use `--smart` on large codebases to filter infrastructure noise.
 - **Resolved types** (`type`) — source may have `val x = ???` with no annotation. Only the compiler knows the actual type.
 - **Related symbols** (`related`) — precise co-occurrence ranked by frequency, not text matching.
 
-**Use scalex as your primary tool** for exploration — it's zero-setup and fast. Reach for scalex-sdb when you need precision: `callers`, precise `refs`, exhaustive `subtypes`, or resolved types.
+**Use scalex as your primary tool** for exploration — it's zero-setup and fast. Reach for sdbx when you need precision: `callers`, precise `refs`, exhaustive `subtypes`, or resolved types.
 
 First run discovers and indexes `.semanticdb` files from build output (~10s for large codebases). Subsequent CLI runs load from cache (~1.5s). For agents making many queries, the **daemon mode** keeps the index hot in memory — queries take **<10ms** instead of 1.5s. Index is stored at `.scalex/semanticdb.bin`.
 
 ## Setup
 
-A bootstrap script at `scripts/scalex-sdb-cli` (next to this SKILL.md) handles everything automatically — downloading the correct JAR from GitHub releases, checking for Java, and caching at `~/.cache/scalex-semanticdb/`. It auto-upgrades when the skill version changes. Requires Java 11+ at runtime.
+A bootstrap script at `scripts/sdbx-cli` (next to this SKILL.md) handles everything automatically — downloading the correct JAR from GitHub releases, checking for Java, and caching at `~/.cache/scalex-semanticdb/`. It auto-upgrades when the skill version changes. Requires Java 11+ at runtime.
 
-**Invocation pattern** — use the absolute path to `scalex-sdb-cli` directly in every command. Do NOT use shell variables (`$SDB`) — coding agent shells are non-persistent, so variables are lost between commands.
+**Invocation pattern** — use the absolute path to `sdbx-cli` directly in every command. Do NOT use shell variables (`$SDB`) — coding agent shells are non-persistent, so variables are lost between commands.
 
 ```bash
-# Pattern: bash "<path-to-scripts>/scalex-sdb-cli" <command> [args] -w <workspace>
-bash "/absolute/path/to/skills/scalex-sdb/scripts/scalex-sdb-cli" callers handleRequest -w /project
-bash "/absolute/path/to/skills/scalex-sdb/scripts/scalex-sdb-cli" refs PaymentService -w /project
+# Pattern: bash "<path-to-scripts>/sdbx-cli" <command> [args] -w <workspace>
+bash "/absolute/path/to/skills/sdbx/scripts/sdbx-cli" callers handleRequest -w /project
+bash "/absolute/path/to/skills/sdbx/scripts/sdbx-cli" refs PaymentService -w /project
 ```
 
-Replace `/absolute/path/to/skills/scalex-sdb` with the absolute path to the directory containing this SKILL.md. Remember this path and substitute it directly into every command.
+Replace `/absolute/path/to/skills/sdbx` with the absolute path to the directory containing this SKILL.md. Remember this path and substitute it directly into every command.
 
 ## Troubleshooting
 
-- **`permission denied`**: Run `chmod +x /path/to/scalex-sdb-cli` once, then retry.
+- **`permission denied`**: Run `chmod +x /path/to/sdbx-cli` once, then retry.
 - **`Java is required`**: Install Java 11+ (e.g. `brew install openjdk` or `sdk install java`).
 - **No .semanticdb files found**: The project must be compiled with SemanticDB enabled. See "Prerequisites" below.
 
 ## Prerequisites — run this first, every time
 
-Before using scalex-sdb (CLI or daemon), generate SemanticDB data for the **entire** codebase:
+Before using sdbx (CLI or daemon), generate SemanticDB data for the **entire** codebase:
 
 ```bash
 ./mill __.semanticDbData
@@ -48,9 +48,9 @@ This step is non-negotiable. Run it before your first query, and re-run it after
 
 ### Why this matters
 
-scalex-sdb does not read source code. It reads `.semanticdb` files — binary artifacts the Scala compiler produces alongside `.class` files. These contain the compiler's resolved understanding of every symbol: which exact method `validate` refers to (not just the name, but the specific overload in the specific package), what type was inferred for `val result = ...`, which class implements which trait. This is what makes callers/refs/types precise instead of approximate.
+sdbx does not read source code. It reads `.semanticdb` files — binary artifacts the Scala compiler produces alongside `.class` files. These contain the compiler's resolved understanding of every symbol: which exact method `validate` refers to (not just the name, but the specific overload in the specific package), what type was inferred for `val result = ...`, which class implements which trait. This is what makes callers/refs/types precise instead of approximate.
 
-**If you skip this step, scalex-sdb has nothing to read.** No `.semanticdb` files means no index, which means every query returns empty results. The tool will tell you "No .semanticdb files found" and exit.
+**If you skip this step, sdbx has nothing to read.** No `.semanticdb` files means no index, which means every query returns empty results. The tool will tell you "No .semanticdb files found" and exit.
 
 ### Why you need ALL modules, not just some
 
@@ -59,7 +59,7 @@ The `__` in `./mill __.semanticDbData` is Mill's wildcard — it means "every mo
 - `callers processPayment` — finds callers *within module A* but silently misses every call from module B. You think there are 3 callers when there are actually 12. You refactor based on this, and break 9 call sites you didn't know existed.
 - `subtypes Repository` — finds implementations in module A but misses the ones in module B. You think you've found every implementation when you haven't.
 - `refs Config` — shows 8 references instead of 40. You conclude a type is barely used when it's actually central to the codebase.
-- `path A B` — reports "no path found" between two symbols because the connecting module wasn't indexed. The path exists, but scalex-sdb can't see the bridge.
+- `path A B` — reports "no path found" between two symbols because the connecting module wasn't indexed. The path exists, but sdbx can't see the bridge.
 
 **Partial data is worse than no data** because it gives you false confidence. With no data, the tool fails loudly and you know to fix it. With partial data, every answer looks plausible but is silently incomplete. You make decisions based on a partial view of the codebase without knowing it's partial.
 
@@ -67,7 +67,7 @@ Think of it like searching a book but only having half the pages. You won't get 
 
 ### After code changes
 
-SemanticDB files are generated at compile time. If you change code and query without regenerating, scalex-sdb uses stale data — it might reference methods that no longer exist or miss new call sites. The daemon auto-detects stale files and rebuilds its index, but only from whatever `.semanticdb` data exists on disk. If the disk data is old, the index is old.
+SemanticDB files are generated at compile time. If you change code and query without regenerating, sdbx uses stale data — it might reference methods that no longer exist or miss new call sites. The daemon auto-detects stale files and rebuilds its index, but only from whatever `.semanticdb` data exists on disk. If the disk data is old, the index is old.
 
 Re-run after significant code changes:
 ```bash
@@ -78,41 +78,41 @@ This is incremental — Mill only recompiles changed modules, so it's fast after
 
 ### Mill only (for now)
 
-scalex-sdb currently discovers `.semanticdb` files from Mill's `out/` directory structure only. Other build tools (sbt, Gradle, scala-cli) are not yet supported. If you're interested in support for other tools, [file an issue](https://github.com/nguyenyou/scalex/issues).
+sdbx currently discovers `.semanticdb` files from Mill's `out/` directory structure only. Other build tools (sbt, Gradle, scala-cli) are not yet supported. If you're interested in support for other tools, [file an issue](https://github.com/nguyenyou/scalex/issues).
 
-## When to use scalex-sdb vs scalex
+## When to use sdbx vs scalex
 
 | Need | Use |
 |---|---|
 | Zero-setup exploration, no compilation | `scalex` |
 | Source body extraction, scaladoc, grep | `scalex` |
 | AST patterns, test discovery, overview | `scalex` |
-| **"Who calls this method?"** | `scalex-sdb callers` |
-| **"Who transitively calls this?"** | `scalex-sdb callers --depth 3` |
-| **"How does A reach B?"** | `scalex-sdb path A B` |
-| **Quick method/type summary** | `scalex-sdb explain` |
-| **Precise references (zero false positives)** | `scalex-sdb refs` |
-| **Exhaustive subtypes** | `scalex-sdb subtypes` |
-| **"What does this method call?"** | `scalex-sdb callees --smart` |
-| **Resolved type signatures** | `scalex-sdb type` |
-| **Related symbol discovery** | `scalex-sdb related` |
+| **"Who calls this method?"** | `sdbx callers` |
+| **"Who transitively calls this?"** | `sdbx callers --depth 3` |
+| **"How does A reach B?"** | `sdbx path A B` |
+| **Quick method/type summary** | `sdbx explain` |
+| **Precise references (zero false positives)** | `sdbx refs` |
+| **Exhaustive subtypes** | `sdbx subtypes` |
+| **"What does this method call?"** | `sdbx callees --smart` |
+| **Resolved type signatures** | `sdbx type` |
+| **Related symbol discovery** | `sdbx related` |
 
 ## Commands
 
-### Precision queries (the primary reason to use scalex-sdb)
+### Precision queries (the primary reason to use sdbx)
 
-#### `scalex-sdb callers <symbol> [--depth N] [--kind K] [--exclude "p1,p2"]` — who calls this method?
+#### `sdbx callers <symbol> [--depth N] [--kind K] [--exclude "p1,p2"]` — who calls this method?
 
 The most valuable command — no scalex equivalent exists. Tells you *which method* contains each call, not just which file. `--kind` narrows symbol resolution (e.g., `--kind method` picks the method over a companion object). `--exclude` filters callers matching FQN or file path patterns.
 
 With `--depth N` (N>1), shows a transitive caller tree — "which HTTP endpoints eventually reach this internal method?" Default depth is 1 (flat list). Supports `--smart` (same-module only) and cycle detection.
 
 ```bash
-scalex-sdb callers handleRequest -w /project
-scalex-sdb callers handleRequest --kind method --exclude "test,integ" -w /project
+sdbx callers handleRequest -w /project
+sdbx callers handleRequest --kind method --exclude "test,integ" -w /project
 
 # Transitive callers — trace back through service layers:
-scalex-sdb callers add --depth 3 -w /project
+sdbx callers add --depth 3 -w /project
 ```
 ```
 Caller tree of 'add' (depth=3)
@@ -121,40 +121,40 @@ method add (EventStoreOperations.scala:42)
     method createOrder (OrderFlowOperations.scala:36)
 ```
 
-#### `scalex-sdb refs <symbol> [--role def|ref]` — zero-false-positive references
+#### `sdbx refs <symbol> [--role def|ref]` — zero-false-positive references
 
 Every occurrence is compiler-resolved — distinguishes overloads, resolves across renames. Filter by role: `--role def` for definitions, `--role ref` for references only.
 
 ```bash
-scalex-sdb refs PaymentService -w /project
-scalex-sdb refs processPayment --role ref -w /project
+sdbx refs PaymentService -w /project
+sdbx refs processPayment --role ref -w /project
 ```
 
-#### `scalex-sdb subtypes <symbol> [--depth N]` — exhaustive subtype tree
+#### `sdbx subtypes <symbol> [--depth N]` — exhaustive subtype tree
 
 Compiler-verified — catches every implementation, including those in unexpected packages that text-based search might miss.
 
 ```bash
-scalex-sdb subtypes Shape --depth 2 -w /project
+sdbx subtypes Shape --depth 2 -w /project
 ```
 
-#### `scalex-sdb type <symbol>` — resolved type signature
+#### `sdbx type <symbol>` — resolved type signature
 
 Shows the compiler-resolved signature, including inferred types not written in source.
 
 ```bash
-scalex-sdb type configLayer -w /project
+sdbx type configLayer -w /project
 ```
 ```
 configLayer: val method configLayer ULayer[AppConfig]
 ```
 
-#### `scalex-sdb path <source> <target> [--depth N] [--smart] [--exclude "p1,p2"]` — find call path between two symbols
+#### `sdbx path <source> <target> [--depth N] [--smart] [--exclude "p1,p2"]` — find call path between two symbols
 
 "How does symbol A reach symbol B?" BFS on the call graph to find the shortest path. Default max depth is 5. Uses compiler-resolved FQNs — zero false positives from name collisions.
 
 ```bash
-scalex-sdb path OrderServer.createOrder EventStoreOperations.add -w /project
+sdbx path OrderServer.createOrder EventStoreOperations.add -w /project
 ```
 ```
 Call path from 'createOrder' to 'add' (3 hops)
@@ -164,12 +164,12 @@ method createOrder (OrderServer.scala:80)
       -> method add (EventStoreOperations.scala:42)
 ```
 
-#### `scalex-sdb explain <symbol> [--kind K] [--smart]` — one-shot method/type summary
+#### `sdbx explain <symbol> [--kind K] [--smart]` — one-shot method/type summary
 
 Combines type signature, callers, callees, members, and subtypes into a single output. Saves multiple round-trips when understanding a method or type. For traits and abstract classes, shows direct subtypes (first 3 + total count). Member listing hides compiler-generated case class synthetics by default.
 
 ```bash
-scalex-sdb explain createOrder --kind method -w /project
+sdbx explain createOrder --kind method -w /project
 ```
 ```
 method createOrder
@@ -179,7 +179,7 @@ method createOrder
   Calls: verifyMembership, validatePlan, createTeam (17 total)
 ```
 ```bash
-scalex-sdb explain Repository --kind trait -w /project
+sdbx explain Repository --kind trait -w /project
 ```
 ```
 trait Repository
@@ -190,20 +190,20 @@ trait Repository
 
 ### Forward call graph
 
-#### `scalex-sdb callees <symbol> [--kind K] [--no-accessors] [--smart] [--exclude "p1,p2"]` — what does this method call?
+#### `sdbx callees <symbol> [--kind K] [--no-accessors] [--smart] [--exclude "p1,p2"]` — what does this method call?
 
 Flat list of all symbols referenced within a method's body. On large codebases, raw output includes val accessors (`.userId`, `.config`), generated code, and functional plumbing — use `--smart` to auto-filter all of this, or `--no-accessors` and `--exclude` for manual control.
 
 `--kind` narrows symbol resolution (e.g., `--kind method` picks the method over a companion object). `--exclude` matches against both FQN and file path.
 
 ```bash
-scalex-sdb callees main -w /project
+sdbx callees main -w /project
 
 # Recommended for large codebases — clean, flat list of meaningful calls:
-scalex-sdb callees createOrder --kind method --smart -w /project
+sdbx callees createOrder --kind method --smart -w /project
 
 # Fine-tune manually:
-scalex-sdb callees createOrder --no-accessors --exclude "protobuf,generatedFactories" -w /project
+sdbx callees createOrder --no-accessors --exclude "protobuf,generatedFactories" -w /project
 ```
 ```
 5 callees of 'main'
@@ -212,7 +212,7 @@ scalex-sdb callees createOrder --no-accessors --exclude "protobuf,generatedFacto
   method fetch (Dog.scala)
 ```
 
-#### `scalex-sdb flow <method> [--depth N] [--kind K] [--smart] [--exclude "p1,p2"]` — recursive call tree
+#### `sdbx flow <method> [--depth N] [--kind K] [--smart] [--exclude "p1,p2"]` — recursive call tree
 
 Traces what a method calls, recursively through service layers. Default depth is 3.
 
@@ -222,10 +222,10 @@ If the output is still too verbose, prefer `callees --smart` (flat list) over `f
 
 ```bash
 # Small codebases — works fine without filters:
-scalex-sdb flow main --depth 2 -w /project
+sdbx flow main --depth 2 -w /project
 
 # Large codebases — always use --smart:
-scalex-sdb flow createOrder --kind method --depth 3 --smart -w /project
+sdbx flow createOrder --kind method --depth 3 --smart -w /project
 ```
 ```
 Call flow from 'main' (depth=2)
@@ -238,12 +238,12 @@ method main (Main.scala:10)
 
 ### Discovery
 
-#### `scalex-sdb related <symbol>` — co-occurring symbols
+#### `sdbx related <symbol>` — co-occurring symbols
 
 Discovers symbols that frequently appear alongside the target. Ranked by co-occurrence count. Useful for discovering the "conceptual neighborhood" around a type.
 
 ```bash
-scalex-sdb related UserService -w /project
+sdbx related UserService -w /project
 ```
 ```
 Symbols related to 'UserService' (by co-occurrence in 4 files)
@@ -252,57 +252,57 @@ Symbols related to 'UserService' (by co-occurrence in 4 files)
   [4]  class UserRepository (com/example/UserRepository#)
 ```
 
-#### `scalex-sdb occurrences <file> [--role def|ref]` — all occurrences in file
+#### `sdbx occurrences <file> [--role def|ref]` — all occurrences in file
 
 Every symbol usage in a file with exact DEFINITION/REFERENCE role and position.
 
 ```bash
-scalex-sdb occurrences Main.scala -w /project
+sdbx occurrences Main.scala -w /project
 ```
 
 ### Navigation (with resolved types)
 
-#### `scalex-sdb lookup <symbol> [--verbose] [--smart] [--source-only]` — find symbol info
+#### `sdbx lookup <symbol> [--verbose] [--smart] [--source-only]` — find symbol info
 
 Resolves by exact FQN, suffix match, or display name. Results ranked: source files before generated code (e.g., protobuf), classes/traits first, locals last. When multiple symbols share a name, use the FQN to target the exact one. Use `--source-only` or `--smart` to exclude generated code (protobuf, codegen) from results.
 
 ```bash
-scalex-sdb lookup PaymentService --verbose -w /project
-scalex-sdb lookup "com/example/PaymentService#" -w /project
-scalex-sdb lookup MyEntity --source-only -w /project
+sdbx lookup PaymentService --verbose -w /project
+sdbx lookup "com/example/PaymentService#" -w /project
+sdbx lookup MyEntity --source-only -w /project
 ```
 
-#### `scalex-sdb supertypes <symbol>` — resolved parent type chain
+#### `sdbx supertypes <symbol>` — resolved parent type chain
 
 ```bash
-scalex-sdb supertypes AnimalRepository -w /project
+sdbx supertypes AnimalRepository -w /project
 ```
 
-#### `scalex-sdb members <symbol> [--kind K] [--smart] [--verbose]` — declarations with resolved types
+#### `sdbx members <symbol> [--kind K] [--smart] [--verbose]` — declarations with resolved types
 
 Hides compiler-generated case class synthetics by default. Use `--verbose` to show all, `--smart` to also filter accessors and generated-code noise.
 
 ```bash
-scalex-sdb members PaymentService -w /project
-scalex-sdb members MyEntity --smart -w /project
+sdbx members PaymentService -w /project
+sdbx members MyEntity --smart -w /project
 ```
 
-#### `scalex-sdb symbols [file] [--kind K]` — symbols in file
+#### `sdbx symbols [file] [--kind K]` — symbols in file
 
 ```bash
-scalex-sdb symbols Dog.scala -w /project
-scalex-sdb symbols --kind trait -w /project
+sdbx symbols Dog.scala -w /project
+sdbx symbols --kind trait -w /project
 ```
 
 ### Batch
 
-#### `scalex-sdb batch "cmd1" "cmd2" ...` — multiple queries in one invocation
+#### `sdbx batch "cmd1" "cmd2" ...` — multiple queries in one invocation
 
 Amortizes the ~1.5s index load across many queries. Each positional arg is a full sub-command string (command + args + flags). Results are separated by `--- <command> ---` delimiters in text mode, or wrapped in `{"batch":[...]}` in JSON mode. Unknown sub-commands produce an error for that entry without affecting others.
 
 ```bash
-scalex-sdb batch "lookup Dog" "members Animal" "subtypes Shape" -w /project
-scalex-sdb batch "callers handleRequest" "callees processPayment --smart" -w /project
+sdbx batch "lookup Dog" "members Animal" "subtypes Shape" -w /project
+sdbx batch "callers handleRequest" "callees processPayment --smart" -w /project
 ```
 
 ### Daemon mode (for coding agents)
@@ -313,10 +313,10 @@ The daemon keeps the index hot in memory so queries take **<10ms** instead of ~1
 
 ```bash
 # Start as a subprocess — reads JSON-lines from stdin, writes JSON to stdout
-bash "/path/to/scalex-sdb-cli" daemon --parent-pid $$ -w /project
+bash "/path/to/sdbx-cli" daemon --parent-pid $$ -w /project
 
 # With custom timeouts (idle=120s, max-lifetime=600s):
-bash "/path/to/scalex-sdb-cli" daemon --parent-pid $$ 120 600 -w /project
+bash "/path/to/sdbx-cli" daemon --parent-pid $$ 120 600 -w /project
 ```
 
 The daemon emits a ready signal on stdout when the index is loaded:
@@ -388,7 +388,7 @@ You do not need to worry about cleanup — the daemon handles it. But you can se
 
 | Scenario | Best approach | Why |
 |---|---|---|
-| 1-2 queries in a session | CLI (`scalex-sdb callers ...`) | Simplest, no setup overhead |
+| 1-2 queries in a session | CLI (`sdbx callers ...`) | Simplest, no setup overhead |
 | 3-5 related queries | `batch` | Amortizes 1.5s load, single command |
 | Many queries over time | Daemon | <10ms per query after initial load |
 | Exploratory session (asking 10+ questions) | Daemon | Dramatically faster iteration |
@@ -396,8 +396,8 @@ You do not need to worry about cleanup — the daemon handles it. But you can se
 ### Index management
 
 ```bash
-scalex-sdb index -w /project              # Force rebuild
-scalex-sdb stats -w /project              # Show counts
+sdbx index -w /project              # Force rebuild
+sdbx stats -w /project              # Show counts
 ```
 
 ## Options
@@ -420,13 +420,13 @@ scalex-sdb stats -w /project              # Show counts
 | `--in <scope>` | Scope symbol resolution by owner class, file path, or package. Avoids full-FQN round-trip. E.g. `--in OrderService` |
 | `--timings` | Print timing info to stderr |
 
-## Getting the most out of scalex-sdb
+## Getting the most out of sdbx
 
-### When to reach for scalex-sdb (and when not to)
+### When to reach for sdbx (and when not to)
 
-scalex is the better default — zero setup, fast, good enough for 90% of queries. Reach for scalex-sdb only when scalex fundamentally can't answer your question:
+scalex is the better default — zero setup, fast, good enough for 90% of queries. Reach for sdbx only when scalex fundamentally can't answer your question:
 
-| Question | scalex can't because... | scalex-sdb command |
+| Question | scalex can't because... | sdbx command |
 |---|---|---|
 | "Who calls `processPayment`?" | Text search finds the name but can't identify which *method* contains the call | `callers processPayment` |
 | "All references to this specific `Config`" | `refs Config` matches every `Config` in every package | `refs Config` (resolves to exact FQN) |
@@ -436,17 +436,17 @@ scalex is the better default — zero setup, fast, good enough for 90% of querie
 
 ### Avoiding the biggest pitfalls
 
-**Pitfall 1: Ambiguous symbol names.** If a name matches multiple symbols (e.g., `createOrder` matches both a case object and a method), scalex-sdb picks the first by rank (classes before methods) and prints a disambiguation hint to stderr listing candidates with their FQNs. Watch for these hints — they tell you exactly how to narrow your query. Add `--kind method` to disambiguate, or use the full FQN from `lookup`:
+**Pitfall 1: Ambiguous symbol names.** If a name matches multiple symbols (e.g., `createOrder` matches both a case object and a method), sdbx picks the first by rank (classes before methods) and prints a disambiguation hint to stderr listing candidates with their FQNs. Watch for these hints — they tell you exactly how to narrow your query. Add `--kind method` to disambiguate, or use the full FQN from `lookup`:
 
 ```bash
 # Bad: might match the wrong symbol
-scalex-sdb callees createOrder
+sdbx callees createOrder
 
 # Good: explicitly target the method
-scalex-sdb callees createOrder --kind method
+sdbx callees createOrder --kind method
 
 # Best: use the FQN when you know it (zero ambiguity)
-scalex-sdb callees "com/example/OrderService#createOrder()."
+sdbx callees "com/example/OrderService#createOrder()."
 ```
 
 **Pitfall 2: Using `flow` without `--smart` on large codebases.** Raw `flow` at depth 3 can produce thousands of lines because it follows every val accessor, generated method, and utility call. On large codebases, always use `--smart`. If still too verbose, fall back to `callees --smart` (flat list, same signal, no depth explosion).
@@ -455,16 +455,16 @@ scalex-sdb callees "com/example/OrderService#createOrder()."
 
 ```bash
 # Bad: 3 invocations = ~4.5s of index loading
-scalex-sdb callers handleRequest -w /project
-scalex-sdb subtypes Repository -w /project
-scalex-sdb members Config -w /project
+sdbx callers handleRequest -w /project
+sdbx subtypes Repository -w /project
+sdbx members Config -w /project
 
 # Good for a few queries: batch amortizes the load
-scalex-sdb batch "callers handleRequest" "subtypes Repository" "members Config" -w /project
+sdbx batch "callers handleRequest" "subtypes Repository" "members Config" -w /project
 
 # Best for many queries: daemon keeps index hot (<10ms per query)
 # Start once, query many times via stdin JSON-lines
-bash "/path/to/scalex-sdb-cli" daemon --parent-pid $$ -w /project
+bash "/path/to/sdbx-cli" daemon --parent-pid $$ -w /project
 ```
 
 ### Decision tree: which command to use
@@ -491,23 +491,23 @@ What do you need?
 
 ```bash
 # Impact analysis — who calls this? (exclude tests)
-scalex-sdb callers processPayment --exclude "test,integ" -w /project
+sdbx callers processPayment --exclude "test,integ" -w /project
 
 # Transitive impact — who *eventually* calls this internal method?
-scalex-sdb callers add --depth 3 --exclude "test,integ" -w /project
+sdbx callers add --depth 3 --exclude "test,integ" -w /project
 
 # Understand a method — clean flat list of what it calls
-scalex-sdb callees createOrder --kind method --smart -w /project
+sdbx callees createOrder --kind method --smart -w /project
 
 # Trace through service layers — recursive call tree
-scalex-sdb flow createOrder --kind method --depth 3 --smart -w /project
+sdbx flow createOrder --kind method --depth 3 --smart -w /project
 
 # How does endpoint A reach database method B?
-scalex-sdb path OrderServer.createOrder EventStoreOperations.add -w /project
+sdbx path OrderServer.createOrder EventStoreOperations.add -w /project
 
 # Quick orientation — callers, callees, type in one shot
-scalex-sdb explain processPayment --kind method -w /project
+sdbx explain processPayment --kind method -w /project
 
 # Verify many claims at once (amortizes index load)
-scalex-sdb batch "lookup UserService" "subtypes AuthProvider" "callers handleLogin" -w /project
+sdbx batch "lookup UserService" "subtypes AuthProvider" "callers handleLogin" -w /project
 ```

--- a/plugins/scalex-semanticdb/skills/sdbx/references/commands.md
+++ b/plugins/scalex-semanticdb/skills/sdbx/references/commands.md
@@ -1,4 +1,4 @@
-# scalex-sdb Command Reference
+# sdbx Command Reference
 
 ## All Commands
 
@@ -81,7 +81,7 @@ Positional args: idle timeout seconds (default: 300), max lifetime seconds (defa
 
 ## Symbol Resolution
 
-When you pass a symbol name, scalex-sdb resolves it in this order:
+When you pass a symbol name, sdbx resolves it in this order:
 
 1. **Exact FQN** — `com/example/MyService#` matches directly
 2. **FQN separator swap** — if exact FQN fails, tries `#` ↔ `.` swap (class member ↔ object member) with a hint

--- a/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
+++ b/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
@@ -9,10 +9,10 @@ set -euo pipefail
 
 EXPECTED_VERSION="0.3.0"
 REPO="nguyenyou/scalex"
-ARTIFACT="scalex-sdb"
+ARTIFACT="sdbx"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_scalex_sdb="a8911c34535b625aa493f7e495b1be0ebb2dbf023e37a04ce03bc8cd5c3a8364"
+CHECKSUM_sdbx="a8911c34535b625aa493f7e495b1be0ebb2dbf023e37a04ce03bc8cd5c3a8364"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"
@@ -27,30 +27,30 @@ fi
 
 # Require Java
 if ! command -v java &>/dev/null; then
-  echo "scalex-sdb: Java is required but not found on PATH." >&2
+  echo "sdbx: Java is required but not found on PATH." >&2
   echo "  Install Java 11+ (e.g. 'brew install openjdk' or 'sdk install java')" >&2
   exit 1
 fi
 
 # Download
-echo "scalex-sdb: downloading v${EXPECTED_VERSION}..." >&2
+echo "sdbx: downloading v${EXPECTED_VERSION}..." >&2
 mkdir -p "$CACHE_DIR"
-TMP=$(mktemp "$CACHE_DIR/scalex-sdb-temp.XXXXXX")
+TMP=$(mktemp "$CACHE_DIR/sdbx-temp.XXXXXX")
 trap 'rm -f "$TMP"' EXIT
 
 BASE_URL="https://github.com/${REPO}/releases/download/sdb-v${EXPECTED_VERSION}"
 
 curl -f -L -o "$TMP" "${BASE_URL}/${ARTIFACT}" || {
-  echo "scalex-sdb: download failed. Visit https://github.com/${REPO}/releases" >&2
+  echo "sdbx: download failed. Visit https://github.com/${REPO}/releases" >&2
   exit 1
 }
 
 # Verify checksum
-if [ -n "$CHECKSUM_scalex_sdb" ]; then
+if [ -n "$CHECKSUM_sdbx" ]; then
   ACTUAL_HASH=$(shasum -a 256 "$TMP" | awk '{print $1}')
-  if [ "$ACTUAL_HASH" != "$CHECKSUM_scalex_sdb" ]; then
-    echo "scalex-sdb: checksum verification FAILED" >&2
-    echo "  expected: $CHECKSUM_scalex_sdb" >&2
+  if [ "$ACTUAL_HASH" != "$CHECKSUM_sdbx" ]; then
+    echo "sdbx: checksum verification FAILED" >&2
+    echo "  expected: $CHECKSUM_sdbx" >&2
     echo "  actual:   $ACTUAL_HASH" >&2
     echo "  The downloaded binary may have been tampered with." >&2
     exit 1
@@ -65,5 +65,5 @@ trap - EXIT
 # macOS: remove quarantine
 [ "$(uname -s)" = "Darwin" ] && xattr -d com.apple.quarantine "$BINARY" 2>/dev/null || true
 
-echo "scalex-sdb: installed v${EXPECTED_VERSION}" >&2
+echo "sdbx: installed v${EXPECTED_VERSION}" >&2
 exec "$BINARY" "$@"

--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+- Renamed CLI tool from `scalex-sdb` to `sdbx` — binary, bootstrap script, version constant, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
+- Added `scalex-semanticdb/CLAUDE.md` documenting the release workflow and feature checklist
+
 ## [0.3.0] — 2026-03-24
 
 ### Added

--- a/scalex-semanticdb/CLAUDE.md
+++ b/scalex-semanticdb/CLAUDE.md
@@ -1,0 +1,30 @@
+# scalex-semanticdb
+
+## Release workflow
+
+### Step 1: Release PR (merge first)
+1. Move `[Unreleased]` section in `CHANGELOG.md` to the new version with date
+2. Bump `SdbxVersion` in `src/model.scala`
+3. Create PR, get it merged to main
+
+### Step 2: Tag + release
+4. Tag as `sdb-vX.Y.Z` and push — GitHub Actions (`release-semanticdb.yml`) builds the assembly JAR and creates a GitHub release with the `sdbx` binary + `.sha256` checksum
+
+### Step 3: Plugin version bump
+5. Bump `EXPECTED_VERSION` in `plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli`
+6. Update `CHECKSUM_sdbx` in `sdbx-cli` — get hash from the `.sha256` release asset:
+   ```bash
+   gh release download sdb-vX.Y.Z -p "sdbx.sha256" -O -
+   ```
+7. Bump `version` for the `scalex-semanticdb` entry in `.claude-plugin/marketplace.json` (at repo root, NOT inside `plugins/`)
+8. Commit, push to main
+
+## Feature checklist
+
+When adding or changing commands/flags in `src/cli.scala`:
+- Update help text in `printUsage()`
+- Update `plugins/scalex-semanticdb/skills/sdbx/SKILL.md` (commands, options, workflows, description frontmatter) and `plugins/scalex-semanticdb/skills/sdbx/references/commands.md`. **Always run `./scripts/check-skill-frontmatter.sh` after editing SKILL.md**
+- Update `CHANGELOG.md` (in this directory)
+- Update `README.md` (in this directory)
+- Update `docs/ROADMAP.md`
+- Update root `README.md` (scalex-semanticdb section)

--- a/scalex-semanticdb/README.md
+++ b/scalex-semanticdb/README.md
@@ -20,7 +20,7 @@ For everything else — grep, body extraction, scaladoc, AST patterns, test disc
 
 ```
                     ┌────────────┐
-                    │scalex-sdb  │
+                    │sdbx  │
                     │    CLI     │
                     └─────┬──────┘
                           │
@@ -38,7 +38,7 @@ For everything else — grep, body extraction, scaladoc, AST patterns, test disc
   └──────────────┘  └────────────────┘  └────────────────┘
 ```
 
-- **scalex-sdb CLI** — 15 commands focused on compiler-unique capabilities
+- **sdbx CLI** — 15 commands focused on compiler-unique capabilities
 - **SemIndex** — lazy indexes: symbolByFqn, occurrencesBySymbol, subtypeIndex, memberIndex, definitionRanges
 - **Discovery** — targeted scan of Mill's `out/` for `semanticDbDataDetailed.dest` directories (fast, Mill-only for now)
 - **.semanticdb protobuf** — compiler output: symbols with resolved types, every occurrence with DEFINITION/REFERENCE role
@@ -126,25 +126,25 @@ This produces `.semanticdb` files under `out/` in each module's `semanticDbDataD
 ## Usage
 
 ```bash
-scalex-sdb <command> [args] [options]
+sdbx <command> [args] [options]
 
 # Call flow tree — the killer feature
-scalex-sdb flow processPayment --depth 3
+sdbx flow processPayment --depth 3
 
 # Who calls this method?
-scalex-sdb callers handleRequest
+sdbx callers handleRequest
 
 # What does this method call?
-scalex-sdb callees main
+sdbx callees main
 
 # Zero-false-positive references
-scalex-sdb refs MyService
+sdbx refs MyService
 
 # Resolved type signature
-scalex-sdb type myFunction
+sdbx type myFunction
 
 # Co-occurring symbols
-scalex-sdb related UserService
+sdbx related UserService
 ```
 
 ## Commands
@@ -203,7 +203,7 @@ scalex-sdb related UserService
 
 Tested on a production Scala monorepo (15k files, 2M symbols). Each scenario shows how many round-trip tool calls a coding agent needs:
 
-| Scenario | grep | scalex | scalex-sdb |
+| Scenario | grep | scalex | sdbx |
 |---|---|---|---|
 | **"What happens when `createRouter` is called?"** (depth 2, 25 callees) | Impossible | Impossible | **1 call** (`flow`) |
 | **"Full call chain from `start()` depth 3"** (40+ nodes across 4 services) | ~30+ calls | ~15+ calls | **1 call** (`flow`) |
@@ -213,9 +213,9 @@ Tested on a production Scala monorepo (15k files, 2M symbols). Each scenario sho
 | **"What symbols are related to `TokenService`?"** | Cannot answer | Cannot answer | **1 call** (`related`) — 1,048 co-occurring symbols ranked |
 | **"Precise refs of `authCheck`"** (no false positives) | 10 lines (includes def) | 10 text matches | **9 exact references** |
 
-The `flow` command is the clearest win: what takes a coding agent **15–30 round trips** with grep/scalex takes **1 call** with scalex-sdb.
+The `flow` command is the clearest win: what takes a coding agent **15–30 round trips** with grep/scalex takes **1 call** with sdbx.
 
-For a 3-level deep trace like `start() → checkToken → getTokenClaim → loadContext`, the agent would need to `def` → `Read` → `def` → `Read` → `def` → `Read` at minimum. scalex-sdb returns the entire tree in a single invocation.
+For a 3-level deep trace like `start() → checkToken → getTokenClaim → loadContext`, the agent would need to `def` → `Read` → `def` → `Read` → `def` → `Read` at minimum. sdbx returns the entire tree in a single invocation.
 
 ## Performance
 
@@ -234,7 +234,7 @@ scala-cli test scalex-semanticdb/src/ scalex-semanticdb/tests/
 
 # Build assembly JAR (requires scala-cli, produces self-executable JAR)
 ./build-native-semanticdb.sh
-# Output: ./scalex-sdb (~49MB, requires Java 11+ at runtime)
+# Output: ./sdbx (~49MB, requires Java 11+ at runtime)
 ```
 
 The assembly JAR is shipped instead of a GraalVM native image because the JVM's JIT compiler is ~11x faster on warm loads for this protobuf-heavy workload (1.8s vs 20s for 3M symbols).

--- a/scalex-semanticdb/src/cli.scala
+++ b/scalex-semanticdb/src/cli.scala
@@ -8,7 +8,7 @@ import java.nio.file.{Files, Path}
     printUsage()
     return
   if argList.head == "--version" then
-    println(s"scalex-semanticdb $ScalexSdbVersion")
+    println(s"sdbx $SdbxVersion")
     return
 
   val cmd = argList.head
@@ -240,9 +240,9 @@ def flagsToContext(flags: SemParsedFlags, index: SemIndex, workspace: Path): Sem
 // ── Usage ──────────────────────────────────────────────────────────────────
 
 def printUsage(): Unit =
-  println("""scalex-semanticdb — Compiler-precise code intelligence from SemanticDB
+  println("""sdbx — Compiler-precise code intelligence from SemanticDB
     |
-    |Usage: scalex-semanticdb <command> [args] [options]
+    |Usage: sdbx <command> [args] [options]
     |
     |Call graph (compiler-only):
     |  callers <symbol>      Who calls this method (reverse call graph, --depth N for transitive)

--- a/scalex-semanticdb/src/daemon.scala
+++ b/scalex-semanticdb/src/daemon.scala
@@ -34,7 +34,7 @@ private val StartupTimeoutSec = 120L
 private val HeapCheckIntervalSec = 60L
 
 def runDaemon(workspace: Path, idleTimeoutSec: Long, maxLifetimeSec: Long, parentPid: Option[Long] = None): Unit =
-  System.err.println("scalex-sdb daemon starting...")
+  System.err.println("sdbx daemon starting...")
 
   // Self-termination timers (created early so startup timeout works)
   val scheduler = Executors.newSingleThreadScheduledExecutor { r =>

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val ScalexSdbVersion = "0.2.0"
+val SdbxVersion = "0.2.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 

--- a/scalex-semanticdb/tests/daemon.test.scala
+++ b/scalex-semanticdb/tests/daemon.test.scala
@@ -17,7 +17,7 @@ class DaemonLifecycleTest extends FunSuite:
   override val munitTimeout = scala.concurrent.duration.Duration(180, "s")
 
   override def beforeAll(): Unit =
-    workspace = Files.createTempDirectory("scalex-sdb-daemon-test")
+    workspace = Files.createTempDirectory("sdbx-daemon-test")
     val srcDir = workspace.resolve("src")
     Files.createDirectories(srcDir)
     writeMinimalFixture(srcDir)
@@ -127,14 +127,14 @@ class DaemonLifecycleTest extends FunSuite:
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
-  private val scalexSdbSrcDir = Path.of("scalex-semanticdb/src").toAbsolutePath.toString
+  private val sdbxSrcDir = Path.of("scalex-semanticdb/src").toAbsolutePath.toString
 
   private def startDaemon(
     idleTimeout: Int = 300,
     maxLifetime: Int = 1800,
     parentPid: Option[Long] = None,
   ): Process =
-    val baseArgs = List("scala-cli", "run", scalexSdbSrcDir, "--")
+    val baseArgs = List("scala-cli", "run", sdbxSrcDir, "--")
     val daemonArgs = List("daemon")
     val pidArgs = parentPid.map(p => List("--parent-pid", p.toString)).getOrElse(Nil)
     val positionalArgs = List(idleTimeout.toString, maxLifetime.toString)

--- a/scalex-semanticdb/tests/index.test.scala
+++ b/scalex-semanticdb/tests/index.test.scala
@@ -165,7 +165,7 @@ class IndexTest extends SemTestBase:
   }
 
   test("rebuild on workspace without out/ produces empty index") {
-    val emptyWorkspace = java.nio.file.Files.createTempDirectory("scalex-sdb-empty")
+    val emptyWorkspace = java.nio.file.Files.createTempDirectory("sdbx-empty")
     val idx = SemIndex(emptyWorkspace)
     idx.rebuild()
     assertEquals(idx.fileCount, 0, "should have zero files when no out/ exists")

--- a/scalex-semanticdb/tests/test-base.test.scala
+++ b/scalex-semanticdb/tests/test-base.test.scala
@@ -16,7 +16,7 @@ abstract class SemTestBase extends FunSuite:
   var index: SemIndex = scala.compiletime.uninitialized
 
   override def beforeAll(): Unit =
-    workspace = Files.createTempDirectory("scalex-sdb-test")
+    workspace = Files.createTempDirectory("sdbx-test")
     val srcDir = workspace.resolve("src")
     Files.createDirectories(srcDir)
 


### PR DESCRIPTION
## Summary
- Renames the CLI tool from `scalex-sdb` to `sdbx` across the entire codebase (binary, bootstrap script, version constant, CI workflow, 19 files)
- Module directory (`scalex-semanticdb/`) and plugin name unchanged
- Adds `scalex-semanticdb/CLAUDE.md` documenting the release workflow and feature checklist

## Test plan
- [x] All scalex tests pass (447 tests)
- [x] All scalex-semanticdb tests pass (137 tests)
- [x] `--version` prints `sdbx 0.2.0`
- [x] Verified against stargazer (15k files): stats, lookup, callers, flow all work
- [x] SKILL.md frontmatter validation passes
- [x] Zero remaining `scalex-sdb` references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)