### PR TITLE
chore(sdbex): rename sdbx to sdbex

### DIFF
--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -25,22 +25,22 @@ jobs:
           power: true
 
       - name: Build assembly JAR
-        run: ./build-native-semanticdb.sh sdbx
+        run: ./build-native-semanticdb.sh sdbex
 
       - name: Test binary
         run: |
-          ./sdbx --help
-          ./sdbx --version
+          ./sdbex --help
+          ./sdbex --version
 
       - name: Generate checksum
-        run: shasum -a 256 sdbx > sdbx.sha256
+        run: shasum -a 256 sdbex > sdbex.sha256
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: sdbx
+          name: sdbex
           path: |
-            sdbx
-            sdbx.sha256
+            sdbex
+            sdbex.sha256
 
   release:
     needs: build
@@ -58,17 +58,17 @@ jobs:
       - name: Prepare release files
         run: |
           # Find the binary wherever download-artifact placed it
-          SDB=$(find artifacts -name "sdbx" -not -name "*.sha256" -type f)
+          SDB=$(find artifacts -name "sdbex" -not -name "*.sha256" -type f)
           echo "Found binary at: $SDB"
           chmod +x "$SDB"
           # Copy to workspace root for predictable paths
-          cp "$SDB" sdbx
-          cp "${SDB}.sha256" sdbx.sha256 2>/dev/null || shasum -a 256 sdbx > sdbx.sha256
+          cp "$SDB" sdbex
+          cp "${SDB}.sha256" sdbex.sha256 2>/dev/null || shasum -a 256 sdbex > sdbex.sha256
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
-          subject-path: sdbx
+          subject-path: sdbex
 
       - name: Extract changelog
         id: changelog
