### PR TITLE
Bump sdbx plugin to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
+++ b/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.3.0"
+EXPECTED_VERSION="0.4.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="sdbx"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbx="a8911c34535b625aa493f7e495b1be0ebb2dbf023e37a04ce03bc8cd5c3a8364"
+CHECKSUM_sdbx="d2a77f9ac1417c56a2776f4cfd327b196257029fd5b308529a90161e82bf1997"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
## Summary
- Bump `EXPECTED_VERSION` to `0.4.0` in `sdbx-cli`
- Update `CHECKSUM_sdbx` from release asset
- Bump marketplace version to `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)