### PR TITLE
docs: add AST-aware grep subtitle to README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   </picture>
   <br>
   <em>Grep knows text. Scalex knows Scala.</em>
+  <br>
+  <sub>Think grep, but it understands Scala's AST — so it finds symbols, not just strings.</sub>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Add a subtitle line beneath the existing tagline explaining scalex as an AST-aware grep for Scala codebases

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)