### PR TITLE
chore(sdbex): bump version to 0.9.0, update CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "scalex-semanticdb",
       "source": "./plugins/scalex-semanticdb",
       "description": "Compiler-precise Scala code intelligence from SemanticDB — call graphs, precise references, resolved types, flow analysis. Companion to scalex for compiled codebases.",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/scalex-semanticdb/CHANGELOG.md
+++ b/scalex-semanticdb/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-03-24
+
 ### Added
 - Trait-aware callers — `callers` now automatically includes callers of overridden trait/abstract methods. When querying callers of an implementation method, call sites that reference the trait's method FQN are included. Works in both flat and transitive (`--depth N`) modes. (#331)
 - `--group-by-file` flag for `callers` — groups flat caller output by source file for readability (#331)

--- a/scalex-semanticdb/src/model.scala
+++ b/scalex-semanticdb/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import scala.meta.internal.{semanticdb => sdb}
 import scala.meta.internal.semanticdb.XtensionSemanticdbSymbolInformation
 
-val SdbexVersion = "0.8.0"
+val SdbexVersion = "0.9.0"
 
 // ── Enums ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bump sdbex version from 0.8.0 → 0.9.0
- Move Unreleased changelog entries to [0.9.0] — trait-aware callers, `--group-by-file` (#331)
- Bump marketplace.json version

## Post-merge
- Tag `sdb-v0.9.0` and push to trigger release build
- Then bump `EXPECTED_VERSION` + checksum in bootstrap script

🤖 Generated with [Claude Code](https://claude.com/claude-code)