### PR TITLE
test(kodex): add snapshot integration test infrastructure

### DIFF
--- a/kodex/.gitignore
+++ b/kodex/.gitignore
@@ -1,3 +1,5 @@
 target/
 kodex.idx
 compare.sh
+tests/snapshot/snapshots/
+tests/snapshot/queries.sh

--- a/kodex/tests/snapshot/queries.sh.example
+++ b/kodex/tests/snapshot/queries.sh.example
@@ -1,0 +1,98 @@
+# queries.sh.example — copy to queries.sh and fill in real symbol names
+#
+# Each test: run_test <test_name> <command> [args...]
+# The --idx flag is appended automatically by run_test.
+#
+# IMPORTANT: queries.sh is gitignored because it contains real project names.
+# This .example file uses placeholders only.
+
+# ── Config: fill in real symbols from your project ──────────────────────────
+
+CLASS_NAME="MyService"                        # a class with members and callers
+TRAIT_NAME="MyTrait"                          # a trait with implementations
+METHOD_NAME="apply"                           # a common method name (ambiguous)
+UNIQUE_METHOD="processRequest"                # a method with a unique name
+FQN_CLASS="com/example/MyService#"            # full SemanticDB FQN of a class
+OBJECT_NAME="MyApp"                           # an object
+TRACE_FROM="createUser"                       # for trace: source symbol
+TRACE_TO="saveToDb"                           # for trace: target symbol
+
+# ── def ─────────────────────────────────────────────────────────────────────
+
+run_test "def__exact_name"       def "$CLASS_NAME"
+run_test "def__fqn"              def "$FQN_CLASS"
+run_test "def__kind_filter"      def "$METHOD_NAME" --kind method --limit 10
+run_test "def__ambiguous"        def "$METHOD_NAME" --limit 5
+run_test "def__verbose"          def "$CLASS_NAME" --kind class -v
+run_test "def__not_found"        def "ThisSymbolDoesNotExist12345"
+
+# ── refs ────────────────────────────────────────────────────────────────────
+
+run_test "refs__basic"           refs "$CLASS_NAME" --limit 20
+run_test "refs__limited"         refs "$TRAIT_NAME" --limit 5
+run_test "refs__not_found"       refs "ThisSymbolDoesNotExist12345"
+
+# ── callers ─────────────────────────────────────────────────────────────────
+
+run_test "callers__basic"        callers "$UNIQUE_METHOD" --limit 20
+run_test "callers__kind_filter"  callers "$METHOD_NAME" --kind method --limit 10
+run_test "callers__limited"      callers "$UNIQUE_METHOD" --limit 3
+run_test "callers__not_found"    callers "ThisSymbolDoesNotExist12345"
+
+# ── callees ─────────────────────────────────────────────────────────────────
+
+run_test "callees__basic"        callees "$UNIQUE_METHOD" --limit 20
+run_test "callees__kind_filter"  callees "$METHOD_NAME" --kind method --limit 10
+run_test "callees__not_found"    callees "ThisSymbolDoesNotExist12345"
+
+# ── hierarchy ───────────────────────────────────────────────────────────────
+
+run_test "hierarchy__trait"      hierarchy "$TRAIT_NAME" --kind trait
+run_test "hierarchy__class"      hierarchy "$CLASS_NAME" --kind class
+run_test "hierarchy__not_found"  hierarchy "ThisSymbolDoesNotExist12345"
+
+# ── members ─────────────────────────────────────────────────────────────────
+
+run_test "members__basic"        members "$CLASS_NAME" --limit 20
+run_test "members__kind_filter"  members "$CLASS_NAME" --kind method --limit 10
+run_test "members__not_found"    members "ThisSymbolDoesNotExist12345"
+
+# ── overrides ───────────────────────────────────────────────────────────────
+
+run_test "overrides__basic"      overrides "$UNIQUE_METHOD" --kind method
+run_test "overrides__not_found"  overrides "ThisSymbolDoesNotExist12345"
+
+# ── type ────────────────────────────────────────────────────────────────────
+
+run_test "type__class"           type "$CLASS_NAME" --kind class
+run_test "type__method"          type "$UNIQUE_METHOD" --kind method
+run_test "type__not_found"       type "ThisSymbolDoesNotExist12345"
+
+# ── orient ──────────────────────────────────────────────────────────────────
+
+run_test "orient"                orient
+
+# ── explore ─────────────────────────────────────────────────────────────────
+
+run_test "explore__class"        explore "$CLASS_NAME" --limit 10
+run_test "explore__trait"        explore "$TRAIT_NAME" --kind trait --limit 10
+run_test "explore__with_exclude" explore "$CLASS_NAME" --exclude "Utils,Ops" --limit 10
+run_test "explore__not_found"    explore "ThisSymbolDoesNotExist12345"
+
+# ── flow ────────────────────────────────────────────────────────────────────
+
+run_test "flow__depth2"          flow "$UNIQUE_METHOD" --depth 2
+run_test "flow__depth1"          flow "$UNIQUE_METHOD" --depth 1
+run_test "flow__with_exclude"    flow "$UNIQUE_METHOD" --depth 3 --exclude "Utils"
+
+# ── impact ──────────────────────────────────────────────────────────────────
+
+run_test "impact__method"        impact "$UNIQUE_METHOD" --kind method
+run_test "impact__class"         impact "$CLASS_NAME" --kind class
+run_test "impact__not_found"     impact "ThisSymbolDoesNotExist12345"
+
+# ── trace ───────────────────────────────────────────────────────────────────
+
+run_test "trace__found"          trace "$TRACE_FROM" "$TRACE_TO"
+run_test "trace__not_found"      trace "ThisSymbolDoesNotExist12345" "AnotherNonExistent"
+run_test "trace__same_symbol"    trace "$CLASS_NAME" "$CLASS_NAME"

