### PR TITLE
chore: replace individual metals ignores with .local/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-metals-main/
-metals-v2/
+.local/
 out
 .bsp
 .scala-build


### PR DESCRIPTION
## Summary
- Replace `metals-main/` and `metals-v2/` gitignore entries with a single `.local/` directory ignore

## Test plan
- [x] Verify `.local/` contents are untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)