### PR TITLE
docs: fix release workflow — main is protected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ The bootstrap script `scalex-cli` contains `EXPECTED_VERSION` that must be bumpe
 5. Bump `EXPECTED_VERSION` in `plugins/scalex/skills/scalex/scripts/scalex-cli`
 6. Update `CHECKSUM_scalex_*` values in `scalex-cli` — get hashes from individual `.sha256` release assets (iterate: `gh release view vX.Y.Z --json assets --jq '.assets[] | select(.name | endswith(".sha256")) | .name'` then download each with `gh release download vX.Y.Z -p <name> -O -`)
 7. Bump `version` in `.claude-plugin/marketplace.json` (plugin version is only managed here, not in `plugins/scalex/.claude-plugin/plugin.json`)
-8. Commit, push to main
+8. Commit, create PR, merge to main (main is protected — cannot push directly)
 
 Note: `marketplace.json` is at the repo root (`.claude-plugin/marketplace.json`), NOT inside `plugins/`.
 

--- a/scalex-semanticdb/CLAUDE.md
+++ b/scalex-semanticdb/CLAUDE.md
@@ -17,7 +17,7 @@
    gh release download sdb-vX.Y.Z -p "sdbx.sha256" -O -
    ```
 7. Bump `version` for the `scalex-semanticdb` entry in `.claude-plugin/marketplace.json` (at repo root, NOT inside `plugins/`)
-8. Commit, push to main
+8. Commit, create PR, merge to main (main is protected — cannot push directly)
 
 ## Feature checklist
 


### PR DESCRIPTION
Release workflow Step 8 said "Commit, push to main" but main is protected. Fixed in both:
- `CLAUDE.md`
- `scalex-semanticdb/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)