### PR TITLE
docs(kodex): add UX perspective to README

### DIFF
--- a/kodex/README.md
+++ b/kodex/README.md
@@ -4,6 +4,14 @@
 
 kodex is a knowledge-base extractor for [Mill](https://mill-build.org)-powered Scala codebases. It reads [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) — the compiler's output where every connection, every reference, every type is resolved with zero ambiguity. If [scalex](../README.md) isn't enough and you need the most powerful tool to understand a Scala codebase, this is it.
 
+From the user's perspective: scalex lets you jump into any cloned Scala git repo and start exploring right away. kodex just needs you to run this once:
+
+```
+./mill __.semanticDbData
+```
+
+After that, everything else is the same.
+
 The tradeoff is clear:
 
 | | **scalex** | **kodex** |


### PR DESCRIPTION
## Summary
- Add a one-liner before the tradeoff table explaining the user experience difference: scalex works on any cloned repo instantly, kodex just needs one `./mill __.semanticDbData` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)