### PR TITLE
docs: fix star history chart URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,11 +461,11 @@ A **kestrel** — the smallest falcon. Fast, sharp-eyed, lightweight, hovers bef
 
 ## Star History
 
-<a href="https://www.star-history.com/#nguyenyou/scalex&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=nguyenyou%2Fscalex&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=nguyenyou/scalex&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=nguyenyou/scalex&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=nguyenyou/scalex&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=nguyenyou/scalex&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
## Summary
- Switch Star History API from `/svg` to `/image` endpoint for proper rendering
- Fix anchor link URL encoding (`#` → `?repos=...%2F...`)

## Test plan
- [ ] Verify star history chart renders correctly in README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)