### PR TITLE
chore: bump plugin to 1.39.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "scalex",
       "source": "./plugins/scalex",
       "description": "Scala code intelligence for coding agents — search symbols, find definitions, find implementations, find references, explore imports. Works on Scala 2 and 3 codebases without a compiler or build server.",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex/skills/scalex/scripts/scalex-cli
+++ b/plugins/scalex/skills/scalex/scripts/scalex-cli
@@ -7,13 +7,13 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="1.38.0"
+EXPECTED_VERSION="1.39.0"
 REPO="nguyenyou/scalex"
 
 # Expected SHA-256 checksums for each artifact (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_scalex_macos_arm64="6f38cccf85f6e39e3e4095e675c52d547274dd64ae7dd206dfaf06bb2a5ccc4f"
-CHECKSUM_scalex_macos_x64="aa2b643c4688aa4bb9f18f7336bda91d6122dd4c7250e110ac8553c702fac0dd"
-CHECKSUM_scalex_linux_x64="988a137b0bf2ec5a1585c0a1cdb171a38d1085191277815936ad32086aebc349"
+CHECKSUM_scalex_macos_arm64="1b00d2fc1717f4f8717ea59ee5073aacebf0a426b53a23ab31806558f6b2cbd5"
+CHECKSUM_scalex_macos_x64="f00dba4ecb0afdf90b6e965bb759c7620ff021b1b68abe5b3ed202befca6cce3"
+CHECKSUM_scalex_linux_x64="3f8fb6faf5c7f534ad49fbd7efa0d24abaacd8a224b4691c45dc9e1c5b82d5f2"
 
 # Cache location: follow XDG spec (like Mill uses ~/.cache/mill/download/)
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex"


### PR DESCRIPTION
## Summary
Post-release plugin bump for [v1.39.0](https://github.com/nguyenyou/scalex/releases/tag/v1.39.0).

- `plugins/scalex/skills/scalex/scripts/scalex-cli`: `EXPECTED_VERSION` → `1.39.0`, updated per-artifact SHA-256 checksums
- `.claude-plugin/marketplace.json`: `version` → `1.39.0`

Checksums verified from the `.sha256` release assets:
- macos-arm64: `1b00d2fc1717f4f8717ea59ee5073aacebf0a426b53a23ab31806558f6b2cbd5`
- macos-x64:   `f00dba4ecb0afdf90b6e965bb759c7620ff021b1b68abe5b3ed202befca6cce3`
- linux-x64:   `3f8fb6faf5c7f534ad49fbd7efa0d24abaacd8a224b4691c45dc9e1c5b82d5f2`

## Test plan
- [ ] Installing the plugin downloads the v1.39.0 binary and checksum verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)