### PR TITLE
chore(sdbx): bump plugin to v0.6.0 with updated checksum

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
+++ b/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.5.0"
+EXPECTED_VERSION="0.6.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="sdbx"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbx="b3d2b276bab2e79dc3f3a17246fd5f2d180ea10887645e550a16faea30983b5a"
+CHECKSUM_sdbx="c18aad31c40549789f5b4a03df0e24de83a8dbe7d71e59942fe092a860f84c6e"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
Step 3 of release workflow:
- `EXPECTED_VERSION` → `0.6.0` in `sdbx-cli`
- `CHECKSUM_sdbx` updated from release asset
- `marketplace.json` version → `0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)