### PR TITLE
Release sdbx 0.4.0

### DIFF
--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-03-24
+
 ### Changed
 - Renamed CLI tool from `scalex-sdb` to `sdbx` — binary, bootstrap script, version constant, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
 - Added `scalex-semanticdb/CLAUDE.md` documenting the release workflow and feature checklist

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val SdbxVersion = "0.2.0"
+val SdbxVersion = "0.4.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `SdbxVersion` to `0.4.0` in `src/model.scala`
- Move `[Unreleased]` changelog entries to `[0.4.0] — 2026-03-24`

## After merge
1. `git tag sdb-v0.4.0 && git push origin sdb-v0.4.0` — triggers CI to build + release
2. Bump `EXPECTED_VERSION` and `CHECKSUM_sdbx` in `plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli`
3. Bump `version` for `scalex-semanticdb` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)