### PR TITLE
chore(sdbx): bump plugin to v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
+++ b/plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.6.0"
+EXPECTED_VERSION="0.7.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="sdbx"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbx="c18aad31c40549789f5b4a03df0e24de83a8dbe7d71e59942fe092a860f84c6e"
+CHECKSUM_sdbx="beb4ac24830a5cd2591ce428ab1d55630d5754dec4c2f3c4b45fa8723a5462de"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
## Summary
- Bump `EXPECTED_VERSION` to `0.7.0` in `sdbx-cli`
- Update `CHECKSUM_sdbx` to match release asset
- Bump `version` in `.claude-plugin/marketplace.json`

Step 3 of the release workflow (tag `sdb-v0.7.0` already published, release assets available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)