### PR TITLE
feat: add MCP server mode for Cursor, Windsurf, Cline integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- `mcp` — MCP (Model Context Protocol) server mode over STDIO; exposes all 29 scalex commands as MCP tools (`scalex_search`, `scalex_def`, `scalex_refs`, etc.); enables integration with Cursor, Windsurf, Cline, and any MCP-compatible coding tool; in-memory index caching between tool calls for faster response times
+
 ## [1.38.0] — 2026-03-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ scala-cli run src/ -- <command> [args...]
 # Run tests
 scala-cli test src/ tests/
 
+# Run a single test suite
+scala-cli test src/ tests/ --test-only 'ExtractionSuite'
+
+# Run a single test by name substring
+scala-cli test src/ tests/ -- '*keyword*'
+
 # Build GraalVM native image (requires GraalVM + scala-cli)
 ./build-native.sh
 # Output: ./scalex (26MB standalone binary)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Here's the architecture (generated with `scalex graph --render`):
  └─────────────┘ └─────────────────┘ └────────────┘
 ```
 
-- **scalex CLI** — 30 commands: search, def, impl, refs, imports, members, graph, ...
+- **scalex CLI** — 31 commands: search, def, impl, refs, imports, members, graph, mcp, ...
 - **WorkspaceIndex** — lazy indexes: symbolsByName, parentIndex, filesByPath, bloom filters
 - **git ls-files** — `--stage` returns path + OID per tracked file (change detection)
 - **Scalameta AST** — Source → AST → SymbolInfo, BloomFilter, imports, parents
@@ -147,6 +147,40 @@ Installs the binary + skill (teaches Claude when and how to use scalex) in one s
 Then try:
 
 > *"use scalex to explore how authentication works in this codebase"*
+
+### MCP server (Cursor, Windsurf, Cline, and others)
+
+Scalex includes a built-in MCP server that exposes all commands as tools over STDIO. This works with any tool that supports the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+Add to your MCP configuration (e.g. `.cursor/mcp.json`, `~/.codeium/windsurf/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "scalex": {
+      "type": "stdio",
+      "command": "/path/to/scalex",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Or run from source without building a native image:
+
+```json
+{
+  "mcpServers": {
+    "scalex": {
+      "type": "stdio",
+      "command": "scala-cli",
+      "args": ["run", "/path/to/scalex/src/", "--power", "--", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server keeps the index in memory between tool calls — no re-loading on each invocation. Each scalex command becomes an MCP tool (e.g. `scalex_search`, `scalex_def`, `scalex_refs`). All tools accept `workspace` (project root path), `query` (for commands that need one), and `args` (additional CLI flags).
 
 ### Other coding agents
 
@@ -291,6 +325,7 @@ scalex summary <package>        Sub-packages with symbol counts   (aka: package 
 scalex entrypoints              Find @main, def main, extends App, test suites
 scalex graph --render "A->B"   Render directed graph as ASCII/Unicode art
 scalex graph --parse           Parse ASCII diagram from stdin into boxes+edges
+scalex mcp                     Start MCP server (JSON-RPC over stdio)
 ```
 
 All commands support `--json`, `--path PREFIX`, `--exclude-path PREFIX`, `--no-tests`, `--in-package PKG`, `--max-output N`, and `--limit N` (0 = unlimited). See the full [command reference and options](plugins/scalex/skills/scalex/SKILL.md) for detailed usage, examples, and all flags.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,14 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### MCP server — use scalex from Cursor, Windsurf, Cline, and any MCP-compatible tool
+
+- [x] `scalex mcp` subcommand — starts a persistent MCP server over STDIO (JSON-RPC 2.0)
+- [x] One MCP tool per command (`scalex_search`, `scalex_def`, `scalex_refs`, etc.) — 29 tools total
+- [x] In-memory index caching between tool calls — avoids re-loading index on each invocation
+- [x] Minimal built-in JSON parser (`McpJson` enum) — no new dependencies
+- [x] Configuration examples for Cursor, Windsurf, Cline in README
+
 ### Community feedback: output budgets & package-scoped refs (#252)
 
 - [x] `--max-output N` global output budget — truncate any command's output at N characters with pagination hint; wraps `render()` centrally via `BudgetPrintStream` in `runCommand`; also serves as per-query budget in `batch` mode

--- a/plugins/scalex/skills/scalex/references/commands.md
+++ b/plugins/scalex/skills/scalex/references/commands.md
@@ -292,6 +292,10 @@ echo -e "def UserService\ngrep processPayment\nimpl UserService" | scalex batch 
 
 Normally not needed — every command auto-reindexes changed files. Use after major branch switches or large merges to get a clean reindex.
 
+### `scalex mcp` — MCP server mode
+
+Starts a persistent MCP (Model Context Protocol) server over STDIO. Exposes all scalex commands as MCP tools (`scalex_search`, `scalex_def`, `scalex_refs`, etc.) for integration with Cursor, Windsurf, Cline, and any MCP-compatible tool. The index is cached in memory between tool calls for faster response times.
+
 ---
 
 ## Options

--- a/site/index.html
+++ b/site/index.html
@@ -963,7 +963,7 @@
             <div class="stat-label">Warm Query</div>
           </div>
           <div class="stat-item">
-            <div class="stat-value">30</div>
+            <div class="stat-value">31</div>
             <div class="stat-label">Commands</div>
           </div>
         </div>
@@ -1220,13 +1220,13 @@
     </section>
 
     <!-- ===========================================
-         SLIDE 7: 30 COMMANDS
+         SLIDE 7: 31 COMMANDS
          =========================================== -->
     <section class="slide content-slide" data-slide="6">
       <span class="slide-number">06</span>
       <div class="slide-content">
         <h2 class="reveal">
-          30 commands. <span class="red">Zero config.</span>
+          31 commands. <span class="red">Zero config.</span>
         </h2>
         <div class="cmd-grid">
           <div class="cmd-card reveal">

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -239,6 +239,7 @@ private def flagsToContext(f: ParsedFlags, idx: WorkspaceIndex, workspace: Path,
         |  scalex entrypoints              Find @main, def main, extends App, test suites
         |  scalex graph --render "A->B"    Render directed graph as ASCII/Unicode art
         |  scalex graph --parse            Parse ASCII diagram from stdin into boxes+edges
+        |  scalex mcp                      Start MCP server (JSON-RPC over stdio)
         |
         |Options:
         |  -w, --workspace PATH  Set workspace path (default: current directory)
@@ -326,6 +327,9 @@ private def flagsToContext(f: ParsedFlags, idx: WorkspaceIndex, workspace: Path,
           Timings.report()
           println()
         line = reader.readLine()
+
+    case "mcp" :: _ =>
+      McpServer.run()
 
     case "graph" :: _ =>
       // graph command doesn't need workspace index — extract raw args after "graph", strip global flags

--- a/src/mcp.scala
+++ b/src/mcp.scala
@@ -1,0 +1,310 @@
+import java.io.{BufferedReader, ByteArrayOutputStream, InputStreamReader, PrintStream}
+import java.nio.file.Path
+
+// ── Minimal JSON (just enough for MCP JSON-RPC) ────────────────────────────
+
+enum McpJson:
+  case Str(value: String)
+  case Num(value: Double)
+  case Bool(value: Boolean)
+  case Null
+  case Arr(values: List[McpJson])
+  case Obj(fields: List[(key: String, value: McpJson)])
+
+  def apply(k: String): McpJson = this match
+    case Obj(fields) => fields.find(_.key == k).map(_.value).getOrElse(McpJson.Null)
+    case _ => McpJson.Null
+
+  def asStr: Option[String] = this match
+    case Str(v) => Some(v)
+    case _ => None
+
+  def asNum: Option[Double] = this match
+    case Num(v) => Some(v)
+    case _ => None
+
+  def asArr: Option[List[McpJson]] = this match
+    case Arr(vs) => Some(vs)
+    case _ => None
+
+  def asBool: Option[Boolean] = this match
+    case Bool(v) => Some(v)
+    case _ => None
+
+object McpJson:
+  def parse(input: String): McpJson =
+    val r = Reader(input)
+    parseValue(r)
+
+  private class Reader(val s: String, var pos: Int = 0):
+    def peek: Char = if pos < s.length then s.charAt(pos) else '\u0000'
+    def next(): Char = { val c = peek; pos += 1; c }
+    def skip(): Unit = while pos < s.length && s.charAt(pos).isWhitespace do pos += 1
+
+  private def parseValue(r: Reader): McpJson =
+    r.skip()
+    r.peek match
+      case '"' => parseStr(r)
+      case '{' => parseObj(r)
+      case '[' => parseArr(r)
+      case 't' => r.pos += 4; Bool(true)
+      case 'f' => r.pos += 5; Bool(false)
+      case 'n' => r.pos += 4; Null
+      case _   => parseNum(r)
+
+  private def parseStr(r: Reader): Str =
+    r.next() // skip opening "
+    val sb = StringBuilder()
+    while r.peek != '"' && r.peek != '\u0000' do
+      if r.peek == '\\' then
+        r.next()
+        r.next() match
+          case '"'  => sb.append('"')
+          case '\\' => sb.append('\\')
+          case '/'  => sb.append('/')
+          case 'n'  => sb.append('\n')
+          case 'r'  => sb.append('\r')
+          case 't'  => sb.append('\t')
+          case 'u'  =>
+            val hex = new String(Array(r.next(), r.next(), r.next(), r.next()))
+            sb.append(Integer.parseInt(hex, 16).toChar)
+          case c => sb.append(c)
+      else sb.append(r.next())
+    r.next() // skip closing "
+    Str(sb.toString)
+
+  private def parseNum(r: Reader): Num =
+    val start = r.pos
+    if r.peek == '-' then r.next()
+    while r.peek.isDigit do r.next()
+    if r.peek == '.' then { r.next(); while r.peek.isDigit do r.next() }
+    if r.peek == 'e' || r.peek == 'E' then
+      r.next()
+      if r.peek == '+' || r.peek == '-' then r.next()
+      while r.peek.isDigit do r.next()
+    Num(r.s.substring(start, r.pos).toDouble)
+
+  private def parseObj(r: Reader): Obj =
+    r.next() // skip {
+    r.skip()
+    if r.peek == '}' then
+      r.next()
+      Obj(Nil)
+    else
+      val fields = scala.collection.mutable.ListBuffer[(key: String, value: McpJson)]()
+      var more = true
+      while more do
+        r.skip()
+        val k = parseStr(r).value
+        r.skip(); r.next() // skip :
+        fields += ((key = k, value = parseValue(r)))
+        r.skip()
+        if r.peek == ',' then r.next() else more = false
+      r.skip(); r.next() // skip }
+      Obj(fields.toList)
+
+  private def parseArr(r: Reader): Arr =
+    r.next() // skip [
+    r.skip()
+    if r.peek == ']' then
+      r.next()
+      Arr(Nil)
+    else
+      val values = scala.collection.mutable.ListBuffer[McpJson]()
+      var more = true
+      while more do
+        values += parseValue(r)
+        r.skip()
+        if r.peek == ',' then r.next() else more = false
+      r.skip(); r.next() // skip ]
+      Arr(values.toList)
+
+// ── MCP Server ────────────────────────────────────────────────────────────
+
+object McpServer:
+  private val indexCache = scala.collection.mutable.Map[Path, WorkspaceIndex]()
+
+  private val validCmds: Set[String] = commands.keySet + "graph"
+
+  private case class ToolDef(name: String, desc: String, queryDesc: Option[String])
+
+  private val toolDefs: List[ToolDef] = List(
+    ToolDef("search", "Search symbols by name (fuzzy camelCase matching). Returns matching classes, traits, objects, methods, types.", Some("Symbol name to search for")),
+    ToolDef("def", "Find where a symbol is defined — returns file path and line number.", Some("Symbol name")),
+    ToolDef("impl", "Find all implementations/extensions of a trait or class.", Some("Trait or class name")),
+    ToolDef("refs", "Find all references to a symbol, categorized by type (definition, extension, import, type usage, call site).", Some("Symbol name")),
+    ToolDef("imports", "Find all files that import a symbol.", Some("Symbol name")),
+    ToolDef("members", "List members of a class, trait, or object. Supports --inherited, --body, --brief.", Some("Class, trait, or object name")),
+    ToolDef("doc", "Show Scaladoc documentation for a symbol.", Some("Symbol name")),
+    ToolDef("symbols", "List all symbols defined in a file.", Some("File path relative to workspace")),
+    ToolDef("file", "Search files by name (fuzzy camelCase matching).", Some("File name or pattern")),
+    ToolDef("annotated", "Find symbols with a specific annotation (e.g. main, deprecated).", Some("Annotation name")),
+    ToolDef("grep", "Regex search in file contents. Supports --in <Type>, --each-method, --count.", Some("Regex pattern")),
+    ToolDef("package", "List symbols in a package. Use --explain for brief explanation of each type.", Some("Package name")),
+    ToolDef("body", "Extract source code of a method, val, or class. Supports -C N context lines, --imports.", Some("Symbol name")),
+    ToolDef("hierarchy", "Show full inheritance tree — parents and children. Use --up/--down/--depth N.", Some("Class or trait name")),
+    ToolDef("overrides", "Find override implementations of a method across the codebase.", Some("Method name")),
+    ToolDef("explain", "Composite one-shot summary: definition + scaladoc + members + implementations + imports.", Some("Symbol name")),
+    ToolDef("deps", "Show symbol dependencies — what this symbol depends on.", Some("Symbol name")),
+    ToolDef("context", "Show enclosing scopes at a specific file location.", Some("file:line (e.g. src/Main.scala:42)")),
+    ToolDef("diff", "Symbol-level diff: what symbols were added/removed/changed vs a git ref.", Some("Git ref (branch, tag, or commit)")),
+    ToolDef("coverage", "Check if a symbol is tested — finds test files that reference it.", Some("Symbol name")),
+    ToolDef("api", "Show public API surface of a package — symbols imported by other packages.", Some("Package name")),
+    ToolDef("summary", "Show sub-packages with symbol counts.", Some("Package name")),
+    ToolDef("overview", "Codebase summary: packages, hub types, dependency graph. Use --architecture, --concise.", None),
+    ToolDef("packages", "List all packages in the workspace.", None),
+    ToolDef("index", "Rebuild the workspace index from scratch.", None),
+    ToolDef("ast-pattern", "Structural AST search. Use --has-method NAME, --extends TRAIT, --body-contains PAT.", None),
+    ToolDef("tests", "List test cases structurally (MUnit, ScalaTest, specs2). Use --count for summary.", None),
+    ToolDef("entrypoints", "Find @main, def main, extends App, and test suites.", None),
+    ToolDef("graph", "Render a directed graph as ASCII/Unicode art.", Some("Graph expression (e.g. 'A->B, B->C')")),
+  )
+
+  def run(): Unit =
+    val reader = BufferedReader(InputStreamReader(System.in))
+    // Save the real stdout for JSON-RPC responses; redirect System.out so command
+    // output doesn't leak into the protocol stream
+    val jsonOut = System.out
+    val nullStream = PrintStream(java.io.OutputStream.nullOutputStream())
+    System.setOut(nullStream)
+    Console.withOut(nullStream) {
+      var running = true
+      while running do
+        val line = reader.readLine()
+        if line == null then running = false
+        else if line.trim.nonEmpty then
+          try
+            val msg = McpJson.parse(line)
+            try
+              handleMessage(msg).foreach { response =>
+                jsonOut.println(response)
+                jsonOut.flush()
+              }
+            catch
+              case e: Exception =>
+                System.err.println(s"scalex MCP: internal error: ${e.getMessage}")
+                val id = msg("id")
+                val errResp = jsonRpcError(id, -32603, s"Internal error: ${Option(e.getMessage).getOrElse(e.getClass.getName)}")
+                jsonOut.println(errResp)
+                jsonOut.flush()
+          catch
+            case e: Exception =>
+              System.err.println(s"scalex MCP: parse error: ${e.getMessage}")
+              val errResp = jsonRpcError(McpJson.Null, -32700, s"Parse error: ${Option(e.getMessage).getOrElse("invalid JSON")}")
+              jsonOut.println(errResp)
+              jsonOut.flush()
+    }
+
+  private def handleMessage(msg: McpJson): Option[String] =
+    val id = msg("id")
+    val method = msg("method").asStr.getOrElse("")
+    method match
+      case "initialize"                => Some(respondInitialize(id))
+      case "notifications/initialized" => None
+      case "tools/list"                => Some(respondToolsList(id))
+      case "tools/call"                => Some(respondToolsCall(id, msg("params")))
+      case "ping"                      => Some(jsonRpcResult(id, "{}"))
+      case _ =>
+        if id == McpJson.Null then None // unknown notification — ignore
+        else Some(jsonRpcError(id, -32601, s"Method not found: $method"))
+
+  // ── Protocol responses ──────────────────────────────────────────────────
+
+  private def respondInitialize(id: McpJson): String =
+    jsonRpcResult(id,
+      s"""{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"scalex","version":"${jsonEscape(ScalexVersion)}"}}""")
+
+  private def respondToolsList(id: McpJson): String =
+    val tools = toolDefs.map { td =>
+      val props = StringBuilder()
+      props.append(""""workspace":{"type":"string","description":"Absolute path to the project root"}""")
+      td.queryDesc.foreach { qd =>
+        props.append(s""","query":{"type":"string","description":"${jsonEscape(qd)}"}""")
+      }
+      props.append(""","args":{"type":"array","items":{"type":"string"},"description":"Additional CLI flags (e.g. [\"--verbose\", \"--json\", \"--kind\", \"class\"])"}""")
+      val required = if td.queryDesc.isDefined then """"workspace","query"""" else """"workspace""""
+      s"""{"name":"scalex_${td.name}","description":"${jsonEscape(td.desc)}","inputSchema":{"type":"object","properties":{${props.toString}},"required":[$required]}}"""
+    }.mkString("[", ",", "]")
+    jsonRpcResult(id, s"""{"tools":$tools}""")
+
+  private def respondToolsCall(id: McpJson, params: McpJson): String =
+    val toolName = params("name").asStr.getOrElse("")
+    val arguments = params("arguments")
+    val cmd = toolName.stripPrefix("scalex_")
+
+    if !validCmds.contains(cmd) then
+      toolResult(id, s"Unknown tool: $toolName", isError = true)
+    else
+      val workspace = arguments("workspace").asStr.getOrElse(".")
+      val query = arguments("query").asStr
+      val extraArgs = arguments("args").asArr.getOrElse(Nil).flatMap(_.asStr)
+
+      try
+        val wsPath = resolveWorkspace(workspace)
+        val allArgs = query.toList ++ extraArgs
+        val flags = parseFlags(allArgs)
+        Timings.enabled = flags.timingsEnabled
+
+        val output =
+          if cmd == "graph" then
+            val graphArgs = query.map(q => List("--render", q)).getOrElse(Nil) ++
+              extraArgs.filterNot(_ == "--parse") // --parse reads stdin, not available in MCP
+            val dummyIdx = WorkspaceIndex(wsPath, needBlooms = false)
+            val ctx = flagsToContext(flags, dummyIdx, wsPath)
+            captureOutput { renderWithBudget(cmdGraph(graphArgs, ctx), ctx) }
+          else if cmd == "index" then
+            indexCache.remove(wsPath)
+            val idx = WorkspaceIndex(wsPath, needBlooms = true)
+            idx.index()
+            indexCache(wsPath) = idx
+            val ctx = flagsToContext(flags, idx, wsPath)
+            captureOutput { renderWithBudget(cmdIndex(Nil, ctx), ctx) }
+          else
+            val idx = indexCache.getOrElseUpdate(wsPath, {
+              val i = WorkspaceIndex(wsPath, needBlooms = true)
+              i.index()
+              i
+            })
+            idx.index() // incremental update — checks OIDs, re-parses only changed files
+            val effectiveNoTests = if cmd == "overview" && !flags.includeTests then true else flags.noTests
+            val ctx = flagsToContext(flags, idx, wsPath, effectiveNoTests = Some(effectiveNoTests))
+            captureOutput { runCommand(cmd, flags.cleanArgs, ctx) }
+
+        Timings.report()
+        Timings.enabled = false
+        toolResult(id, output)
+      catch
+        case e: Exception =>
+          Timings.enabled = false
+          val msg = Option(e.getMessage).getOrElse(e.getClass.getName)
+          toolResult(id, s"Error: $msg", isError = true)
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private def captureOutput(block: => Unit): String =
+    val baos = ByteArrayOutputStream()
+    val ps = PrintStream(baos, true, "UTF-8")
+    val savedOut = System.out
+    System.setOut(ps)
+    try Console.withOut(ps) { block }
+    finally System.setOut(savedOut)
+    baos.toString("UTF-8").stripTrailing()
+
+  private def toolResult(id: McpJson, text: String, isError: Boolean = false): String =
+    val errField = if isError then ""","isError":true""" else ""
+    jsonRpcResult(id, s"""{"content":[{"type":"text","text":"${jsonEscape(text)}"}]$errField}""")
+
+  private def jsonRpcResult(id: McpJson, result: String): String =
+    s"""{"jsonrpc":"2.0","id":${formatId(id)},"result":$result}"""
+
+  private def jsonRpcError(id: McpJson, code: Int, message: String): String =
+    s"""{"jsonrpc":"2.0","id":${formatId(id)},"error":{"code":$code,"message":"${jsonEscape(message)}"}}"""
+
+  // Test-only entry points
+  def testHandleMessage(msg: McpJson): Option[String] = handleMessage(msg)
+  def testClearCache(): Unit = indexCache.clear()
+
+  private def formatId(id: McpJson): String = id match
+    case McpJson.Num(n) => if n == n.toLong then n.toLong.toString else n.toString
+    case McpJson.Str(s) => s""""${jsonEscape(s)}""""
+    case _ => "null"

--- a/tests/mcp.test.scala
+++ b/tests/mcp.test.scala
@@ -1,0 +1,346 @@
+import munit.FunSuite
+
+class McpSuite extends FunSuite:
+
+  // ── JSON parser ─────────────────────────────────────────────────────────
+
+  test("McpJson parses strings") {
+    val result = McpJson.parse(""""hello world"""")
+    assertEquals(result, McpJson.Str("hello world"))
+  }
+
+  test("McpJson parses strings with escapes") {
+    val result = McpJson.parse(""""line1\\nline2\ttab\""""")
+    assertEquals(result, McpJson.Str("line1\\nline2\ttab\""))
+  }
+
+  test("McpJson parses unicode escapes") {
+    val result = McpJson.parse(""""\\u0048ello"""")
+    // \\u0048 is literal backslash + u0048 in JSON, but \u0048 is 'H'
+    val result2 = McpJson.parse(""""\u0048ello"""")
+    assertEquals(result2, McpJson.Str("Hello"))
+  }
+
+  test("McpJson parses integers") {
+    val result = McpJson.parse("42")
+    assertEquals(result, McpJson.Num(42.0))
+  }
+
+  test("McpJson parses negative numbers") {
+    val result = McpJson.parse("-3.14")
+    assertEquals(result, McpJson.Num(-3.14))
+  }
+
+  test("McpJson parses booleans and null") {
+    assertEquals(McpJson.parse("true"), McpJson.Bool(true))
+    assertEquals(McpJson.parse("false"), McpJson.Bool(false))
+    assertEquals(McpJson.parse("null"), McpJson.Null)
+  }
+
+  test("McpJson parses arrays") {
+    val result = McpJson.parse("""[1, "two", true, null]""")
+    assertEquals(result, McpJson.Arr(List(
+      McpJson.Num(1.0), McpJson.Str("two"), McpJson.Bool(true), McpJson.Null
+    )))
+  }
+
+  test("McpJson parses empty array") {
+    assertEquals(McpJson.parse("[]"), McpJson.Arr(Nil))
+  }
+
+  test("McpJson parses objects") {
+    val result = McpJson.parse("""{"name": "scalex", "version": 1}""")
+    assertEquals(result, McpJson.Obj(List(
+      (key = "name", value = McpJson.Str("scalex")),
+      (key = "version", value = McpJson.Num(1.0))
+    )))
+  }
+
+  test("McpJson parses empty object") {
+    assertEquals(McpJson.parse("{}"), McpJson.Obj(Nil))
+  }
+
+  test("McpJson parses nested structures") {
+    val result = McpJson.parse("""{"a": {"b": [1, 2]}, "c": null}""")
+    val a = result("a")
+    assertEquals(a("b"), McpJson.Arr(List(McpJson.Num(1.0), McpJson.Num(2.0))))
+    assertEquals(result("c"), McpJson.Null)
+  }
+
+  test("McpJson.apply returns Null for missing keys") {
+    val obj = McpJson.parse("""{"a": 1}""")
+    assertEquals(obj("missing"), McpJson.Null)
+  }
+
+  test("McpJson.apply on non-object returns Null") {
+    assertEquals(McpJson.Str("hello")("key"), McpJson.Null)
+  }
+
+  test("McpJson.asStr extracts string values") {
+    assertEquals(McpJson.Str("hello").asStr, Some("hello"))
+    assertEquals(McpJson.Num(42.0).asStr, None)
+  }
+
+  test("McpJson.asNum extracts numeric values") {
+    assertEquals(McpJson.Num(42.0).asNum, Some(42.0))
+    assertEquals(McpJson.Str("hello").asNum, None)
+  }
+
+  test("McpJson.asArr extracts array values") {
+    assertEquals(McpJson.Arr(Nil).asArr, Some(Nil))
+    assertEquals(McpJson.Str("hello").asArr, None)
+  }
+
+  test("McpJson.asBool extracts boolean values") {
+    assertEquals(McpJson.Bool(true).asBool, Some(true))
+    assertEquals(McpJson.Null.asBool, None)
+  }
+
+  test("McpJson parseStr handles unterminated string without infinite loop") {
+    // Should not hang — EOF terminates the parse
+    val result = McpJson.parse(""""unterminated""")
+    assertEquals(result, McpJson.Str("unterminated"))
+  }
+
+  test("McpJson parses scientific notation") {
+    val result = McpJson.parse("1.5e10")
+    assertEquals(result, McpJson.Num(1.5e10))
+  }
+
+  test("McpJson parses deeply nested structures") {
+    val result = McpJson.parse("""{"a":{"b":{"c":{"d":42}}}}""")
+    assertEquals(result("a")("b")("c")("d").asNum, Some(42.0))
+  }
+
+  // ── JSON-RPC message parsing ────────────────────────────────────────────
+
+  test("McpJson parses initialize request") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cursor","version":"1.0"}}}""")
+    assertEquals(msg("jsonrpc").asStr, Some("2.0"))
+    assertEquals(msg("id").asNum, Some(1.0))
+    assertEquals(msg("method").asStr, Some("initialize"))
+    assertEquals(msg("params")("protocolVersion").asStr, Some("2024-11-05"))
+    assertEquals(msg("params")("clientInfo")("name").asStr, Some("cursor"))
+  }
+
+  test("McpJson parses tools/call request") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"scalex_search","arguments":{"workspace":"/tmp/project","query":"UserService","args":["--verbose","--kind","class"]}}}""")
+    assertEquals(msg("method").asStr, Some("tools/call"))
+    val params = msg("params")
+    assertEquals(params("name").asStr, Some("scalex_search"))
+    val args = params("arguments")
+    assertEquals(args("workspace").asStr, Some("/tmp/project"))
+    assertEquals(args("query").asStr, Some("UserService"))
+    val extraArgs = args("args").asArr.get.flatMap(_.asStr)
+    assertEquals(extraArgs, List("--verbose", "--kind", "class"))
+  }
+
+  test("McpJson parses notification (no id)") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+    assertEquals(msg("method").asStr, Some("notifications/initialized"))
+    assertEquals(msg("id"), McpJson.Null)
+  }
+
+  // ── MCP protocol responses ──────────────────────────────────────────────
+
+  test("McpServer.handleMessage returns initialize response") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isDefined, "initialize should return a response")
+    val resp = McpJson.parse(response.get)
+    assertEquals(resp("jsonrpc").asStr, Some("2.0"))
+    assertEquals(resp("id").asNum, Some(1.0))
+    val result = resp("result")
+    assertEquals(result("protocolVersion").asStr, Some("2024-11-05"))
+    assertEquals(result("serverInfo")("name").asStr, Some("scalex"))
+    assertEquals(result("serverInfo")("version").asStr, Some(ScalexVersion))
+  }
+
+  test("McpServer.handleMessage returns no response for notifications") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isEmpty, "notifications should not return a response")
+  }
+
+  test("McpServer.handleMessage returns tools list") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isDefined, "tools/list should return a response")
+    val resp = McpJson.parse(response.get)
+    val tools = resp("result")("tools").asArr.get
+    assert(tools.nonEmpty, "should have tools")
+    // Verify expected tool names exist
+    val toolNames = tools.flatMap(t => t("name").asStr).toSet
+    assert(toolNames.contains("scalex_search"), s"should have scalex_search: $toolNames")
+    assert(toolNames.contains("scalex_def"), s"should have scalex_def: $toolNames")
+    assert(toolNames.contains("scalex_refs"), s"should have scalex_refs: $toolNames")
+    assert(toolNames.contains("scalex_overview"), s"should have scalex_overview: $toolNames")
+    assert(toolNames.contains("scalex_graph"), s"should have scalex_graph: $toolNames")
+    assert(toolNames.contains("scalex_mcp") == false, "should not have scalex_mcp (mcp is a mode, not a tool)")
+    assert(toolNames.contains("scalex_batch") == false, "should not have scalex_batch (use individual tool calls)")
+  }
+
+  test("McpServer.handleMessage returns tool schemas with workspace") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val tools = McpJson.parse(response.get)("result")("tools").asArr.get
+    // Check a tool with query
+    val searchTool = tools.find(t => t("name").asStr.contains("scalex_search")).get
+    val schema = searchTool("inputSchema")
+    val required = schema("required").asArr.get.flatMap(_.asStr)
+    assert(required.contains("workspace"), "search should require workspace")
+    assert(required.contains("query"), "search should require query")
+    // Check a tool without query
+    val overviewTool = tools.find(t => t("name").asStr.contains("scalex_overview")).get
+    val overviewRequired = overviewTool("inputSchema")("required").asArr.get.flatMap(_.asStr)
+    assert(overviewRequired.contains("workspace"), "overview should require workspace")
+    assert(!overviewRequired.contains("query"), "overview should not require query")
+  }
+
+  test("McpServer.handleMessage returns error for unknown method") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":99,"method":"unknown/method"}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isDefined, "unknown method should return error")
+    val resp = McpJson.parse(response.get)
+    assertEquals(resp("error")("code").asNum, Some(-32601.0))
+  }
+
+  test("McpServer.handleMessage ignores unknown notifications") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","method":"unknown/notification"}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isEmpty, "unknown notification should be ignored")
+  }
+
+  test("McpServer.handleMessage responds to ping") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":5,"method":"ping"}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isDefined, "ping should return a response")
+    val resp = McpJson.parse(response.get)
+    assertEquals(resp("id").asNum, Some(5.0))
+  }
+
+  test("McpServer.handleMessage returns error for unknown tool") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scalex_nonexistent","arguments":{"workspace":"/tmp"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    val content = resp("result")("content").asArr.get.head
+    assert(content("text").asStr.get.contains("Unknown tool"), "should report unknown tool")
+    assertEquals(resp("result")("isError").asBool, Some(true))
+  }
+
+  test("McpServer.handleMessage handles string id") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":"abc-123","method":"ping"}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    assertEquals(resp("id").asStr, Some("abc-123"))
+  }
+
+  test("McpServer tools/call with invalid workspace returns error") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"scalex_search","arguments":{"workspace":"/nonexistent/path/that/does/not/exist","query":"Foo"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    val content = resp("result")("content").asArr.get.head
+    assert(content("text").asStr.get.startsWith("Error:"), s"should report error: ${content("text").asStr}")
+    assertEquals(resp("result")("isError").asBool, Some(true))
+  }
+
+  test("McpServer tools/call with missing query for required-query tool returns result") {
+    // Commands handle missing args gracefully (usage error or empty results)
+    val ws = java.nio.file.Files.createTempDirectory("mcp-missing-query")
+    val msg = McpJson.parse(s"""{"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"scalex_search","arguments":{"workspace":"${jsonEscape(ws.toString)}"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    assert(response.isDefined, "should return a response even without query")
+    deleteRecursive(ws)
+  }
+
+  test("McpServer tool count matches expectation") {
+    val msg = McpJson.parse("""{"jsonrpc":"2.0","id":17,"method":"tools/list","params":{}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val tools = McpJson.parse(response.get)("result")("tools").asArr.get
+    assertEquals(tools.size, 29, s"expected 29 tools, got ${tools.size}")
+  }
+
+  // ── Tool call integration tests ─────────────────────────────────────────
+
+  test("McpServer tools/call scalex_search returns results") {
+    val ws = java.nio.file.Files.createTempDirectory("mcp-test")
+    val srcDir = ws.resolve("src")
+    java.nio.file.Files.createDirectories(srcDir)
+    java.nio.file.Files.writeString(srcDir.resolve("Example.scala"),
+      """package test
+        |class Example {
+        |  def hello: String = "world"
+        |}
+        |""".stripMargin)
+    // Initialize git repo
+    val pb1 = ProcessBuilder("git", "init").directory(ws.toFile)
+    pb1.start().waitFor()
+    val pb2 = ProcessBuilder("git", "add", ".").directory(ws.toFile)
+    pb2.start().waitFor()
+    val pb3 = ProcessBuilder("git", "commit", "-m", "init").directory(ws.toFile)
+    pb3.environment().put("GIT_AUTHOR_NAME", "test")
+    pb3.environment().put("GIT_AUTHOR_EMAIL", "test@test.com")
+    pb3.environment().put("GIT_COMMITTER_NAME", "test")
+    pb3.environment().put("GIT_COMMITTER_EMAIL", "test@test.com")
+    pb3.start().waitFor()
+
+    val msg = McpJson.parse(s"""{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"scalex_search","arguments":{"workspace":"${jsonEscape(ws.toString)}","query":"Example"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    val text = resp("result")("content").asArr.get.head("text").asStr.get
+    assert(text.contains("Example"), s"search result should contain 'Example': $text")
+
+    // Cleanup
+    deleteRecursive(ws)
+    McpServer.testClearCache()
+  }
+
+  test("McpServer tools/call scalex_index rebuilds index") {
+    val ws = java.nio.file.Files.createTempDirectory("mcp-index-test")
+    val srcDir = ws.resolve("src")
+    java.nio.file.Files.createDirectories(srcDir)
+    java.nio.file.Files.writeString(srcDir.resolve("Indexed.scala"),
+      """package indexed
+        |object Indexed
+        |""".stripMargin)
+    val pb1 = ProcessBuilder("git", "init").directory(ws.toFile)
+    pb1.start().waitFor()
+    val pb2 = ProcessBuilder("git", "add", ".").directory(ws.toFile)
+    pb2.start().waitFor()
+    val pb3 = ProcessBuilder("git", "commit", "-m", "init").directory(ws.toFile)
+    pb3.environment().put("GIT_AUTHOR_NAME", "test")
+    pb3.environment().put("GIT_AUTHOR_EMAIL", "test@test.com")
+    pb3.environment().put("GIT_COMMITTER_NAME", "test")
+    pb3.environment().put("GIT_COMMITTER_EMAIL", "test@test.com")
+    pb3.start().waitFor()
+
+    val msg = McpJson.parse(s"""{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{"name":"scalex_index","arguments":{"workspace":"${jsonEscape(ws.toString)}"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    val text = resp("result")("content").asArr.get.head("text").asStr.get
+    // Index stats should mention files and symbols
+    assert(text.contains("file") || text.contains("symbol") || text.contains("Indexed"), s"index result should show stats: $text")
+
+    deleteRecursive(ws)
+    McpServer.testClearCache()
+  }
+
+  test("McpServer tools/call scalex_graph renders graph") {
+    val ws = java.nio.file.Files.createTempDirectory("mcp-graph-test")
+    val msg = McpJson.parse(s"""{"jsonrpc":"2.0","id":30,"method":"tools/call","params":{"name":"scalex_graph","arguments":{"workspace":"${jsonEscape(ws.toString)}","query":"A->B, B->C"}}}""")
+    val response = McpServer.testHandleMessage(msg)
+    val resp = McpJson.parse(response.get)
+    val text = resp("result")("content").asArr.get.head("text").asStr.get
+    assert(text.contains("A"), s"graph should contain node A: $text")
+    assert(text.contains("B"), s"graph should contain node B: $text")
+    assert(text.contains("C"), s"graph should contain node C: $text")
+
+    deleteRecursive(ws)
+  }
+
+  private def deleteRecursive(path: java.nio.file.Path): Unit =
+    if java.nio.file.Files.isDirectory(path) then
+      val stream = java.nio.file.Files.list(path)
+      try stream.forEach(deleteRecursive)
+      finally stream.close()
+    java.nio.file.Files.deleteIfExists(path)


### PR DESCRIPTION
## Summary

- Add `scalex mcp` subcommand — starts a persistent MCP server over STDIO (JSON-RPC 2.0)
- Exposes all 29 scalex commands as MCP tools (`scalex_search`, `scalex_def`, `scalex_refs`, etc.) for integration with Cursor, Windsurf, Cline, and any MCP-compatible coding tool
- In-memory index caching between tool calls — avoids re-loading `.scalex/index.bin` on each invocation
- Minimal built-in JSON parser (`McpJson` enum) — no new dependencies
- 38 new tests (JSON parser, protocol handling, tool dispatch, integration tests with real git repos)

### Configuration

Native binary:
```json
{
  "mcpServers": {
    "scalex": {
      "type": "stdio",
      "command": "/path/to/scalex",
      "args": ["mcp"]
    }
  }
}
```

From source:
```json
{
  "mcpServers": {
    "scalex": {
      "type": "stdio",
      "command": "scala-cli",
      "args": ["run", "/path/to/scalex/src/", "--power", "--", "mcp"]
    }
  }
}
```

### Files changed

| File | Change |
|---|---|
| `src/mcp.scala` | New: JSON parser + MCP server (~310 lines) |
| `src/cli.scala` | `scalex mcp` subcommand + help text |
| `tests/mcp.test.scala` | New: 38 tests |
| `docs/ROADMAP.md` | MCP section, all items checked |
| `CHANGELOG.md` | Entry under [Unreleased] |
| `README.md` | MCP section with config examples, command count 31 |
| `site/index.html` | 30 → 31 commands |
| `plugins/.../commands.md` | `scalex mcp` documentation |
| `CLAUDE.md` | Added single-test-run instructions |

## Test plan

- [x] Zero compiler warnings (`scala-cli compile src/`)
- [x] Zero deprecation warnings (`--scalac-option "-deprecation"`)
- [x] All 485 tests pass (447 existing + 38 new MCP tests)
- [ ] Verify MCP server works with Cursor/Windsurf/Cline
- [ ] Verify native image build includes MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)