### PR TITLE
chore(sdbex): bump plugin to v0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli
+++ b/plugins/scalex-semanticdb/skills/sdbex/scripts/sdbex-cli
@@ -7,12 +7,12 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="0.7.0"
+EXPECTED_VERSION="0.8.0"
 REPO="nguyenyou/scalex"
 ARTIFACT="sdbex"
 
 # Expected SHA-256 checksum (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_sdbex="beb4ac24830a5cd2591ce428ab1d55630d5754dec4c2f3c4b45fa8723a5462de"
+CHECKSUM_sdbex="935c99e5fb6d6c530e0ec4b19ec7b3b09e69fc2b6100881fa328c2b4cd4e4d67"
 
 # Cache location: follow XDG spec
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex-semanticdb"


### PR DESCRIPTION
## Summary
- Bump `EXPECTED_VERSION` to `0.8.0` in `sdbex-cli`
- Update `CHECKSUM_sdbex` to match `sdb-v0.8.0` release asset
- Bump `version` to `0.8.0` in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)