### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,16 @@ Built with [Claude Code](https://claude.ai/code) powered by **Claude Opus 4.6** 
 
 A **kestrel** — the smallest falcon. Fast, sharp-eyed, lightweight, hovers before diving. See [MASCOT.md](site/MASCOT.md) for the full design brief.
 
+## Star History
+
+<a href="https://www.star-history.com/#nguyenyou/scalex&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add star history chart section to README using star-history.com, with dark/light mode support

## Test plan
- [ ] Verify chart renders on GitHub README in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)