### PR TITLE
chore(sdbex): bump version to 0.8.0

### DIFF
--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-03-24
+
 ### Changed
 - Renamed CLI tool from `sdbx` to `sdbex` — binary, bootstrap script, version constant, wire protocol markers (`SDBEX_OK`/`SDBEX_ERR`), socket path prefix, all documentation and references updated. The module directory (`scalex-semanticdb/`) and plugin name are unchanged.
 

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val SdbexVersion = "0.7.0"
+val SdbexVersion = "0.8.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump `SdbexVersion` to `0.8.0` in `src/model.scala`
- Move `[Unreleased]` changelog entry to `[0.8.0] — 2026-03-24`

## Next steps (after merge)
1. Tag `sdb-v0.8.0` and push — CI builds assembly JAR + creates release
2. Bump `EXPECTED_VERSION` and `CHECKSUM_sdbex` in `plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli`
3. Bump `version` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)