--- a/kodex/tests/snapshot/run.sh
+++ b/kodex/tests/snapshot/run.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Snapshot integration tests for kodex.
+# Runs every command against a real project index and compares output to golden files.
+#
+# Usage:
+#   ./run.sh                     # run all tests, compare against snapshots
+#   ./run.sh --update            # regenerate all snapshots
+#   ./run.sh --update <name>     # regenerate one specific snapshot
+#
+# Environment:
+#   KODEX      path to kodex binary     (default: ../../target/release/kodex)
+#   PROJECT  path to Mill workspace root (required)
+#   IDX        path to kodex.idx        (default: $PROJECT/.scalex/kodex.idx)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SNAP_DIR="$SCRIPT_DIR/snapshots"
+KODEX="${KODEX:-$SCRIPT_DIR/../../target/release/kodex}"
+if [ -z "${PROJECT:-}" ]; then
+    echo -e "${RED}PROJECT not set${NC}"
+    echo "Set PROJECT to your Mill workspace root. Example:"
+    echo "  PROJECT=/path/to/your/project ./run.sh"
+    exit 1
+fi
+IDX="${IDX:-$PROJECT/.scalex/kodex.idx}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Mode detection
+UPDATE=false
+UPDATE_TARGET=""
+if [ "${1:-}" = "--update" ]; then
+    UPDATE=true
+    UPDATE_TARGET="${2:-}"
+fi
+
+# Verify binary exists
+if [ ! -x "$KODEX" ]; then
+    echo -e "${RED}kodex binary not found at $KODEX${NC}"
+    echo "Run: cd kodex && cargo build --release"
+    exit 1
+fi
+
+# Verify queries.sh exists
+if [ ! -f "$SCRIPT_DIR/queries.sh" ]; then
+    echo -e "${RED}queries.sh not found${NC}"
+    echo "Copy queries.sh.example to queries.sh and fill in real symbol names."
+    exit 1
+fi
+
+# Build index if missing
+if [ ! -f "$IDX" ]; then
+    echo -e "${CYAN}Index not found at $IDX. Building...${NC}"
+    "$KODEX" index --root "$PROJECT"
+    echo ""
+fi
+
+mkdir -p "$SNAP_DIR"
+
+PASS=0
+FAIL=0
+NEW=0
+SKIP=0
+
+# run_test <test_name> <kodex_args...>
+# Runs a kodex command, captures stdout, compares against snapshot.
+run_test() {
+    local name="$1"; shift
+
+    # If --update with a specific target, skip non-matching tests
+    if $UPDATE && [ -n "$UPDATE_TARGET" ] && [ "$name" != "$UPDATE_TARGET" ]; then
+        SKIP=$((SKIP + 1))
+        return
+    fi
+
+    local snap_file="$SNAP_DIR/${name}.stdout"
+
+    # Capture stdout only (stderr has disambiguation messages, timings)
+    local actual
+    actual=$("$KODEX" "$@" --idx "$IDX" 2>/dev/null) || actual="[ERROR: exit code $?]"
+
+    if $UPDATE; then
+        printf '%s' "$actual" > "$snap_file"
+        echo -e "${YELLOW}UPDATED${NC} $name"
+        NEW=$((NEW + 1))
+        return
+    fi
+
+    if [ ! -f "$snap_file" ]; then
+        printf '%s' "$actual" > "$snap_file"
+        echo -e "${YELLOW}NEW${NC}     $name (snapshot created)"
+        NEW=$((NEW + 1))
+        return
+    fi
+
+    local expected
+    expected=$(cat "$snap_file")
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "${GREEN}PASS${NC}    $name"
+        PASS=$((PASS + 1))
+    else
+        echo -e "${RED}FAIL${NC}    $name"
+        diff --color=always <(echo "$expected") <(echo "$actual") | head -30
+        echo "        (use --update $name to accept)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "kodex snapshot tests"
+echo "  binary:  $KODEX"
+echo "  project: $PROJECT"
+echo "  index:   $IDX"
+echo ""
+
+# Source test case definitions
+source "$SCRIPT_DIR/queries.sh"
+
+# Summary
+echo ""
+echo "========================================"
+echo -e "Results: ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}, ${YELLOW}$NEW new${NC}, $SKIP skipped"
+echo "========================================"
+if [ $FAIL -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- Add shell-based snapshot test infrastructure for kodex at `kodex/tests/snapshot/`
- `run.sh`: generic test runner (3 modes: compare, update all, update one)
- `queries.sh.example`: 41 test case template across all 12 query commands (def, refs, callers, callees, hierarchy, members, overrides, type, orient, explore, flow, impact, trace)
- `queries.sh` and `snapshots/` are gitignored — they contain real project output with proprietary names

## How it works
1. Copy `queries.sh.example` → `queries.sh`, fill in real symbols
2. `./run.sh` — first run creates golden files (all NEW)
3. `./run.sh` — subsequent runs compare (PASS/FAIL with diff)
4. `./run.sh --update` — regenerate after intentional changes

## Test plan
- [x] Verify only `run.sh` and `queries.sh.example` are tracked (no proprietary data)
- [ ] Build kodex, fill in queries.sh, run against stargazer

🤖 Generated with [Claude Code](https://claude.com/claude-code)