### PR TITLE
chore(sdbx): bump plugin to v0.5.0 with updated checksum

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
+++ b/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.4.0"
+EXPECTED_VERSION="0.5.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="sdbx"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbx="d2a77f9ac1417c56a2776f4cfd327b196257029fd5b308529a90161e82bf1997"
+CHECKSUM_sdbx="b3d2b276bab2e79dc3f3a17246fd5f2d180ea10887645e550a16faea30983b5a"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
## Summary
- Bump `EXPECTED_VERSION` to `0.5.0` in `sdbx-cli` bootstrap script
- Update `CHECKSUM_sdbx` to match the `sdb-v0.5.0` release asset
- Bump `scalex-semanticdb` version to `0.5.0` in `marketplace.json`

## Test plan
- [ ] `sdbx-cli` downloads and verifies the v0.5.0 assembly JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)