@@ -83,6 +83,6 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
-            sdbx
-            sdbx.sha256
+            sdbex
+            sdbex.sha256
           body: ${{ steps.changelog.outputs.body }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ scalex-workspace/
 /scalex
 /scalex-before
 /scalex-after
-/sdbx
+/sdbex
 
 # Profiling artifacts
 profiling/*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ scala-cli test scalex-semanticdb/src/ scalex-semanticdb/tests/
 ```
 
 ### Mill-only discovery
-sdbx auto-discovers `.semanticdb` files from Mill's `out/` directory only. It finds `semanticDbDataDetailed.dest/data/META-INF/semanticdb/` directories and walks them in parallel. No sbt/Bloop/generic fallback — other build tools are not supported yet. See `docs/MILL-SEMANTICDB.md` for the full `out/` layout.
+sdbex auto-discovers `.semanticdb` files from Mill's `out/` directory only. It finds `semanticDbDataDetailed.dest/data/META-INF/semanticdb/` directories and walks them in parallel. No sbt/Bloop/generic fallback — other build tools are not supported yet. See `docs/MILL-SEMANTICDB.md` for the full `out/` layout.
 
 ### Daemon mode
 The `daemon` command keeps the index hot in memory so queries take <10ms instead of ~3.2s. It listens on a Unix domain socket. Non-daemon CLI commands auto-detect the daemon and forward queries transparently — output is identical whether the daemon is running or not.

--- a/README.md
+++ b/README.md
@@ -445,10 +445,10 @@ Scalex reads source text. `scalex-semanticdb` reads the compiler's output. The t
 ### How it works
 
 ```
-Scala compiler (-Xsemanticdb) → .semanticdb protobuf files → sdbx indexes → query
+Scala compiler (-Xsemanticdb) → .semanticdb protobuf files → sdbex indexes → query
 ```
 
-The Scala compiler emits `.semanticdb` files containing every symbol definition, every reference with its resolved target, and full type information. `sdbx` indexes this data into `.scalex/semanticdb.bin` and exposes it through 15 commands.
+The Scala compiler emits `.semanticdb` files containing every symbol definition, every reference with its resolved target, and full type information. `sdbex` indexes this data into `.scalex/semanticdb.bin` and exposes it through 15 commands.
 
 **Generate .semanticdb files** (Mill only — other build tools coming later):
 
@@ -461,9 +461,9 @@ The Scala compiler emits `.semanticdb` files containing every symbol definition,
 | | Pros | Cons |
 |---|---|---|
 | **scalex** | Zero setup, works on any git repo. Fast cold start (~3s). Grep, AST patterns, body extraction, scaladoc, test discovery. | No type info. References are text-based (false positives). No call graph. |
-| **sdbx** | Compiler-precise refs. Call graphs (callers/callees/flow). Resolved types. Related symbols. | Requires compilation with SemanticDB. Slower cold start (~50s). No source body extraction, grep, or scaladoc. |
+| **sdbex** | Compiler-precise refs. Call graphs (callers/callees/flow). Resolved types. Related symbols. | Requires compilation with SemanticDB. Slower cold start (~50s). No source body extraction, grep, or scaladoc. |
 
-Use both together: scalex for fast exploration, sdbx for precision queries.
+Use both together: scalex for fast exploration, sdbex for precision queries.
 
 ### Install
 
@@ -487,7 +487,7 @@ If IntelliJ IDEA is already open with your project, you can tap into its compile
 
 **Requirements:** IntelliJ IDEA **2026.1 RC** or later, MCP Server enabled (Settings → Tools → MCP Server). Needs `curl` and `jq`.
 
-| | **scalex** | **sdbx** | **scalex-intellij** |
+| | **scalex** | **sdbex** | **scalex-intellij** |
 |---|---|---|---|
 | **Setup** | Just a binary + git repo | Mill + compiled `.semanticdb` files | IntelliJ running with MCP Server |
 | **Precision** | Source-level | Compiler-level | Compiler-level + IDE features |

--- a/build-native-semanticdb.sh
+++ b/build-native-semanticdb.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-OUT="${1:-$SCRIPT_DIR/sdbx}"
+OUT="${1:-$SCRIPT_DIR/sdbex}"
 
 echo "Building scalex-semanticdb assembly JAR..."
 scala-cli package --assembly \

--- a/docs/DAEMON-SAFETY.md
+++ b/docs/DAEMON-SAFETY.md
@@ -1,6 +1,6 @@
 # Daemon Safety: Research & Design
 
-Research on safe daemon management across the Scala/JVM ecosystem and beyond, applied to sdbx's daemon mode.
+Research on safe daemon management across the Scala/JVM ecosystem and beyond, applied to sdbex's daemon mode.
 
 ---
 
@@ -60,14 +60,14 @@ Adopted by:
 |------|---------|-------|
 | gopls | 1 min | Shortest — aggressive for shared daemon |
 | sbt server | 5 min | `serverIdleTimeout` setting |
-| sdbx | 5 min | Our current default |
+| sdbex | 5 min | Our current default |
 | Gradle | **3 hours** | Too long — the root cause of many daemon accumulation bugs |
 
 **Lesson**: Shorter is better. A 5-minute idle timeout means at most 5 minutes of wasted memory after the agent session ends. Gradle's 3-hour timeout is directly responsible for their daemon proliferation problems.
 
 ### 2.4 Max Lifetime Cap
 
-Unique to sdbx among the tools surveyed. Most daemons rely only on idle timeout, which fails when:
+Unique to sdbex among the tools surveyed. Most daemons rely only on idle timeout, which fails when:
 - A buggy client sends periodic heartbeats but never actually uses the daemon
 - The agent session runs for hours with sporadic queries (idle timer keeps resetting)
 
@@ -102,7 +102,7 @@ From [Guido Flohr's analysis](https://www.guido-flohr.net/never-delete-your-pid-
 - **Race condition**: Two processes can hold file descriptors to different files with the same name, both acquiring exclusive locks
 - **Correct pattern**: Open and lock; never delete; let kernel reclaim on exit
 
-**For sdbx**: We don't use PID files, which is correct. stdin/stdout pipes are strictly superior for our use case.
+**For sdbex**: We don't use PID files, which is correct. stdin/stdout pipes are strictly superior for our use case.
 
 ---
 
@@ -239,7 +239,7 @@ Every termination layer must have a dedicated test. The daemon is useless if it 
 | **Parent PID exit** | Daemon exits when monitored parent exits | Start with parent PID of a short-lived process, assert daemon exits after it |
 | **Heap pressure** | Daemon exits under memory pressure | (Hard to unit test; integration test with `-Xmx32m` and large index) |
 | **Startup timeout** | Daemon exits if build hangs | (Mock/fault injection on index build) |
-| **Orphan check** | No zombies after test suite | After all tests, `pgrep -f sdbx` finds zero processes |
+| **Orphan check** | No zombies after test suite | After all tests, `pgrep -f sdbex` finds zero processes |
 
 ### 5.2 Implementation Pattern
 
@@ -298,7 +298,7 @@ class DaemonLifecycleTest extends munit.FunSuite:
 
   // After all tests: verify no orphan daemons
   override def afterAll(): Unit =
-    val result = ProcessBuilder("pgrep", "-f", "sdbx.*daemon")
+    val result = ProcessBuilder("pgrep", "-f", "sdbex.*daemon")
       .start().waitFor()
     assertEquals(result, 1, "Orphan daemon processes detected after test suite!")
 ```
@@ -322,9 +322,9 @@ Add to CI pipeline:
 # After running daemon tests:
 - name: Check for orphan processes
   run: |
-    if pgrep -f 'sdbx.*daemon'; then
+    if pgrep -f 'sdbex.*daemon'; then
       echo "FAIL: Orphan daemon processes found"
-      pkill -f 'sdbx.*daemon'
+      pkill -f 'sdbex.*daemon'
       exit 1
     fi
 ```
@@ -354,7 +354,7 @@ Things we must **never** add to the daemon:
 
 ### Comparison Matrix
 
-| Feature | sdbx | sbt server | Bloop | Metals | Gradle | gopls | rust-analyzer |
+| Feature | sdbex | sbt server | Bloop | Metals | Gradle | gopls | rust-analyzer |
 |---------|-----------|------------|-------|--------|--------|-------|---------------|
 | stdin EOF detection | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Parent PID monitoring | ✅ | ❌ | ❌ | ✅ (fixed) | ❌ | ❌ | ❌ |
@@ -365,7 +365,7 @@ Things we must **never** add to the daemon:
 | Heap monitoring | ✅ | ❌ | ❌ | ❌ | ✅ | N/A | N/A |
 | Lifecycle tests | ✅ | ❌ | Partial | Partial | Partial | ❌ | ❌ |
 
-sdbx has more termination layers (8) than any tool surveyed, with full lifecycle test coverage.
+sdbex has more termination layers (8) than any tool surveyed, with full lifecycle test coverage.
 
 ---
 

--- a/docs/MILL-SEMANTICDB.md
+++ b/docs/MILL-SEMANTICDB.md
@@ -1,6 +1,6 @@
 # Mill SemanticDB Layout
 
-How Mill produces `.semanticdb` files and how sdbx discovers them.
+How Mill produces `.semanticdb` files and how sdbex discovers them.
 
 ## Generating SemanticDB files
 
@@ -55,7 +55,7 @@ out/
 ### Key facts
 
 - **One dest per module**: `out/<module-path>/semanticDbDataDetailed.dest/`
-- **Two copies**: `.semanticdb` files appear in both `data/` and `classes/` — sdbx only reads `data/` (skips `classes/` entirely)
+- **Two copies**: `.semanticdb` files appear in both `data/` and `classes/` — sdbex only reads `data/` (skips `classes/` entirely)
 - **Source-relative paths**: Files under `META-INF/semanticdb/` mirror the source tree relative to the workspace root
 - **Persistent**: Mill marks the task `persistent = true` — SemanticDB files survive failed compilations
 - **Incremental**: Only modified sources get new `.semanticdb` files. Mill cleans stale ones whose source was deleted
@@ -70,12 +70,12 @@ out/modules/foo/jvm/jvmSharedSources.dest/com/example/Shared.scala
 modules/foo/shared/src/com/example/Shared.scala        ← the real source
 ```
 
-sdbx detects these generated-source markers and keeps only the real source:
+sdbex detects these generated-source markers and keeps only the real source:
 - `jsSharedSources.dest/`
 - `jvmSharedSources.dest/`
 - `nativeSharedSources.dest/`
 
-## How sdbx discovers files
+## How sdbex discovers files
 
 Discovery uses a fast targeted search of `out/`:
 
@@ -96,7 +96,7 @@ Discovery uses a fast targeted search of `out/`:
 
 ### Staleness detection
 
-After the first discovery, sdbx saves a manifest of discovered `semanticDbDataDetailed.dest` directories at `.scalex/semanticdb-dirs.txt`. On subsequent runs:
+After the first discovery, sdbex saves a manifest of discovered `semanticDbDataDetailed.dest` directories at `.scalex/semanticdb-dirs.txt`. On subsequent runs:
 
 1. Check if any manifest directory has a newer mtime than the cache
 2. If stale: re-discover and incrementally rebuild (only parse changed files)
@@ -111,7 +111,7 @@ Each `.semanticdb` file is a protobuf `TextDocuments` message containing:
 - **SymbolInformation**: Every symbol defined in the source file — class, method, field, type, etc. Includes fully-qualified name, kind, properties (abstract, sealed, etc.), resolved type signature, parent types, and annotations
 - **SymbolOccurrence**: Every reference and definition site — exact position (line, column, end line, end column), the symbol's FQN, and role (DEFINITION or REFERENCE)
 
-sdbx parses these into `SemSymbol` and `SemOccurrence` records, builds reverse indexes (occurrencesBySymbol, memberIndex, subtypeIndex, definitionRanges), and persists to `.scalex/semanticdb.bin`.
+sdbex parses these into `SemSymbol` and `SemOccurrence` records, builds reverse indexes (occurrencesBySymbol, memberIndex, subtypeIndex, definitionRanges), and persists to `.scalex/semanticdb.bin`.
 
 ## Forcing a clean rebuild
 
@@ -119,8 +119,8 @@ sdbx parses these into `SemSymbol` and `SemOccurrence` records, builds reverse i
 # Regenerate all SemanticDB data
 ./mill __.semanticDbData
 
-# Force sdbx to re-index (ignores cache)
-sdbx index -w /project
+# Force sdbex to re-index (ignores cache)
+sdbex index -w /project
 ```
 
 If `.semanticdb` files seem stale after refactoring, run both commands.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
-### sdbx: daemon --fifo for non-interactive shells (#317)
+### sdbex: daemon --fifo for non-interactive shells (#317)
 
 - [x] `--fifo <path>` flag — daemon reads from named pipe instead of stdin; solves immediate exit when backgrounding with `&` in non-interactive shells
 - [x] Document `coproc` workaround in SKILL.md for shells that prefer keeping bidirectional pipes
@@ -170,7 +170,7 @@
 - ~~`scalex sealed <trait>`~~ — `hierarchy --down --depth 1` already serves this use case; marginal
 - ~~Smarter default limits~~ — auto-summarize is hard to get right universally; better to give users explicit flags (`--members-limit`, `--definitions-only`)
 
-### sdbx: noise filtering for flow/callees/callers
+### sdbex: noise filtering for flow/callees/callers
 
 - [x] `--no-accessors` flag — filter val/var field accessors from flow/callees
 - [x] `--exclude "p1,p2,..."` flag — filter symbols by FQN or file path from flow/callees/callers
@@ -179,7 +179,7 @@
 - [x] `resolveSymbol` prefers source over generated code in ranking
 - [x] `batch` command — run multiple queries in one invocation
 
-### sdbx: agent UX improvements (#303)
+### sdbex: agent UX improvements (#303)
 
 - [x] Fix `batch` FQN quoting — strip surrounding quotes in `runBatch()`
 - [x] `--in <scope>` flag — scope symbol resolution by owner, FQN, or file without full FQN
@@ -189,7 +189,7 @@
 - [x] `lookup` shows `[object]`/`[class/trait]` annotations for method/field members
 - [x] FQN resolution `#`↔`.` fallback with stderr hint
 
-### sdbx: reduce noise in members/lookup output (#307)
+### sdbex: reduce noise in members/lookup output (#307)
 
 - [x] `members` synthetic filtering — hide compiler-generated case class members (`_N`, `copy`, `copy$default$N`, `productElement`, `productPrefix`, `canEqual`, `apply`, `unapply`) by default; show with `--verbose`. Note: `hashCode`/`toString`/`equals` are not filtered because Scala 3 SemanticDB only emits them when user-overridden.
 - [x] `--smart` on `members` — consistent with `--smart` on flow/callees/callers; filters synthetic case class methods + val accessors, showing only user-declared members
@@ -197,7 +197,7 @@
 - [x] `explain` subtypes — add `subtypes: N` line + first 3 names for traits/abstract classes; new field in `ExplainResult`, `findSubtypes()` call, formatter update
 - Discarded: SKILL.md daemon nudge — already documented with decision tree (lines 374-382) recommending daemon for 3+ queries and exploratory sessions
 
-### sdbx: daemon mode & Mill-only discovery
+### sdbex: daemon mode & Mill-only discovery
 
 - [x] `daemon` command — Unix domain socket server, keeps index hot in memory (<10ms queries vs ~1.5s CLI). Text output identical to CLI mode.
 - [x] 8 defensive termination layers: stdin EOF, parent PID monitoring, idle timeout, max lifetime, shutdown command, per-query timeout, heap pressure, shutdown hook

--- a/plugins/scalex-semanticdb/skills/sdbex/SKILL.md
+++ b/plugins/scalex-semanticdb/skills/sdbex/SKILL.md
@@ -1,44 +1,44 @@
 ---
-name: sdbx
-description: "Compiler-precise Scala code intelligence from SemanticDB data. Call graph analysis (callers, callees, flow), precise references with zero false positives, resolved type signatures, related symbol discovery. Requires compiled .semanticdb files (Scala 2/3). Triggers: \"who calls X\", \"what does X call\", \"trace the call flow from X\", \"what calls this method\", \"precise references of X\", \"what type does X return\", \"show callers of X\", \"call graph of X\", \"what symbols are related to X\", \"what methods does this class have with types\", \"trace execution flow\", \"trace the service layers\", \"how does A reach B\", \"find call path from X to Y\", \"explain this method\", or when you need compiler-precise (not text-based) code intelligence. Use this over scalex when you need call graphs, type information, or zero-false-positive references. Use scalex for zero-setup exploration; use sdbx when the project has been compiled with SemanticDB enabled. Daemon mode: <10ms queries."
+name: sdbex
+description: "Compiler-precise Scala code intelligence from SemanticDB data. Call graph analysis (callers, callees, flow), precise references with zero false positives, resolved type signatures, related symbol discovery. Requires compiled .semanticdb files (Scala 2/3). Triggers: \"who calls X\", \"what does X call\", \"trace the call flow from X\", \"what calls this method\", \"precise references of X\", \"what type does X return\", \"show callers of X\", \"call graph of X\", \"what symbols are related to X\", \"what methods does this class have with types\", \"trace execution flow\", \"trace the service layers\", \"how does A reach B\", \"find call path from X to Y\", \"explain this method\", or when you need compiler-precise (not text-based) code intelligence. Use this over scalex when you need call graphs, type information, or zero-false-positive references. Use scalex for zero-setup exploration; use sdbex when the project has been compiled with SemanticDB enabled. Daemon mode: <10ms queries."
 ---
 
-You have access to `sdbx`, a compiler-precise Scala code intelligence CLI. It reads `.semanticdb` files produced by the Scala compiler and provides capabilities that source-text parsing fundamentally cannot:
+You have access to `sdbex`, a compiler-precise Scala code intelligence CLI. It reads `.semanticdb` files produced by the Scala compiler and provides capabilities that source-text parsing fundamentally cannot:
 
 - **Reverse call graph** (`callers`) — "who calls this method?" resolved to the exact enclosing method, not just the file. No scalex equivalent.
-- **Zero-false-positive references** (`refs`) — the compiler resolves each reference to its exact fully-qualified symbol. `refs Config` in scalex matches every `Config` across all packages; sdbx resolves each to its exact FQN.
+- **Zero-false-positive references** (`refs`) — the compiler resolves each reference to its exact fully-qualified symbol. `refs Config` in scalex matches every `Config` across all packages; sdbex resolves each to its exact FQN.
 - **Exhaustive subtypes** (`subtypes`) — compiler-verified, catches everything scalex's text-based `impl` might miss.
 - **Forward call graph** (`callees`, `flow`) — what does a method call? `callees` gives a flat list; `flow` gives a recursive tree. Use `--smart` on large codebases to filter infrastructure noise.
 - **Resolved types** (`type`) — source may have `val x = ???` with no annotation. Only the compiler knows the actual type.
 - **Related symbols** (`related`) — precise co-occurrence ranked by frequency, not text matching.
 
-**Use scalex as your primary tool** for exploration — it's zero-setup and fast. Reach for sdbx when you need precision: `callers`, precise `refs`, exhaustive `subtypes`, or resolved types.
+**Use scalex as your primary tool** for exploration — it's zero-setup and fast. Reach for sdbex when you need precision: `callers`, precise `refs`, exhaustive `subtypes`, or resolved types.
 
 First run discovers and indexes `.semanticdb` files from build output (~10s for large codebases). Subsequent CLI runs load from cache (~1.5s). For agents making many queries, start the **daemon** once (`daemon -w /project &`) — all subsequent queries auto-detect it and take **<10ms** instead of 1.5s. Index is stored at `.scalex/semanticdb.bin`.
 
 ## Setup
 
-A bootstrap script at `scripts/sdbx-cli` (next to this SKILL.md) handles everything automatically — downloading the correct JAR from GitHub releases, checking for Java, and caching at `~/.cache/scalex-semanticdb/`. It auto-upgrades when the skill version changes. Requires Java 11+ at runtime.
+A bootstrap script at `scripts/sdbex-cli` (next to this SKILL.md) handles everything automatically — downloading the correct JAR from GitHub releases, checking for Java, and caching at `~/.cache/scalex-semanticdb/`. It auto-upgrades when the skill version changes. Requires Java 11+ at runtime.
 
-**Invocation pattern** — use the absolute path to `sdbx-cli` directly in every command. Do NOT use shell variables (`$SDB`) — coding agent shells are non-persistent, so variables are lost between commands.
+**Invocation pattern** — use the absolute path to `sdbex-cli` directly in every command. Do NOT use shell variables (`$SDB`) — coding agent shells are non-persistent, so variables are lost between commands.
 
 ```bash
-# Pattern: bash "<path-to-scripts>/sdbx-cli" <command> [args] -w <workspace>
-bash "/absolute/path/to/skills/sdbx/scripts/sdbx-cli" callers handleRequest -w /project
-bash "/absolute/path/to/skills/sdbx/scripts/sdbx-cli" refs PaymentService -w /project
+# Pattern: bash "<path-to-scripts>/sdbex-cli" <command> [args] -w <workspace>
+bash "/absolute/path/to/skills/sdbex/scripts/sdbex-cli" callers handleRequest -w /project
+bash "/absolute/path/to/skills/sdbex/scripts/sdbex-cli" refs PaymentService -w /project
 ```
 
-Replace `/absolute/path/to/skills/sdbx` with the absolute path to the directory containing this SKILL.md. Remember this path and substitute it directly into every command.
+Replace `/absolute/path/to/skills/sdbex` with the absolute path to the directory containing this SKILL.md. Remember this path and substitute it directly into every command.
 
 ## Troubleshooting
 
-- **`permission denied`**: Run `chmod +x /path/to/sdbx-cli` once, then retry.
+- **`permission denied`**: Run `chmod +x /path/to/sdbex-cli` once, then retry.
 - **`Java is required`**: Install Java 11+ (e.g. `brew install openjdk` or `sdk install java`).
 - **No .semanticdb files found**: The project must be compiled with SemanticDB enabled. See "Prerequisites" below.
 
 ## Prerequisites — run this first, every time
 
-Before using sdbx (CLI or daemon), generate SemanticDB data for the **entire** codebase:
+Before using sdbex (CLI or daemon), generate SemanticDB data for the **entire** codebase:
 
 ```bash
 ./mill __.semanticDbData
@@ -48,9 +48,9 @@ This step is non-negotiable. Run it before your first query, and re-run it after
 
 ### Why this matters
 
-sdbx does not read source code. It reads `.semanticdb` files — binary artifacts the Scala compiler produces alongside `.class` files. These contain the compiler's resolved understanding of every symbol: which exact method `validate` refers to (not just the name, but the specific overload in the specific package), what type was inferred for `val result = ...`, which class implements which trait. This is what makes callers/refs/types precise instead of approximate.
+sdbex does not read source code. It reads `.semanticdb` files — binary artifacts the Scala compiler produces alongside `.class` files. These contain the compiler's resolved understanding of every symbol: which exact method `validate` refers to (not just the name, but the specific overload in the specific package), what type was inferred for `val result = ...`, which class implements which trait. This is what makes callers/refs/types precise instead of approximate.
 
-**If you skip this step, sdbx has nothing to read.** No `.semanticdb` files means no index, which means every query returns empty results. The tool will tell you "No .semanticdb files found" and exit.
+**If you skip this step, sdbex has nothing to read.** No `.semanticdb` files means no index, which means every query returns empty results. The tool will tell you "No .semanticdb files found" and exit.
 
 ### Why you need ALL modules, not just some
 
@@ -59,7 +59,7 @@ The `__` in `./mill __.semanticDbData` is Mill's wildcard — it means "every mo
 - `callers processPayment` — finds callers *within module A* but silently misses every call from module B. You think there are 3 callers when there are actually 12. You refactor based on this, and break 9 call sites you didn't know existed.
 - `subtypes Repository` — finds implementations in module A but misses the ones in module B. You think you've found every implementation when you haven't.
 - `refs Config` — shows 8 references instead of 40. You conclude a type is barely used when it's actually central to the codebase.
-- `path A B` — reports "no path found" between two symbols because the connecting module wasn't indexed. The path exists, but sdbx can't see the bridge.
+- `path A B` — reports "no path found" between two symbols because the connecting module wasn't indexed. The path exists, but sdbex can't see the bridge.
 
 **Partial data is worse than no data** because it gives you false confidence. With no data, the tool fails loudly and you know to fix it. With partial data, every answer looks plausible but is silently incomplete. You make decisions based on a partial view of the codebase without knowing it's partial.
 
@@ -67,7 +67,7 @@ Think of it like searching a book but only having half the pages. You won't get 
 
 ### After code changes
 
-SemanticDB files are generated at compile time. If you change code and query without regenerating, sdbx uses stale data — it might reference methods that no longer exist or miss new call sites. The daemon auto-detects stale files and rebuilds its index, but only from whatever `.semanticdb` data exists on disk. If the disk data is old, the index is old.
+SemanticDB files are generated at compile time. If you change code and query without regenerating, sdbex uses stale data — it might reference methods that no longer exist or miss new call sites. The daemon auto-detects stale files and rebuilds its index, but only from whatever `.semanticdb` data exists on disk. If the disk data is old, the index is old.
 
 Re-run after significant code changes:
 ```bash
@@ -78,13 +78,13 @@ This is incremental — Mill only recompiles changed modules, so it's fast after
 
 ### Mill only (for now)
 
-sdbx currently discovers `.semanticdb` files from Mill's `out/` directory structure only. Other build tools (sbt, Gradle, scala-cli) are not yet supported. If you're interested in support for other tools, [file an issue](https://github.com/nguyenyou/scalex/issues).
+sdbex currently discovers `.semanticdb` files from Mill's `out/` directory structure only. Other build tools (sbt, Gradle, scala-cli) are not yet supported. If you're interested in support for other tools, [file an issue](https://github.com/nguyenyou/scalex/issues).
 
-## When to use sdbx vs scalex
+## When to use sdbex vs scalex
 
-scalex is the better default — zero setup, fast, good enough for 90% of queries. Reach for sdbx only when scalex fundamentally can't answer your question:
+scalex is the better default — zero setup, fast, good enough for 90% of queries. Reach for sdbex only when scalex fundamentally can't answer your question:
 
-| Question | scalex can't because... | sdbx command |
+| Question | scalex can't because... | sdbex command |
 |---|---|---|
 | "Who calls `processPayment`?" | Text search finds the name but can't identify which *method* contains the call | `callers processPayment` |
 | "Who transitively calls this?" | No call graph | `callers X --depth 3` |
@@ -98,20 +98,20 @@ For everything else — grep, body extraction, scaladoc, AST patterns, test disc
 
 ## Commands
 
-### Precision queries (the primary reason to use sdbx)
+### Precision queries (the primary reason to use sdbex)
 
-#### `sdbx callers <symbol> [--depth N] [--kind K] [--exclude "p1,p2"]` — who calls this method?
+#### `sdbex callers <symbol> [--depth N] [--kind K] [--exclude "p1,p2"]` — who calls this method?
 
 The most valuable command — no scalex equivalent exists. Tells you *which method* contains each call, not just which file. `--kind` narrows symbol resolution (e.g., `--kind method` picks the method over a companion object). `--exclude` filters callers matching FQN or file path patterns.
 
 With `--depth N` (N>1), shows a transitive caller tree — "which HTTP endpoints eventually reach this internal method?" Default depth is 1 (flat list). Supports `--smart` (same-module only) and cycle detection.
 
 ```bash
-sdbx callers handleRequest -w /project
-sdbx callers handleRequest --kind method --exclude "test,integ" -w /project
+sdbex callers handleRequest -w /project
+sdbex callers handleRequest --kind method --exclude "test,integ" -w /project
 
 # Transitive callers — trace back through service layers:
-sdbx callers add --depth 3 -w /project
+sdbex callers add --depth 3 -w /project
 ```
 ```
 Caller tree of 'add' (depth=3)
@@ -120,40 +120,40 @@ method add (EventStoreOperations.scala:42)
     method createOrder (OrderFlowOperations.scala:36)
 ```
 
-#### `sdbx refs <symbol> [--role def|ref]` — zero-false-positive references
+#### `sdbex refs <symbol> [--role def|ref]` — zero-false-positive references
 
 Every occurrence is compiler-resolved — distinguishes overloads, resolves across renames. Filter by role: `--role def` for definitions, `--role ref` for references only.
 
 ```bash
-sdbx refs PaymentService -w /project
-sdbx refs processPayment --role ref -w /project
+sdbex refs PaymentService -w /project
+sdbex refs processPayment --role ref -w /project
 ```
 
-#### `sdbx subtypes <symbol> [--depth N]` — exhaustive subtype tree
+#### `sdbex subtypes <symbol> [--depth N]` — exhaustive subtype tree
 
 Compiler-verified — catches every implementation, including those in unexpected packages that text-based search might miss.
 
 ```bash
-sdbx subtypes Shape --depth 2 -w /project
+sdbex subtypes Shape --depth 2 -w /project
 ```
 
-#### `sdbx type <symbol>` — resolved type signature
+#### `sdbex type <symbol>` — resolved type signature
 
 Shows the compiler-resolved signature, including inferred types not written in source.
 
 ```bash
-sdbx type configLayer -w /project
+sdbex type configLayer -w /project
 ```
 ```
 configLayer: val method configLayer ULayer[AppConfig]
 ```
 
-#### `sdbx path <source> <target> [--depth N] [--smart] [--exclude "p1,p2"]` — find call path between two symbols
+#### `sdbex path <source> <target> [--depth N] [--smart] [--exclude "p1,p2"]` — find call path between two symbols
 
 "How does symbol A reach symbol B?" BFS on the call graph to find the shortest path. Default max depth is 5. Uses compiler-resolved FQNs — zero false positives from name collisions.
 
 ```bash
-sdbx path OrderServer.createOrder EventStoreOperations.add -w /project
+sdbex path OrderServer.createOrder EventStoreOperations.add -w /project
 ```
 ```
 Call path from 'createOrder' to 'add' (3 hops)
@@ -163,12 +163,12 @@ method createOrder (OrderServer.scala:80)
       -> method add (EventStoreOperations.scala:42)
 ```
 
-#### `sdbx explain <symbol> [--kind K] [--smart]` — one-shot method/type summary
+#### `sdbex explain <symbol> [--kind K] [--smart]` — one-shot method/type summary
 
 Combines type signature, callers, callees, members, and subtypes into a single output. Saves multiple round-trips when understanding a method or type. For traits and abstract classes, shows direct subtypes (first 3 + total count). Member listing hides compiler-generated case class synthetics by default.
 
 ```bash
-sdbx explain createOrder --kind method -w /project
+sdbex explain createOrder --kind method -w /project
 ```
 ```
 method createOrder
@@ -178,7 +178,7 @@ method createOrder
   Calls: verifyMembership, validatePlan, createTeam (17 total)
 ```
 ```bash
-sdbx explain Repository --kind trait -w /project
+sdbex explain Repository --kind trait -w /project
 ```
 ```
 trait Repository
@@ -189,20 +189,20 @@ trait Repository
 
 ### Forward call graph
 
-#### `sdbx callees <symbol> [--kind K] [--no-accessors] [--smart] [--exclude "p1,p2"]` — what does this method call?
+#### `sdbex callees <symbol> [--kind K] [--no-accessors] [--smart] [--exclude "p1,p2"]` — what does this method call?
 
 Flat list of all symbols referenced within a method's body. On large codebases, raw output includes val accessors (`.userId`, `.config`), generated code, and functional plumbing — use `--smart` to auto-filter all of this, or `--no-accessors` and `--exclude` for manual control.
 
 `--kind` narrows symbol resolution (e.g., `--kind method` picks the method over a companion object). `--exclude` matches against both FQN and file path.
 
 ```bash
-sdbx callees main -w /project
+sdbex callees main -w /project
 
 # Recommended for large codebases — clean, flat list of meaningful calls:
-sdbx callees createOrder --kind method --smart -w /project
+sdbex callees createOrder --kind method --smart -w /project
 
 # Fine-tune manually:
-sdbx callees createOrder --no-accessors --exclude "protobuf,generatedFactories" -w /project
+sdbex callees createOrder --no-accessors --exclude "protobuf,generatedFactories" -w /project
 ```
 ```
 5 callees of 'main'
@@ -211,7 +211,7 @@ sdbx callees createOrder --no-accessors --exclude "protobuf,generatedFactories" 
   method fetch (Dog.scala)
 ```
 
-#### `sdbx flow <method> [--depth N] [--kind K] [--smart] [--exclude "p1,p2"]` — recursive call tree
+#### `sdbex flow <method> [--depth N] [--kind K] [--smart] [--exclude "p1,p2"]` — recursive call tree
 
 Traces what a method calls, recursively through service layers. Default depth is 3.
 
@@ -221,10 +221,10 @@ If the output is still too verbose, prefer `callees --smart` (flat list) over `f
 
 ```bash
 # Small codebases — works fine without filters:
-sdbx flow main --depth 2 -w /project
+sdbex flow main --depth 2 -w /project
 
 # Large codebases — always use --smart:
-sdbx flow createOrder --kind method --depth 3 --smart -w /project
+sdbex flow createOrder --kind method --depth 3 --smart -w /project
 ```
 ```
 Call flow from 'main' (depth=2)
@@ -237,12 +237,12 @@ method main (Main.scala:10)
 
 ### Discovery
 
-#### `sdbx related <symbol>` — co-occurring symbols
+#### `sdbex related <symbol>` — co-occurring symbols
 
 Discovers symbols that frequently appear alongside the target. Ranked by co-occurrence count. Useful for discovering the "conceptual neighborhood" around a type.
 
 ```bash
-sdbx related UserService -w /project
+sdbex related UserService -w /project
 ```
 ```
 Symbols related to 'UserService' (by co-occurrence in 4 files)
@@ -251,57 +251,57 @@ Symbols related to 'UserService' (by co-occurrence in 4 files)
   [4]  class UserRepository (com/example/UserRepository#)
 ```
 
-#### `sdbx occurrences <file> [--role def|ref]` — all occurrences in file
+#### `sdbex occurrences <file> [--role def|ref]` — all occurrences in file
 
 Every symbol usage in a file with exact DEFINITION/REFERENCE role and position.
 
 ```bash
-sdbx occurrences Main.scala -w /project
+sdbex occurrences Main.scala -w /project
 ```
 
 ### Navigation (with resolved types)
 
-#### `sdbx lookup <symbol> [--verbose] [--smart] [--source-only]` — find symbol info
+#### `sdbex lookup <symbol> [--verbose] [--smart] [--source-only]` — find symbol info
 
 Resolves by exact FQN, suffix match, or display name. Results ranked: source files before generated code (e.g., protobuf), classes/traits first, locals last. When multiple symbols share a name, use the FQN to target the exact one. Use `--source-only` or `--smart` to exclude generated code (protobuf, codegen) from results.
 
 ```bash
-sdbx lookup PaymentService --verbose -w /project
-sdbx lookup "com/example/PaymentService#" -w /project
-sdbx lookup MyEntity --source-only -w /project
+sdbex lookup PaymentService --verbose -w /project
+sdbex lookup "com/example/PaymentService#" -w /project
+sdbex lookup MyEntity --source-only -w /project
 ```
 
-#### `sdbx supertypes <symbol>` — resolved parent type chain
+#### `sdbex supertypes <symbol>` — resolved parent type chain
 
 ```bash
-sdbx supertypes AnimalRepository -w /project
+sdbex supertypes AnimalRepository -w /project
 ```
 
-#### `sdbx members <symbol> [--kind K] [--smart] [--verbose]` — declarations with resolved types
+#### `sdbex members <symbol> [--kind K] [--smart] [--verbose]` — declarations with resolved types
 
 Hides compiler-generated case class synthetics by default. Use `--verbose` to show all, `--smart` to also filter accessors and generated-code noise.
 
 ```bash
-sdbx members PaymentService -w /project
-sdbx members MyEntity --smart -w /project
+sdbex members PaymentService -w /project
+sdbex members MyEntity --smart -w /project
 ```
 
-#### `sdbx symbols [file] [--kind K]` — symbols in file
+#### `sdbex symbols [file] [--kind K]` — symbols in file
 
 ```bash
-sdbx symbols Dog.scala -w /project
-sdbx symbols --kind trait -w /project
+sdbex symbols Dog.scala -w /project
+sdbex symbols --kind trait -w /project
 ```
 
 ### Batch
 
-#### `sdbx batch "cmd1" "cmd2" ...` — multiple queries in one invocation
+#### `sdbex batch "cmd1" "cmd2" ...` — multiple queries in one invocation
 
 Amortizes the ~1.5s index load across many queries. Each positional arg is a full sub-command string (command + args + flags). Results are separated by `--- <command> ---` delimiters. Unknown sub-commands produce an error for that entry without affecting others.
 
 ```bash
-sdbx batch "lookup Dog" "members Animal" "subtypes Shape" -w /project
-sdbx batch "callers handleRequest" "callees processPayment --smart" -w /project
+sdbex batch "lookup Dog" "members Animal" "subtypes Shape" -w /project
+sdbex batch "callers handleRequest" "callees processPayment --smart" -w /project
 ```
 
 ### Daemon mode (for coding agents)
@@ -311,7 +311,7 @@ The daemon keeps the index hot in memory so queries take **<10ms** instead of ~1
 **Start the daemon once at the beginning of a session:**
 
 ```bash
-bash "/path/to/sdbx-cli" daemon -w /project &
+bash "/path/to/sdbex-cli" daemon -w /project &
 ```
 
 The daemon builds the index, binds the socket, and runs in the background. It self-terminates after 5 minutes of inactivity (or 30 minutes max lifetime). No cleanup needed.
@@ -319,9 +319,9 @@ The daemon builds the index, binds the socket, and runs in the background. It se
 **All subsequent queries auto-detect the daemon — no special handling:**
 
 ```bash
-bash "/path/to/sdbx-cli" callers handleRequest -w /project   # <10ms via socket
-bash "/path/to/sdbx-cli" refs Config -w /project              # <10ms via socket
-bash "/path/to/sdbx-cli" subtypes Repository -w /project      # <10ms via socket
+bash "/path/to/sdbex-cli" callers handleRequest -w /project   # <10ms via socket
+bash "/path/to/sdbex-cli" refs Config -w /project              # <10ms via socket
+bash "/path/to/sdbex-cli" subtypes Repository -w /project      # <10ms via socket
 ```
 
 If the daemon isn't running yet (still building index, or not started), queries fall back to local index loading (~1.5s) transparently.
@@ -332,15 +332,15 @@ If the daemon isn't running yet (still building index, or not started), queries 
 
 | Scenario | Best approach | Why |
 |---|---|---|
-| 1-2 queries | CLI (`sdbx callers ...`) | Simplest, no setup |
+| 1-2 queries | CLI (`sdbex callers ...`) | Simplest, no setup |
 | 3-5 related queries | `batch` | Amortizes 1.5s load |
 | Many queries across a session | Daemon | <10ms, works across independent shell calls |
 
 ### Index management
 
 ```bash
-sdbx index -w /project              # Force rebuild
-sdbx stats -w /project              # Show counts
+sdbex index -w /project              # Force rebuild
+sdbex stats -w /project              # Show counts
 ```
 
 ## Options
@@ -362,21 +362,21 @@ sdbx stats -w /project              # Show counts
 | `--in <scope>` | Scope symbol resolution by owner class, file path, or package. Avoids full-FQN round-trip. E.g. `--in OrderService` |
 | `--timings` | Print timing info to stderr |
 
-## Getting the most out of sdbx
+## Getting the most out of sdbex
 
 ### Avoiding the biggest pitfalls
 
-**Pitfall 1: Ambiguous symbol names.** If a name matches multiple symbols, sdbx picks the first by rank and prints a disambiguation hint to stderr. Add `--kind method` to disambiguate, or use the full FQN from `lookup`:
+**Pitfall 1: Ambiguous symbol names.** If a name matches multiple symbols, sdbex picks the first by rank and prints a disambiguation hint to stderr. Add `--kind method` to disambiguate, or use the full FQN from `lookup`:
 
 ```bash
 # Bad: might match the wrong symbol
-sdbx callees createOrder
+sdbex callees createOrder
 
 # Good: explicitly target the method
-sdbx callees createOrder --kind method
+sdbex callees createOrder --kind method
 
 # Best: use the FQN when you know it (zero ambiguity)
-sdbx callees "com/example/OrderService#createOrder()."
+sdbex callees "com/example/OrderService#createOrder()."
 ```
 
 **Pitfall 2: Using `flow` without `--smart` on large codebases.** Raw `flow` at depth 3 can produce thousands of lines. On large codebases, always use `--smart`. If still too verbose, fall back to `callees --smart` (flat list, no depth explosion).
@@ -407,23 +407,23 @@ What do you need?
 
 ```bash
 # Impact analysis — who calls this? (exclude tests)
-sdbx callers processPayment --exclude "test,integ" -w /project
+sdbex callers processPayment --exclude "test,integ" -w /project
 
 # Transitive impact — who *eventually* calls this internal method?
-sdbx callers add --depth 3 --exclude "test,integ" -w /project
+sdbex callers add --depth 3 --exclude "test,integ" -w /project
 
 # Understand a method — clean flat list of what it calls
-sdbx callees createOrder --kind method --smart -w /project
+sdbex callees createOrder --kind method --smart -w /project
 
 # Trace through service layers — recursive call tree
-sdbx flow createOrder --kind method --depth 3 --smart -w /project
+sdbex flow createOrder --kind method --depth 3 --smart -w /project
 
 # How does endpoint A reach database method B?
-sdbx path OrderServer.createOrder EventStoreOperations.add -w /project
+sdbex path OrderServer.createOrder EventStoreOperations.add -w /project
 
 # Quick orientation — callers, callees, type in one shot
-sdbx explain processPayment --kind method -w /project
+sdbex explain processPayment --kind method -w /project
 
 # Verify many claims at once (amortizes index load)
-sdbx batch "lookup UserService" "subtypes AuthProvider" "callers handleLogin" -w /project
+sdbex batch "lookup UserService" "subtypes AuthProvider" "callers handleLogin" -w /project
 ```

--- a/plugins/scalex-semanticdb/skills/sdbex/references/commands.md
+++ b/plugins/scalex-semanticdb/skills/sdbex/references/commands.md
@@ -1,4 +1,4 @@
-# sdbx Command Reference
+# sdbex Command Reference
 
 ## All Commands
 
@@ -81,7 +81,7 @@ Output is identical whether daemon is running or not — always human-readable t
 
 ## Symbol Resolution
 
-When you pass a symbol name, sdbx resolves it in this order:
+When you pass a symbol name, sdbex resolves it in this order:
 
 1. **Exact FQN** — `com/example/MyService#` matches directly
 2. **FQN separator swap** — if exact FQN fails, tries `#` ↔ `.` swap (class member ↔ object member) with a hint
@@ -109,8 +109,8 @@ The daemon listens on a Unix domain socket. Non-daemon CLI commands auto-detect 
 
 The daemon uses a text-based protocol over the socket:
 
-- **Success**: `SDBX_OK\n<text output>`
-- **Error**: `SDBX_ERR\n<error message>`
+- **Success**: `SDBEX_OK\n<text output>`
+- **Error**: `SDBEX_ERR\n<error message>`
 
 The client (CLI) parses this internally — users and agents always see clean text output.
 

--- a/plugins/scalex-semanticdb/skills/sdbex/references/daemon.md
+++ b/plugins/scalex-semanticdb/skills/sdbex/references/daemon.md
@@ -6,10 +6,10 @@ The daemon listens on a Unix domain socket. Any process can connect, send a quer
 
 ```bash
 # Start daemon (backgrounding is fine)
-bash "/path/to/sdbx-cli" daemon -w /project &
+bash "/path/to/sdbex-cli" daemon -w /project &
 
 # Non-daemon commands auto-detect the daemon and forward queries transparently:
-sdbx callers handleRequest -w /project  # <10ms via socket, falls back to local index if no daemon
+sdbex callers handleRequest -w /project  # <10ms via socket, falls back to local index if no daemon
 ```
 
 The socket is created at a short path under `/tmp/` (hashed from workspace path) to respect the macOS 104-byte limit on Unix domain socket paths. Requires Java 16+.
@@ -19,8 +19,8 @@ The socket is created at a short path under `/tmp/` (hashed from workspace path)
 The daemon uses a text-based wire protocol over the Unix domain socket. Non-daemon CLI commands auto-detect the daemon and forward queries transparently — output is identical whether the daemon is running or not.
 
 **Response format** (over socket):
-- Success: `SDBX_OK\n<text output>` — human-readable text, same as CLI
-- Error: `SDBX_ERR\n<error message>` — CLI prints to stderr, exits with code 1
+- Success: `SDBEX_OK\n<text output>` — human-readable text, same as CLI
+- Error: `SDBEX_ERR\n<error message>` — CLI prints to stderr, exits with code 1
 
 **Request format** (internal, sent by CLI):
 ```json

--- a/plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli
+++ b/plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli
@@ -9,10 +9,10 @@ set -euo pipefail
 
 EXPECTED_VERSION="0.7.0"
 REPO="nguyenyou/scalex"
-ARTIFACT="sdbx"
+ARTIFACT="sdbex"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbx="beb4ac24830a5cd2591ce428ab1d55630d5754dec4c2f3c4b45fa8723a5462de"
+CHECKSUM_sdbex="beb4ac24830a5cd2591ce428ab1d55630d5754dec4c2f3c4b45fa8723a5462de"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"
@@ -27,30 +27,30 @@ fi
 
 # Require Java
 if ! command -v java &>/dev/null; then
-  echo "sdbx: Java is required but not found on PATH." >&2
+  echo "sdbex: Java is required but not found on PATH." >&2
   echo "  Install Java 11+ (e.g. 'brew install openjdk' or 'sdk install java')" >&2
   exit 1
 fi
 
 # Download
-echo "sdbx: downloading v${EXPECTED_VERSION}..." >&2
+echo "sdbex: downloading v${EXPECTED_VERSION}..." >&2
 mkdir -p "$CACHE_DIR"
-TMP=$(mktemp "$CACHE_DIR/sdbx-temp.XXXXXX")
+TMP=$(mktemp "$CACHE_DIR/sdbex-temp.XXXXXX")
 trap 'rm -f "$TMP"' EXIT
 
 BASE_URL="https://github.com/${REPO}/releases/download/sdb-v${EXPECTED_VERSION}"
 
 curl -f -L -o "$TMP" "${BASE_URL}/${ARTIFACT}" || {
-  echo "sdbx: download failed. Visit https://github.com/${REPO}/releases" >&2
+  echo "sdbex: download failed. Visit https://github.com/${REPO}/releases" >&2
   exit 1
 }
 
 # Verify checksum
-if [ -n "$CHECKSUM_sdbx" ]; then
+if [ -n "$CHECKSUM_sdbex" ]; then
   ACTUAL_HASH=$(shasum -a 256 "$TMP" | awk '{print $1}')
-  if [ "$ACTUAL_HASH" != "$CHECKSUM_sdbx" ]; then
-    echo "sdbx: checksum verification FAILED" >&2
-    echo "  expected: $CHECKSUM_sdbx" >&2
+  if [ "$ACTUAL_HASH" != "$CHECKSUM_sdbex" ]; then
+    echo "sdbex: checksum verification FAILED" >&2
+    echo "  expected: $CHECKSUM_sdbex" >&2
     echo "  actual:   $ACTUAL_HASH" >&2
     echo "  The downloaded binary may have been tampered with." >&2
     exit 1
@@ -65,5 +65,5 @@ trap - EXIT
 # macOS: remove quarantine
 [ "$(uname -s)" = "Darwin" ] && xattr -d com.apple.quarantine "$BINARY" 2>/dev/null || true
 
-echo "sdbx: installed v${EXPECTED_VERSION}" >&2
+echo "sdbex: installed v${EXPECTED_VERSION}" >&2
 exec "$BINARY" "$@"

--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+- Renamed CLI tool from `sdbx` to `sdbex` — binary, bootstrap script, version constant, wire protocol markers (`SDBEX_OK`/`SDBEX_ERR`), socket path prefix, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
+
 ## [0.7.0] — 2026-03-24
 
 ### Changed
 - Daemon now returns text output instead of JSON — identical output whether daemon is running or not
-- Wire protocol changed from JSON envelope to `SDBX_OK`/`SDBX_ERR` text protocol
+- Wire protocol changed from JSON envelope to `SDBEX_OK`/`SDBEX_ERR` text protocol
 - Ready signal changed from JSON to human-readable text
-- Daemon errors (`SDBX_ERR`) now cause CLI to exit with code 1
+- Daemon errors (`SDBEX_ERR`) now cause CLI to exit with code 1
 
 ### Removed
 - `--json` flag — all output is now text-only
@@ -18,7 +21,7 @@
 ## [0.6.0] — 2026-03-24
 
 ### Added
-- Unix domain socket daemon — `daemon` now listens on a socket at `/tmp/sdbx-<hash>.sock` instead of stdin/stdout. Any process can connect, send a JSON-line query, read a response, and disconnect. Designed for coding agent environments (like Claude Code) where each shell invocation is independent. (#323)
+- Unix domain socket daemon — `daemon` now listens on a socket at `/tmp/sdbex-<hash>.sock` instead of stdin/stdout. Any process can connect, send a JSON-line query, read a response, and disconnect. Designed for coding agent environments (like Claude Code) where each shell invocation is independent. (#323)
 - Transparent daemon forwarding — non-daemon CLI commands auto-detect a running socket daemon and forward queries transparently (<10ms). Falls back to local index loading if no daemon is available. (#323)
 - Socket file permissions locked to `rwx------` (owner-only) for security (#323)
 - Stale socket detection — daemon cleans up leftover socket files from crashed daemons (#323)
@@ -43,7 +46,7 @@
 ## [0.4.0] — 2026-03-24
 
 ### Changed
-- Renamed CLI tool from `scalex-sdb` to `sdbx` — binary, bootstrap script, version constant, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
+- Renamed CLI tool from `scalex-sdb` to `sdbex` — binary, bootstrap script, version constant, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
 - Added `scalex-semanticdb/CLAUDE.md` documenting the release workflow and feature checklist
 
 ## [0.3.0] — 2026-03-24

--- a/scalex-semanticdb/CLAUDE.md
+++ b/scalex-semanticdb/CLAUDE.md
@@ -4,17 +4,17 @@
 
 ### Step 1: Release PR (merge first)
 1. Move `[Unreleased]` section in `CHANGELOG.md` to the new version with date
-2. Bump `SdbxVersion` in `src/model.scala`
+2. Bump `SdbexVersion` in `src/model.scala`
 3. Create PR, get it merged to main
 
 ### Step 2: Tag + release
-4. Tag as `sdb-vX.Y.Z` and push — GitHub Actions (`release-semanticdb.yml`) builds the assembly JAR and creates a GitHub release with the `sdbx` binary + `.sha256` checksum
+4. Tag as `sdb-vX.Y.Z` and push — GitHub Actions (`release-semanticdb.yml`) builds the assembly JAR and creates a GitHub release with the `sdbex` binary + `.sha256` checksum
 
 ### Step 3: Plugin version bump
-5. Bump `EXPECTED_VERSION` in `plugins/scalex-semanticdb/skills/sdbx/scripts/sdbx-cli`
-6. Update `CHECKSUM_sdbx` in `sdbx-cli` — get hash from the `.sha256` release asset:
+5. Bump `EXPECTED_VERSION` in `plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli`
+6. Update `CHECKSUM_sdbex` in `sdbex-cli` — get hash from the `.sha256` release asset:
    ```bash
-   gh release download sdb-vX.Y.Z -p "sdbx.sha256" -O -
+   gh release download sdb-vX.Y.Z -p "sdbex.sha256" -O -
    ```
 7. Bump `version` for the `scalex-semanticdb` entry in `.claude-plugin/marketplace.json` (at repo root, NOT inside `plugins/`)
 8. Commit, create PR, merge to main (main is protected — cannot push directly)
@@ -23,7 +23,7 @@
 
 When adding or changing commands/flags in `src/cli.scala`:
 - Update help text in `printUsage()`
-- Update `plugins/scalex-semanticdb/skills/sdbx/SKILL.md` (commands, options, workflows, description frontmatter) and `plugins/scalex-semanticdb/skills/sdbx/references/commands.md`. **Always run `./scripts/check-skill-frontmatter.sh` after editing SKILL.md**
+- Update `plugins/scalex-semanticdb/skills/sdbex/SKILL.md` (commands, options, workflows, description frontmatter) and `plugins/scalex-semanticdb/skills/sdbex/references/commands.md`. **Always run `./scripts/check-skill-frontmatter.sh` after editing SKILL.md**
 - Update `CHANGELOG.md` (in this directory)
 - Update `README.md` (in this directory)
 - Update `docs/ROADMAP.md`

--- a/scalex-semanticdb/README.md
+++ b/scalex-semanticdb/README.md
@@ -20,7 +20,7 @@ For everything else — grep, body extraction, scaladoc, AST patterns, test disc
 
 ```
                     ┌────────────┐
-                    │sdbx  │
+                    │sdbex  │
                     │    CLI     │
                     └─────┬──────┘
                           │
@@ -38,7 +38,7 @@ For everything else — grep, body extraction, scaladoc, AST patterns, test disc
   └──────────────┘  └────────────────┘  └────────────────┘
 ```
 
-- **sdbx CLI** — 15 commands focused on compiler-unique capabilities
+- **sdbex CLI** — 15 commands focused on compiler-unique capabilities
 - **SemIndex** — lazy indexes: symbolByFqn, occurrencesBySymbol, subtypeIndex, memberIndex, definitionRanges
 - **Discovery** — targeted scan of Mill's `out/` for `semanticDbDataDetailed.dest` directories (fast, Mill-only for now)
 - **.semanticdb protobuf** — compiler output: symbols with resolved types, every occurrence with DEFINITION/REFERENCE role
@@ -126,25 +126,25 @@ This produces `.semanticdb` files under `out/` in each module's `semanticDbDataD
 ## Usage
 
 ```bash
-sdbx <command> [args] [options]
+sdbex <command> [args] [options]
 
 # Call flow tree — the killer feature
-sdbx flow processPayment --depth 3
+sdbex flow processPayment --depth 3
 
 # Who calls this method?
-sdbx callers handleRequest
+sdbex callers handleRequest
 
 # What does this method call?
-sdbx callees main
+sdbex callees main
 
 # Zero-false-positive references
-sdbx refs MyService
+sdbex refs MyService
 
 # Resolved type signature
-sdbx type myFunction
+sdbex type myFunction
 
 # Co-occurring symbols
-sdbx related UserService
+sdbex related UserService
 ```
 
 ## Commands
@@ -205,7 +205,7 @@ Listens on a Unix domain socket. Non-daemon commands auto-detect a running daemo
 
 Tested on a production Scala monorepo (15k files, 2M symbols). Each scenario shows how many round-trip tool calls a coding agent needs:
 
-| Scenario | grep | scalex | sdbx |
+| Scenario | grep | scalex | sdbex |
 |---|---|---|---|
 | **"What happens when `createRouter` is called?"** (depth 2, 25 callees) | Impossible | Impossible | **1 call** (`flow`) |
 | **"Full call chain from `start()` depth 3"** (40+ nodes across 4 services) | ~30+ calls | ~15+ calls | **1 call** (`flow`) |
@@ -215,9 +215,9 @@ Tested on a production Scala monorepo (15k files, 2M symbols). Each scenario sho
 | **"What symbols are related to `TokenService`?"** | Cannot answer | Cannot answer | **1 call** (`related`) — 1,048 co-occurring symbols ranked |
 | **"Precise refs of `authCheck`"** (no false positives) | 10 lines (includes def) | 10 text matches | **9 exact references** |
 
-The `flow` command is the clearest win: what takes a coding agent **15–30 round trips** with grep/scalex takes **1 call** with sdbx.
+The `flow` command is the clearest win: what takes a coding agent **15–30 round trips** with grep/scalex takes **1 call** with sdbex.
 
-For a 3-level deep trace like `start() → checkToken → getTokenClaim → loadContext`, the agent would need to `def` → `Read` → `def` → `Read` → `def` → `Read` at minimum. sdbx returns the entire tree in a single invocation.
+For a 3-level deep trace like `start() → checkToken → getTokenClaim → loadContext`, the agent would need to `def` → `Read` → `def` → `Read` → `def` → `Read` at minimum. sdbex returns the entire tree in a single invocation.
 
 ## Performance
 
@@ -236,7 +236,7 @@ scala-cli test scalex-semanticdb/src/ scalex-semanticdb/tests/
 
 # Build assembly JAR (requires scala-cli, produces self-executable JAR)
 ./build-native-semanticdb.sh
-# Output: ./sdbx (~49MB, requires Java 11+ at runtime)
+# Output: ./sdbex (~49MB, requires Java 11+ at runtime)
 ```
 
 The assembly JAR is shipped instead of a GraalVM native image because the JVM's JIT compiler is ~11x faster on warm loads for this protobuf-heavy workload (1.8s vs 20s for 3M symbols).

--- a/scalex-semanticdb/src/cli.scala
+++ b/scalex-semanticdb/src/cli.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, Path}
   if argList.isEmpty || argList.head == "--help" || argList.head == "-h" then
     printUsage()
   else if argList.head == "--version" then
-    println(s"sdbx $SdbxVersion")
+    println(s"sdbex $SdbexVersion")
   else
     run(argList)
 
@@ -263,14 +263,14 @@ private def trySocketForward(cmd: String, flags: SemParsedFlags, sockPath: Path)
       )
       val firstLine = reader.readLine()
       if firstLine == null then SocketResult.None
-      else if firstLine == "SDBX_OK" then
+      else if firstLine == "SDBEX_OK" then
         val sb = StringBuilder()
         var line = reader.readLine()
         while line != null do
           sb.append(line).append('\n')
           line = reader.readLine()
         SocketResult.Ok(sb.toString)
-      else if firstLine == "SDBX_ERR" then
+      else if firstLine == "SDBEX_ERR" then
         val errMsg = reader.readLine()
         SocketResult.Err(if errMsg != null then errMsg else "unknown error")
       else SocketResult.None // unknown protocol, fall through to local
@@ -302,9 +302,9 @@ private def buildDaemonRequest(cmd: String, flags: SemParsedFlags): String =
 // ── Usage ──────────────────────────────────────────────────────────────────
 
 def printUsage(): Unit =
-  println("""sdbx — Compiler-precise code intelligence from SemanticDB
+  println("""sdbex — Compiler-precise code intelligence from SemanticDB
     |
-    |Usage: sdbx <command> [args] [options]
+    |Usage: sdbex <command> [args] [options]
     |
     |Call graph (compiler-only):
     |  callers <symbol>      Who calls this method (reverse call graph, --depth N for transitive)

--- a/scalex-semanticdb/src/daemon.scala
+++ b/scalex-semanticdb/src/daemon.scala
@@ -32,7 +32,7 @@ private val StartupTimeoutSec = 120L
 private val HeapCheckIntervalSec = 60L
 
 def runDaemon(workspace: Path, idleTimeoutSec: Long, maxLifetimeSec: Long): Unit =
-  System.err.println("sdbx daemon starting...")
+  System.err.println("sdbex daemon starting...")
 
   // Fail fast: check if a socket daemon is already running before expensive index build
   val sockPath = socketPath(workspace)
@@ -120,7 +120,7 @@ def runDaemon(workspace: Path, idleTimeoutSec: Long, maxLifetimeSec: Long): Unit
 
   // Ready signal
   resetIdleTimer()
-  println(s"sdbx daemon ready (${index.fileCount} files, ${index.symbolCount} symbols, ${index.occurrenceCount} occurrences, ${index.buildTimeMs}ms)")
+  println(s"sdbex daemon ready (${index.fileCount} files, ${index.symbolCount} symbols, ${index.occurrenceCount} occurrences, ${index.buildTimeMs}ms)")
   System.out.flush()
 
   runSocketLoop(server, index, workspace, queryExecutor, resetIdleTimer, lastBuildMs)
@@ -131,7 +131,7 @@ private def socketPath(workspace: Path): Path =
   // Unix domain sockets have a 104-byte path limit on macOS.
   // Use /tmp with a hash of the workspace to keep it short.
   val hash = Integer.toHexString(workspace.toAbsolutePath.normalize.toString.hashCode & 0x7fffffff)
-  Path.of(System.getProperty("java.io.tmpdir")).resolve(s"sdbx-$hash.sock")
+  Path.of(System.getProperty("java.io.tmpdir")).resolve(s"sdbex-$hash.sock")
 
 private def cleanupSocket(sockPath: java.nio.file.Path): Unit =
   try java.nio.file.Files.deleteIfExists(sockPath) catch case _: Exception => ()
@@ -235,31 +235,31 @@ private def processQuery(
       catch
         case _: java.util.concurrent.TimeoutException =>
           future.cancel(true)
-          DaemonResponse(s"SDBX_ERR\nQuery timed out after ${QueryTimeoutSec}s\n")
+          DaemonResponse(s"SDBEX_ERR\nQuery timed out after ${QueryTimeoutSec}s\n")
     QueryResult(response.text, response.rebuilt, response.shutdown)
   catch
     case e: java.util.concurrent.ExecutionException =>
       val cause = if e.getCause != null then e.getCause else e
       System.err.println(s"Error: ${cause.getMessage}")
-      QueryResult(s"SDBX_ERR\n${cause.getMessage}\n")
+      QueryResult(s"SDBEX_ERR\n${cause.getMessage}\n")
     case e: Exception =>
       System.err.println(s"Error: ${e.getMessage}")
-      QueryResult(s"SDBX_ERR\n${e.getMessage}\n")
+      QueryResult(s"SDBEX_ERR\n${e.getMessage}\n")
 
 private def handleDaemonRequest(line: String, index: SemIndex, workspace: Path, lastBuildMs: Long): DaemonResponse =
   parseDaemonRequest(line) match
     case Left(err) =>
-      DaemonResponse(s"SDBX_ERR\n$err\n")
+      DaemonResponse(s"SDBEX_ERR\n$err\n")
     case Right(req) =>
       dispatchDaemonCommand(req, index, workspace, lastBuildMs)
 
 private def dispatchDaemonCommand(req: DaemonRequest, index: SemIndex, workspace: Path, lastBuildMs: Long): DaemonResponse =
   req.command match
     case "heartbeat" =>
-      DaemonResponse("SDBX_OK\n")
+      DaemonResponse("SDBEX_OK\n")
 
     case "shutdown" =>
-      DaemonResponse("SDBX_OK\n", shutdown = true)
+      DaemonResponse("SDBEX_OK\n", shutdown = true)
 
     case "rebuild" | "index" =>
       index.rebuild()
@@ -268,7 +268,7 @@ private def dispatchDaemonCommand(req: DaemonRequest, index: SemIndex, workspace
         index.buildTimeMs, index.cachedLoad, index.parsedCount, index.skippedCount,
       )
       val text = captureText(statsResult, SemCommandContext(index, workspace))
-      DaemonResponse(s"SDBX_OK\n$text", rebuilt = true)
+      DaemonResponse(s"SDBEX_OK\n$text", rebuilt = true)
 
     case "stats" =>
       val statsResult = SemCmdResult.Stats(
@@ -276,12 +276,12 @@ private def dispatchDaemonCommand(req: DaemonRequest, index: SemIndex, workspace
         index.buildTimeMs, index.cachedLoad, index.parsedCount, index.skippedCount,
       )
       val text = captureText(statsResult, SemCommandContext(index, workspace))
-      DaemonResponse(s"SDBX_OK\n$text")
+      DaemonResponse(s"SDBEX_OK\n$text")
 
     case cmd =>
       // Validate command exists before doing any work
       if cmd != "batch" && !commands.contains(cmd) then
-        DaemonResponse(s"SDBX_ERR\nUnknown command: $cmd\n")
+        DaemonResponse(s"SDBEX_ERR\nUnknown command: $cmd\n")
       else
         // Check staleness before query (~7ms)
         val rebuilt = if index.isStale(lastBuildMs) then
@@ -301,13 +301,13 @@ private def dispatchDaemonCommand(req: DaemonRequest, index: SemIndex, workspace
 
         result match
           case SemCmdResult.UsageError(msg) =>
-            DaemonResponse(s"SDBX_ERR\n$msg\n", rebuilt = rebuilt)
+            DaemonResponse(s"SDBEX_ERR\n$msg\n", rebuilt = rebuilt)
           case SemCmdResult.NotFound(msg) =>
             val text = captureText(result, ctx)
-            DaemonResponse(s"SDBX_OK\n$text", rebuilt = rebuilt)
+            DaemonResponse(s"SDBEX_OK\n$text", rebuilt = rebuilt)
           case _ =>
             val text = captureText(result, ctx)
-            DaemonResponse(s"SDBX_OK\n$text", rebuilt = rebuilt)
+            DaemonResponse(s"SDBEX_OK\n$text", rebuilt = rebuilt)
 
 private def captureText(result: SemCmdResult, ctx: SemCommandContext): String =
   val buf = java.io.ByteArrayOutputStream()

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val SdbxVersion = "0.7.0"
+val SdbexVersion = "0.7.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 

--- a/scalex-semanticdb/tests/daemon.test.scala
+++ b/scalex-semanticdb/tests/daemon.test.scala
@@ -17,7 +17,7 @@ class DaemonLifecycleTest extends FunSuite:
   override val munitTimeout = scala.concurrent.duration.Duration(180, "s")
 
   override def beforeAll(): Unit =
-    workspace = Files.createTempDirectory("sdbx-daemon-test")
+    workspace = Files.createTempDirectory("sdbex-daemon-test")
     val srcDir = workspace.resolve("src")
     Files.createDirectories(srcDir)
     writeMinimalFixture(srcDir)
@@ -36,7 +36,7 @@ class DaemonLifecycleTest extends FunSuite:
       val sockPath = socketPath(workspace)
       assert(Files.exists(sockPath), s"Socket file not created at $sockPath")
       val response = socketQuery(sockPath, """{"command":"stats"}""")
-      assert(response.startsWith("SDBX_OK"), s"Expected SDBX_OK stats response, got: $response")
+      assert(response.startsWith("SDBEX_OK"), s"Expected SDBEX_OK stats response, got: $response")
       assert(response.contains("Files:"), s"Expected Files: in stats, got: $response")
     finally
       sendSocketCommand(workspace, """{"command":"shutdown"}""")
@@ -48,7 +48,7 @@ class DaemonLifecycleTest extends FunSuite:
     waitForReady(proc)
     val sockPath = socketPath(workspace)
     val response = socketQuery(sockPath, """{"command":"shutdown"}""")
-    assert(response.startsWith("SDBX_OK"), s"Expected SDBX_OK response, got: $response")
+    assert(response.startsWith("SDBEX_OK"), s"Expected SDBEX_OK response, got: $response")
     val exited = proc.waitFor(10, TimeUnit.SECONDS)
     assert(exited, "Daemon did not exit after shutdown command")
     assertEquals(proc.exitValue(), 0)
@@ -91,7 +91,7 @@ class DaemonLifecycleTest extends FunSuite:
     // Send heartbeat at ~1s to reset idle timer
     Thread.sleep(1000)
     val hbResponse = socketQuery(sockPath, """{"command":"heartbeat"}""")
-    assert(hbResponse.startsWith("SDBX_OK"))
+    assert(hbResponse.startsWith("SDBEX_OK"))
     // At ~3s total (past original idle timeout of 2s), daemon should still be alive
     Thread.sleep(2000)
     assert(proc.isAlive, "Daemon died prematurely despite heartbeat activity")
@@ -106,11 +106,11 @@ class DaemonLifecycleTest extends FunSuite:
     val sockPath = socketPath(workspace)
     try
       val r1 = socketQuery(sockPath, """{"command":"stats"}""")
-      assert(r1.startsWith("SDBX_OK"), s"First query failed: $r1")
+      assert(r1.startsWith("SDBEX_OK"), s"First query failed: $r1")
       val r2 = socketQuery(sockPath, """{"command":"heartbeat"}""")
-      assert(r2.startsWith("SDBX_OK"), s"Second query failed: $r2")
+      assert(r2.startsWith("SDBEX_OK"), s"Second query failed: $r2")
       val r3 = socketQuery(sockPath, """{"command":"stats"}""")
-      assert(r3.startsWith("SDBX_OK"), s"Third query failed: $r3")
+      assert(r3.startsWith("SDBEX_OK"), s"Third query failed: $r3")
     finally
       sendSocketCommand(workspace, """{"command":"shutdown"}""")
       proc.waitFor(10, TimeUnit.SECONDS)
@@ -122,10 +122,10 @@ class DaemonLifecycleTest extends FunSuite:
     val sockPath = socketPath(workspace)
     try
       val errResponse = socketQuery(sockPath, "this is not json")
-      assert(errResponse.startsWith("SDBX_ERR"), s"Expected SDBX_ERR response, got: $errResponse")
+      assert(errResponse.startsWith("SDBEX_ERR"), s"Expected SDBEX_ERR response, got: $errResponse")
       // Daemon should still accept connections
       val okResponse = socketQuery(sockPath, """{"command":"heartbeat"}""")
-      assert(okResponse.startsWith("SDBX_OK"), s"Expected SDBX_OK after recovery, got: $okResponse")
+      assert(okResponse.startsWith("SDBEX_OK"), s"Expected SDBEX_OK after recovery, got: $okResponse")
     finally
       sendSocketCommand(workspace, """{"command":"shutdown"}""")
       proc.waitFor(10, TimeUnit.SECONDS)
@@ -133,13 +133,13 @@ class DaemonLifecycleTest extends FunSuite:
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
-  private val sdbxSrcDir = Path.of("scalex-semanticdb/src").toAbsolutePath.toString
+  private val sdbexSrcDir = Path.of("scalex-semanticdb/src").toAbsolutePath.toString
 
   private def startDaemon(
     idleTimeout: Int = 300,
     maxLifetime: Int = 1800,
   ): Process =
-    val baseArgs = List("scala-cli", "run", sdbxSrcDir, "--")
+    val baseArgs = List("scala-cli", "run", sdbexSrcDir, "--")
     val daemonArgs = List("daemon")
     val positionalArgs = List(idleTimeout.toString, maxLifetime.toString)
     val wsArgs = List("--workspace", workspace.toString)
@@ -153,7 +153,7 @@ class DaemonLifecycleTest extends FunSuite:
     val reader = BufferedReader(InputStreamReader(proc.getInputStream))
     val ready = reader.readLine()
     assert(ready != null, "Daemon exited before sending ready signal")
-    assert(ready.contains("sdbx daemon ready"), s"Expected ready signal, got: $ready")
+    assert(ready.contains("sdbex daemon ready"), s"Expected ready signal, got: $ready")
 
   // ── Fixture setup ──────────────────────────────────────────────────────
 

--- a/scalex-semanticdb/tests/index.test.scala
+++ b/scalex-semanticdb/tests/index.test.scala
@@ -165,7 +165,7 @@ class IndexTest extends SemTestBase:
   }
 
   test("rebuild on workspace without out/ produces empty index") {
-    val emptyWorkspace = java.nio.file.Files.createTempDirectory("sdbx-empty")
+    val emptyWorkspace = java.nio.file.Files.createTempDirectory("sdbex-empty")
     val idx = SemIndex(emptyWorkspace)
     idx.rebuild()
     assertEquals(idx.fileCount, 0, "should have zero files when no out/ exists")

--- a/scalex-semanticdb/tests/test-base.test.scala
+++ b/scalex-semanticdb/tests/test-base.test.scala
@@ -16,7 +16,7 @@ abstract class SemTestBase extends FunSuite:
   var index: SemIndex = scala.compiletime.uninitialized
 
   override def beforeAll(): Unit =
-    workspace = Files.createTempDirectory("sdbx-test")
+    workspace = Files.createTempDirectory("sdbex-test")
     val srcDir = workspace.resolve("src")
     Files.createDirectories(srcDir)
 


### PR DESCRIPTION
## Summary
- Rename CLI tool from `sdbx` to `sdbex` — binary name, bootstrap script (`sdbex-cli`), version constant (`SdbexVersion`), wire protocol markers (`SDBEX_OK`/`SDBEX_ERR`), socket path prefix (`sdbex-<hash>.sock`), skill directory, and all documentation/references
- 21 files changed across source, tests, docs, plugin, CI workflow, and build script
- Module directory (`scalex-semanticdb/`) and plugin name unchanged

## Test plan
- [ ] `scala-cli compile scalex-semanticdb/src/` — no warnings
- [ ] `scala-cli test scalex-semanticdb/src/ scalex-semanticdb/tests/` — all tests pass
- [ ] `grep -r sdbx --include='*.scala' --include='*.md' --include='*.yml' --include='*.sh' .` returns zero hits (excluding `.git/`)
- [ ] `./build-native-semanticdb.sh` produces `sdbex` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)