### PR TITLE
chore(sdbx): bump version to 0.5.0 for release

### DIFF
--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-03-24
+
 ### Added
 - `daemon --fifo <path>` flag — read requests from a named pipe instead of stdin, for non-interactive shells where backgrounding with `&` closes stdin (#317)
 

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val SdbxVersion = "0.4.0"
+val SdbxVersion = "0.5.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `SdbxVersion` from `0.4.0` to `0.5.0` in `scalex-semanticdb/src/model.scala`
- Move unreleased changelog entry (`daemon --fifo`) to `[0.5.0] — 2026-03-24`

## Test plan
- [ ] Verify `sdbx --version` prints `0.5.0`
- [ ] Tag `sdb-v0.5.0` after merge and confirm CI builds assembly JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)