### PR TITLE
[codex] Migrate build to Mill

### DIFF
--- a/.agents/skills/benchmark/SKILL.md
+++ b/.agents/skills/benchmark/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: benchmark
+description: "Run scalex performance benchmarks, profiling, and timing analysis. Use this skill whenever the user asks to benchmark scalex, measure performance, profile index/query times, compare before/after performance of a change, investigate bottlenecks, or mentions \"benchmark\", \"perf\", \"how fast\", \"timing\", \"hyperfine\", \"profile\", \"flame graph\", \"profiling\", \"--timings\", \"slow\", \"bottleneck\", \"regression\", \"memory\", \"heap\", \"GC\", \"allocation\". Also use proactively after implementing performance improvements to verify gains. Covers 6 layers: built-in --timings, hyperfine benchmarks, async-profiler flame graphs, JFR recording, microbenchmarks, and memory profiling."
+---
+
+## Overview
+
+Scalex has a multi-layered profiling and benchmarking system. Pick the right layer for the situation:
+
+| Layer | Tool | When to use | Works in native? |
+|-------|------|-------------|-------------------|
+| 1. `--timings` | Built-in flag | Quick phase breakdown, first look at any perf question | Yes |
+| 2. hyperfine | `bench.sh` | Reproducible before/after comparison with statistics | Yes |
+| 3. async-profiler | `profiling/profile.sh` | Deep CPU/alloc/lock flame graphs to find hotspots | JVM only |
+| 4. JFR | `profiling/scalex.jfc` | GC pressure, file I/O patterns, thread utilization | JVM only |
+| 5. Microbenchmarks | `src/bench.scala` | Isolate per-function cost with warmup + statistics | JVM only |
+| 6. Memory profiling | `bench.sh memory` | Heap usage, GC pressure, peak memory across scenarios | JVM only |
+
+## Decision guide
+
+**"Where is time spent?"** → Start with `--timings` (Layer 1)
+
+**"Is this change faster?"** → Use hyperfine before/after (Layer 2), optionally with `bench-compare.sh`
+
+**"Why is parsing slow?"** → async-profiler CPU flame graph (Layer 3)
+
+**"Why are allocations high?"** → async-profiler alloc or JFR ObjectAllocationSample (Layer 3/4)
+
+**"Is there GC pressure?"** → JFR (Layer 4)
+
+**"How fast is extractSymbols on one file?"** → Microbenchmark (Layer 5)
+
+**"How much memory does indexing use?"** → Memory profiling (Layer 6)
+
+**"Is there a memory leak or GC regression?"** → Memory profiling before/after (Layer 6)
+
+---
+
+## Layer 1: `--timings` flag
+
+The fastest way to see where time goes. Works in both JVM and native image. Prints to stderr.
+
+```bash
+# Cold index phase breakdown
+rm -rf benchmark/scala3/.scalex
+./scalex index benchmark/scala3 --timings
+
+# Warm index
+./scalex index benchmark/scala3 --timings
+
+# Query with bloom/text-search breakdown
+./scalex refs benchmark/scala3 Compiler --timings
+
+# JVM mode
+scala-cli run src/ -- index benchmark/scala3 --timings
+```
+
+### Phases reported
+
+**Index phases:** `git-ls-files`, `cache-load`, `oid-compare`, `parse`, `index-build`, `cache-save`
+
+**Query phases** (refs/imports/coverage): `bloom-screen`, `text-search`
+
+### Reading the output
+
+```
+Timings:
+  git-ls-files          12.3 ms  ( 1%)
+  cache-load            45.2 ms  ( 5%)
+  oid-compare            3.1 ms  ( 0%)
+  parse                782.0 ms  (80%)
+  index-build           89.4 ms  ( 9%)
+  cache-save            42.1 ms  ( 4%)
+  total                974.1 ms
+```
+
+- **parse > 70%**: Scalameta parsing dominates — look at parallelism, parser options, or reducing parsed file count
+- **cache-load > 20%**: Index deserialization — check bloom skip, file size, buffering
+- **cache-save > 10%**: Index serialization — check if save is running unnecessarily (when `parsedCount == 0`)
+- **bloom-screen > text-search**: Bloom filter is slow — check expected element count, FPP
+- **text-search >> bloom-screen**: Text scanning dominates — check candidate count (bloom too permissive?)
+
+---
+
+## Layer 2: hyperfine benchmarks (`bench.sh`)
+
+Reproducible, statistical benchmarks using [hyperfine](https://github.com/sharkdp/hyperfine) against the Scala 3 compiler repo (~17.7K files).
+
+### Prerequisites
+
+- `hyperfine` installed (`brew install hyperfine`)
+- Native scalex binary built (`./build-native.sh`)
+- The scala3 repo is cloned automatically on first run
+
+### Running
+
+```bash
+# Full suite (cold + warm + query + diverse + timings)
+.Codex/skills/benchmark/scripts/bench.sh
+
+# Individual modes
+.Codex/skills/benchmark/scripts/bench.sh cold
+.Codex/skills/benchmark/scripts/bench.sh warm
+.Codex/skills/benchmark/scripts/bench.sh query
+.Codex/skills/benchmark/scripts/bench.sh diverse    # miss, heavy refs, fuzzy, grep, hierarchy
+.Codex/skills/benchmark/scripts/bench.sh timings    # --timings output for cold/warm/refs
+.Codex/skills/benchmark/scripts/bench.sh memory     # heap usage, GC pressure (JVM only)
+
+# Custom runs/binary
+BENCH_RUNS=10 SCALEX_BIN=./target/scalex .Codex/skills/benchmark/scripts/bench.sh
+```
+
+### Before/after comparison
+
+```bash
+# 1. Benchmark current state
+BENCH_EXPORT=benchmark/results/before.json .Codex/skills/benchmark/scripts/bench.sh
+
+# 2. Make changes, rebuild
+./build-native.sh
+
+# 3. Benchmark new state
+BENCH_EXPORT=benchmark/results/after.json .Codex/skills/benchmark/scripts/bench.sh
+
+# 4. Compare (flags >5% regressions)
+.Codex/skills/benchmark/scripts/bench-compare.sh benchmark/results/before.json benchmark/results/after.json
+```
+
+`bench-compare.sh` exits non-zero if any benchmark regressed >5%.
+
+### Typical ranges (Apple M3 Max)
+
+| Metric | Range | Bottleneck |
+|--------|-------|------------|
+| Cold index | 3-5s | Scalameta parsing (CPU-bound, parallel) |
+| Warm index | 0.8-1.0s | OID compare + index load |
+| Query (any) | 1.2-1.5s | Index deserialization from disk |
+| refs (heavy symbol) | 2-4s | Text search across candidate files |
+
+---
+
+## Layer 3: async-profiler flame graphs
+
+Reveals call-stack-level CPU hotspots. No code changes needed — JVM agent only.
+
+### Prerequisites
+
+```bash
+brew install async-profiler
+# Or set AP_HOME to your installation
+```
+
+### Running
+
+```bash
+# CPU flame graph of cold index
+./profiling/profile.sh benchmark/scala3
+
+# Wall-clock (includes I/O wait — useful for parallelStream bottlenecks)
+./profiling/profile.sh benchmark/scala3 wall
+
+# Allocation hotspots (where objects are created)
+./profiling/profile.sh benchmark/scala3 alloc
+
+# Lock contention (parallelStream synchronization)
+./profiling/profile.sh benchmark/scala3 lock
+```
+
+Output: `profiling/profile-<event>.html` — open in browser for interactive flame graph.
+
+### What to look for
+
+- **CPU**: Wide bars in Scalameta parsing → specific parser methods. Wide bars in `parallelStream` infrastructure → overhead from small task granularity.
+- **Alloc**: Hot allocation sites → potential for object reuse or structural changes.
+- **Lock**: Contention in `ConcurrentLinkedQueue.add()` → batch results instead of per-item add.
+- **Wall**: I/O wait in `Files.readAllLines` or `Files.readString` → potential for memory-mapped I/O.
+
+---
+
+## Layer 4: JFR (Java Flight Recorder)
+
+Built into JDK 21. Near-zero overhead. Best for GC, file I/O, and thread analysis.
+
+### Running
+
+```bash
+# Record with custom config
+scala-cli run src/ \
+  --java-opt "-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
+  -- index benchmark/scala3
+
+# Quick summary
+jfr summary profiling/scalex.jfr
+
+# Specific events
+jfr print --events jdk.ObjectAllocationSample profiling/scalex.jfr | head -100
+jfr print --events jdk.GarbageCollection profiling/scalex.jfr
+jfr print --events jdk.FileRead profiling/scalex.jfr | head -50
+jfr print --events jdk.ThreadPark profiling/scalex.jfr | head -50
+
+# GUI analysis
+open profiling/scalex.jfr  # Opens in JDK Mission Control
+```
+
+### Custom config
+
+`profiling/scalex.jfc` is tuned for scalex — it enables allocation sampling, GC events, file I/O (>1ms threshold), and thread parking/monitor events.
+
+---
+
+## Layer 5: Microbenchmarks (`src/bench.scala`)
+
+Isolate per-function costs with warmup and statistical measurement.
+
+### Running
+
+```bash
+# Specific benchmark
+scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3
+scala-cli run src/bench.scala src/*.scala -- bloom-build benchmark/scala3
+scala-cli run src/bench.scala src/*.scala -- persistence-load benchmark/scala3
+scala-cli run src/bench.scala src/*.scala -- search benchmark/scala3
+scala-cli run src/bench.scala src/*.scala -- refs benchmark/scala3
+
+# All benchmarks
+scala-cli run src/bench.scala src/*.scala -- all benchmark/scala3
+
+# Custom warmup/iterations
+scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3 --warmup 3 --iterations 10
+```
+
+### Available benchmarks
+
+| Benchmark | What it measures |
+|-----------|-----------------|
+| `extract-single` | `extractSymbols` on the largest file |
+| `extract-batch` | `extractSymbols` on 100 files (sequential AND parallel) |
+| `bloom-build` | `buildBloomFilterFromSource` on a large source |
+| `persistence-load` | `IndexPersistence.load` with and without bloom deserialization |
+| `search` | `WorkspaceIndex.search("Compiler")` warm |
+| `refs` | `findReferences("Phase")` warm |
+| `index-cold` | Full cold index including map building |
+
+Reports: mean, median, p99, stddev, min, max per benchmark.
+
+---
+
+## Layer 6: Memory profiling (`bench.sh memory`)
+
+Measures heap usage, GC pressure, and peak memory across three scenarios: cold index (full parse), warm index (cache load), and refs query. Uses JVM GC logging via `-Xlog:gc*` — requires scala-cli (JVM mode), not native binary.
+
+### Running
+
+```bash
+# Full memory profile (cold + warm + refs)
+.Codex/skills/benchmark/scripts/bench.sh memory
+```
+
+No prerequisites beyond scala-cli. Does not require hyperfine or native binary.
+
+### Output
+
+Reports per-scenario: phase timings (from `--timings`), then memory stats:
+
+```
+--- Cold index (full parse, ~17.7k files) ---
+  git-ls-files            60.7 ms  ( 1%)
+  parse                 5576.5 ms  (94%)
+  cache-save             228.7 ms  ( 4%)
+  total                 5952.2 ms
+
+  Peak pre-GC heap:        790 MB
+  Heap at exit (used):     676 MB
+  Heap at exit (committed): 1184 MB
+  GC pauses:               34
+  Total GC pause time:     185.3 ms
+```
+
+Ends with a summary table:
+
+```
+=== Memory Summary ===
+
+Scenario             Peak Heap      Exit Used    Exit Commit     GC #
+--------             ---------      ---------    -----------     ----
+Cold index              790 MB       676.2 MB      1184.0 MB       34
+Warm index              256 MB       271.8 MB       584.0 MB        2
+refs Phase               53 MB        29.7 MB        56.0 MB        0
+```
+
+### Reading the output
+
+- **Peak pre-GC heap**: Highest live heap before any GC — the true high-water mark. This is the number that determines minimum `-Xmx` for constrained environments.
+- **Heap at exit (used)**: Retained heap at process exit — the steady-state footprint of the loaded index + results.
+- **Heap at exit (committed)**: OS-committed memory — what the JVM actually reserved. Higher than "used" because G1 keeps headroom.
+- **GC pauses**: Number of young-gen collections. High count during cold index is normal (Scalameta ASTs are short-lived).
+- **Total GC pause time**: Sum of all GC pauses. Should be small relative to wall time (<5%).
+
+### What to watch for
+
+- **Cold peak > 1 GB**: `parallelStream` is creating too many concurrent ASTs. Consider batching files in chunks.
+- **Warm used > 400 MB**: Index deserialization is holding too much data. Check if lazy maps are working.
+- **Refs used > 100 MB**: Text search is accumulating results. Check if bloom filtering is effective.
+- **GC time > 10% of wall time**: GC pressure is impacting performance. Look at allocation hotspots (async-profiler alloc, Layer 3).
+
+### Baseline ranges (scala3 corpus, 17.7k files, ~38k symbols)
+
+| Scenario | Peak Heap | Exit Used | GC Pauses |
+|----------|-----------|-----------|-----------|
+| Cold index | 700-900 MB | 600-700 MB | 30-70 |
+| Warm index | 200-300 MB | 250-300 MB | 1-3 |
+| refs query | 30-60 MB | 25-35 MB | 0-1 |
+
+### Ad-hoc memory profiling
+
+For one-off measurements without the script:
+
+```bash
+# Run any scalex command with GC logging to a temp file
+scala-cli run src/ \
+  --java-opt "-Xlog:gc*=info:file=/tmp/scalex-gc.log" \
+  -- overview benchmark/scala3
+
+# Check peak heap
+grep -o '[0-9]*M->' /tmp/scalex-gc.log | sed 's/M->//' | sort -n | tail -1
+# Check exit heap
+grep "garbage-first" /tmp/scalex-gc.log | tail -1
+```
+
+---
+
+## Native image profiling
+
+async-profiler and JFR don't work with GraalVM native images. Options:
+
+```bash
+# macOS Instruments (Time Profiler)
+xcrun xctrace record --template "Time Profiler" --launch -- ./scalex index scala3
+
+# --timings always works
+./scalex index scala3 --timings
+```
+
+---
+
+## Performance budget (from AGENTS.md)
+
+When evaluating changes:
+
+- **Index times**: Accept <5% regression
+- **Index size**: 0% growth for non-index features, <10% if schema changes
+- **Query latency**: No regression
+- **Feature gate**: "Is this better than grep, or does it introduce a worst case?"
+
+The `bench-compare.sh` script automates the regression check against these thresholds.
+
+## Typical workflow for a performance change
+
+1. `--timings` to identify which phase to optimize
+2. `BENCH_EXPORT=before.json bench.sh` to capture baseline
+3. If deeper analysis needed: async-profiler flame graph or JFR
+4. Make the change
+5. `--timings` to verify phase improvement
+6. `BENCH_EXPORT=after.json bench.sh` to capture new numbers
+7. `bench-compare.sh before.json after.json` to check for regressions
+8. Microbenchmarks if isolating a specific function

--- a/.agents/skills/benchmark/scripts/bench-compare.sh
+++ b/.agents/skills/benchmark/scripts/bench-compare.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Compare two hyperfine JSON exports and flag regressions ─────────────────
+#
+# Usage:
+#   BENCH_EXPORT=before.json ./bench.sh all
+#   # ... make changes ...
+#   BENCH_EXPORT=after.json ./bench.sh all
+#   ./bench-compare.sh before.json after.json
+#
+# Flags >5% regression with ⚠️, >10% with 🔴
+
+BEFORE="${1:-}"
+AFTER="${2:-}"
+THRESHOLD="${3:-5}"
+
+if [ -z "$BEFORE" ] || [ -z "$AFTER" ]; then
+  echo "Usage: $0 <before.json> <after.json> [threshold_pct]"
+  echo ""
+  echo "Compare two hyperfine JSON exports and flag regressions."
+  echo "Default threshold: 5%"
+  exit 1
+fi
+
+if [ ! -f "$BEFORE" ]; then
+  echo "Error: $BEFORE not found"
+  exit 1
+fi
+
+if [ ! -f "$AFTER" ]; then
+  echo "Error: $AFTER not found"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq not found. Install with: brew install jq"
+  exit 1
+fi
+
+echo "Comparing: $BEFORE → $AFTER (threshold: ${THRESHOLD}%)"
+echo ""
+
+HAS_REGRESSION=0
+
+# Extract benchmark results and compare
+BEFORE_COUNT=$(jq '.results | length' "$BEFORE")
+AFTER_COUNT=$(jq '.results | length' "$AFTER")
+
+printf "%-20s %12s %12s %10s %s\n" "Benchmark" "Before (ms)" "After (ms)" "Change" "Status"
+printf "%-20s %12s %12s %10s %s\n" "---------" "-----------" "----------" "------" "------"
+
+for i in $(seq 0 $((AFTER_COUNT - 1))); do
+  NAME=$(jq -r ".results[$i].command" "$AFTER")
+  AFTER_MEAN=$(jq ".results[$i].mean" "$AFTER")
+
+  # Find matching benchmark in before file
+  BEFORE_MEAN=$(jq -r --arg name "$NAME" '.results[] | select(.command == $name) | .mean' "$BEFORE" 2>/dev/null || echo "")
+
+  if [ -z "$BEFORE_MEAN" ] || [ "$BEFORE_MEAN" = "null" ]; then
+    printf "%-20s %12s %12.1f %10s %s\n" "$NAME" "N/A" "$(echo "$AFTER_MEAN * 1000" | bc)" "" "(new)"
+    continue
+  fi
+
+  BEFORE_MS=$(echo "$BEFORE_MEAN * 1000" | bc)
+  AFTER_MS=$(echo "$AFTER_MEAN * 1000" | bc)
+
+  if [ "$(echo "$BEFORE_MEAN > 0" | bc)" = "1" ]; then
+    CHANGE_PCT=$(echo "scale=1; ($AFTER_MEAN - $BEFORE_MEAN) / $BEFORE_MEAN * 100" | bc)
+    CHANGE_ABS=$(echo "$CHANGE_PCT" | sed 's/^-//')
+
+    STATUS=""
+    if [ "$(echo "$CHANGE_PCT > 10" | bc)" = "1" ]; then
+      STATUS="REGRESSION"
+      HAS_REGRESSION=1
+    elif [ "$(echo "$CHANGE_PCT > $THRESHOLD" | bc)" = "1" ]; then
+      STATUS="warning"
+      HAS_REGRESSION=1
+    elif [ "$(echo "$CHANGE_PCT < -$THRESHOLD" | bc)" = "1" ]; then
+      STATUS="faster"
+    else
+      STATUS="ok"
+    fi
+
+    printf "%-20s %12.1f %12.1f %+9.1f%% %s\n" "$NAME" "$BEFORE_MS" "$AFTER_MS" "$CHANGE_PCT" "$STATUS"
+  fi
+done
+
+echo ""
+if [ "$HAS_REGRESSION" = "1" ]; then
+  echo "Result: REGRESSIONS DETECTED (>${THRESHOLD}%)"
+  exit 1
+else
+  echo "Result: No regressions (all within ${THRESHOLD}%)"
+  exit 0
+fi

--- a/.agents/skills/benchmark/scripts/bench.sh
+++ b/.agents/skills/benchmark/scripts/bench.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+SCALEX_BIN="${SCALEX_BIN:-$PROJECT_ROOT/scalex}"
+SCALA3_DIR="$PROJECT_ROOT/benchmark/scala3"
+BENCH_RUNS="${BENCH_RUNS:-5}"
+BENCH_EXPORT="${BENCH_EXPORT:-}"
+MODE="${1:-all}"
+
+# ── Validate prerequisites ──────────────────────────────────────────────────
+
+if ! command -v hyperfine &>/dev/null; then
+  echo "Error: hyperfine not found. Install with: brew install hyperfine"
+  exit 1
+fi
+
+if [ ! -x "$SCALEX_BIN" ]; then
+  echo "Error: scalex binary not found at $SCALEX_BIN"
+  echo "Build it with: ./build-native.sh"
+  exit 1
+fi
+
+# ── Clone scala3 repo if needed ─────────────────────────────────────────────
+
+if [ ! -d "$SCALA3_DIR" ]; then
+  echo "Cloning scala3 repo (depth=1)..."
+  git clone --depth=1 https://github.com/scala/scala3.git "$SCALA3_DIR"
+  echo ""
+fi
+
+FILE_COUNT=$(git -C "$SCALA3_DIR" ls-files '*.scala' | wc -l | tr -d ' ')
+echo "scala3 repo: $FILE_COUNT .scala files"
+echo "scalex binary: $SCALEX_BIN"
+echo "runs per benchmark: $BENCH_RUNS"
+echo ""
+
+# ── Hyperfine export flags ──────────────────────────────────────────────────
+
+EXPORT_FLAGS=()
+if [ -n "$BENCH_EXPORT" ]; then
+  mkdir -p "$(dirname "$BENCH_EXPORT")"
+  EXPORT_FLAGS=(--export-json "$BENCH_EXPORT")
+fi
+
+# ── Index size ──────────────────────────────────────────────────────────────
+
+report_index_size() {
+  local idx="$SCALA3_DIR/.scalex/index.bin"
+  if [ -f "$idx" ]; then
+    local size
+    size=$(stat -f%z "$idx" 2>/dev/null || stat -c%s "$idx" 2>/dev/null || echo "?")
+    local size_mb
+    size_mb=$(echo "scale=1; $size / 1048576" | bc 2>/dev/null || echo "?")
+    echo "Index size: ${size_mb} MB ($size bytes)"
+    echo ""
+  fi
+}
+
+# ── Cold index ──────────────────────────────────────────────────────────────
+
+run_cold() {
+  echo "=== Cold Index (no cache) ==="
+  echo ""
+  hyperfine \
+    --warmup 0 \
+    --runs "$BENCH_RUNS" \
+    --prepare "rm -rf $SCALA3_DIR/.scalex" \
+    "$SCALEX_BIN index $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  report_index_size
+}
+
+# ── Warm index ──────────────────────────────────────────────────────────────
+
+run_warm() {
+  echo "=== Warm Index (fully cached) ==="
+  echo ""
+  # Ensure cache exists
+  "$SCALEX_BIN" index "$SCALA3_DIR" >/dev/null 2>&1
+  hyperfine \
+    --warmup 1 \
+    --runs "$BENCH_RUNS" \
+    "$SCALEX_BIN index $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Query benchmarks ────────────────────────────────────────────────────────
+
+run_query() {
+  echo "=== Query Performance (warm cache) ==="
+  echo ""
+  # Ensure cache exists
+  "$SCALEX_BIN" index "$SCALA3_DIR" >/dev/null 2>&1
+  hyperfine \
+    --warmup 1 \
+    --runs "$BENCH_RUNS" \
+    --command-name "def" "$SCALEX_BIN def $SCALA3_DIR Compiler" \
+    --command-name "search" "$SCALEX_BIN search $SCALA3_DIR Compiler" \
+    --command-name "impl" "$SCALEX_BIN impl $SCALA3_DIR Compiler" \
+    --command-name "refs" "$SCALEX_BIN refs $SCALA3_DIR Compiler" \
+    --command-name "imports" "$SCALEX_BIN imports $SCALA3_DIR Compiler" \
+    --command-name "packages" "$SCALEX_BIN packages $SCALA3_DIR" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Diverse query benchmarks ────────────────────────────────────────────────
+
+run_query_diverse() {
+  echo "=== Diverse Queries (warm cache) ==="
+  echo ""
+  "$SCALEX_BIN" index "$SCALA3_DIR" >/dev/null 2>&1
+  hyperfine \
+    --warmup 1 \
+    --runs "$BENCH_RUNS" \
+    --command-name "def-common"      "$SCALEX_BIN def $SCALA3_DIR Phase" \
+    --command-name "def-miss"        "$SCALEX_BIN def $SCALA3_DIR NonExistentSymbolXyz123" \
+    --command-name "refs-heavy"      "$SCALEX_BIN refs $SCALA3_DIR Type" \
+    --command-name "refs-miss"       "$SCALEX_BIN refs $SCALA3_DIR NonExistentSymbolXyz123" \
+    --command-name "search-fuzzy"    "$SCALEX_BIN search $SCALA3_DIR tpd" \
+    --command-name "grep"            "$SCALEX_BIN grep $SCALA3_DIR 'override def' --count" \
+    --command-name "hierarchy"       "$SCALEX_BIN hierarchy $SCALA3_DIR Phase" \
+    --command-name "explain"         "$SCALEX_BIN explain $SCALA3_DIR Phase" \
+    "${EXPORT_FLAGS[@]}"
+  echo ""
+}
+
+# ── Memory profiling (JVM only) ────────────────────────────────────────────
+
+run_memory() {
+  echo "=== Memory Profiling (JVM mode via scala-cli) ==="
+  echo ""
+  echo "Note: Runs via scala-cli (not native binary) to access JVM GC logs."
+  echo ""
+
+  local HEAP_LOG
+  HEAP_LOG=$(mktemp /tmp/scalex-gc-XXXXXX.log)
+
+  parse_gc_stats() {
+    local log="$1" label="$2"
+    local peak exit_used_k exit_committed_k gc_count gc_time_ms
+    peak=$(grep -o '[0-9]*M->' "$log" | sed 's/M->//' | sort -n | tail -1)
+    exit_used_k=$(grep "garbage-first" "$log" | grep -o 'used [0-9]*K' | sed 's/[^0-9]//g' | tail -1)
+    exit_committed_k=$(grep "garbage-first" "$log" | grep -o 'committed [0-9]*K' | sed 's/[^0-9]//g' | tail -1)
+    gc_count=$(grep -c "Pause Young" "$log" 2>/dev/null || echo "0")
+    gc_time_ms=$(grep "Pause Young" "$log" | grep -oE '[0-9]+\.[0-9]+ms$' | sed 's/ms//' | awk '{s+=$1} END {printf "%.1f", s}')
+    local exit_used_mb exit_committed_mb
+    exit_used_mb=$(echo "scale=1; ${exit_used_k:-0} / 1024" | bc)
+    exit_committed_mb=$(echo "scale=1; ${exit_committed_k:-0} / 1024" | bc)
+
+    printf "  %-26s %s\n" "Peak pre-GC heap:" "${peak:-n/a} MB"
+    printf "  %-26s %s\n" "Heap at exit (used):" "${exit_used_mb} MB"
+    printf "  %-26s %s\n" "Heap at exit (committed):" "${exit_committed_mb} MB"
+    printf "  %-26s %s\n" "GC pauses:" "${gc_count}"
+    printf "  %-26s %s\n" "Total GC pause time:" "${gc_time_ms} ms"
+
+    # Store for summary table
+    eval "${label}_PEAK=\"${peak:-n/a}\""
+    eval "${label}_USED=\"${exit_used_mb}\""
+    eval "${label}_COMMITTED=\"${exit_committed_mb}\""
+    eval "${label}_GC=\"${gc_count}\""
+  }
+
+  # --- Cold index (full parse) ---
+  echo "--- Cold index (full parse, ~17.7k files) ---"
+  rm -rf "$SCALA3_DIR/.scalex"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "COLD"
+  echo ""
+
+  # --- Warm index (cache load) ---
+  echo "--- Warm index (cache load) ---"
+  > "$HEAP_LOG"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "WARM"
+  echo ""
+
+  # --- Refs query (text search across files) ---
+  echo "--- refs Phase (warm cache, text search) ---"
+  > "$HEAP_LOG"
+  scala-cli run "$PROJECT_ROOT/src/" \
+    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
+    -- --timings refs "$SCALA3_DIR" Phase 2>&1 | grep -E '^\s'
+  echo ""
+  parse_gc_stats "$HEAP_LOG" "REFS"
+  echo ""
+
+  # --- Summary table ---
+  echo "=== Memory Summary ==="
+  echo ""
+  printf "%-20s %14s %14s %14s %8s\n" "Scenario" "Peak Heap" "Exit Used" "Exit Commit" "GC #"
+  printf "%-20s %14s %14s %14s %8s\n" "--------" "---------" "---------" "-----------" "----"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "Cold index" "$COLD_PEAK" "$COLD_USED" "$COLD_COMMITTED" "$COLD_GC"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "Warm index" "$WARM_PEAK" "$WARM_USED" "$WARM_COMMITTED" "$WARM_GC"
+  printf "%-20s %11s MB %11s MB %11s MB %8s\n" "refs Phase" "$REFS_PEAK" "$REFS_USED" "$REFS_COMMITTED" "$REFS_GC"
+  echo ""
+
+  rm -f "$HEAP_LOG"
+}
+
+# ── Timings breakdown ───────────────────────────────────────────────────────
+
+run_timings() {
+  echo "=== Phase Timings ==="
+  echo ""
+  echo "--- Cold index ---"
+  rm -rf "$SCALA3_DIR/.scalex"
+  "$SCALEX_BIN" index "$SCALA3_DIR" --timings 2>&1 | grep -E '^\s'
+  echo ""
+  echo "--- Warm index ---"
+  "$SCALEX_BIN" index "$SCALA3_DIR" --timings 2>&1 | grep -E '^\s'
+  echo ""
+  echo "--- refs Compiler ---"
+  "$SCALEX_BIN" refs "$SCALA3_DIR" Compiler --timings 2>&1 | grep -E '^\s'
+  echo ""
+}
+
+# ── Run selected benchmarks ─────────────────────────────────────────────────
+
+case "$MODE" in
+  cold)    run_cold ;;
+  warm)    run_warm ;;
+  query)   run_query ;;
+  diverse) run_query_diverse ;;
+  timings) run_timings ;;
+  memory)  run_memory ;;
+  all)
+    run_cold
+    run_warm
+    run_query
+    run_query_diverse
+    run_timings
+    report_index_size
+    ;;
+  *)
+    echo "Usage: $0 [cold|warm|query|diverse|timings|memory|all]"
+    exit 1
+    ;;
+esac
+
+echo "Done."

--- a/.agents/skills/capture-banners/SKILL.md
+++ b/.agents/skills/capture-banners/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: capture-banners
+description: Re-render Scalex banner and OG image PNGs from their HTML source files using Chrome DevTools MCP. Use this skill whenever banner HTML files are edited (slogan changes, color tweaks, layout changes) and the corresponding PNGs need to be regenerated. Triggers on "capture banners", "update banner images", "re-render banners", "regenerate PNGs", or after any edit to files in site/*-banner*.html or site/og-banner*.html.
+---
+
+# Capture Banners
+
+The Scalex project has 4 banner images that are rendered from HTML source files. When the HTML is edited, the PNGs must be re-captured to stay in sync.
+
+## Banner inventory
+
+| HTML source | PNG output | Purpose |
+|---|---|---|
+| `site/readme-banner-dark.html` | `site/readme-banner-dark.png` | GitHub README banner (dark mode) |
+| `site/readme-banner-light.html` | `site/readme-banner-light.png` | GitHub README banner (light mode) |
+| `site/og-banner.html` | `site/og-banner.png` | OpenGraph social preview (dark) |
+| `site/og-banner-light.html` | `site/og-banner-light.png` | OpenGraph social preview (light) |
+
+## Required viewport size
+
+All banners are designed at **1200 x 630** pixels. The HTML `<body>` is hardcoded to this size. The Chrome DevTools viewport must match exactly, otherwise the screenshot will crop or include extra whitespace.
+
+## Capture procedure
+
+Use Chrome DevTools MCP tools. For each banner:
+
+1. **Open or navigate** to the HTML file using a `file://` URL:
+   ```
+   file:///absolute/path/to/scalex/site/readme-banner-dark.html
+   ```
+
+2. **Resize the viewport** to 1200x630:
+   ```
+   mcp__chrome-devtools__resize_page(width=1200, height=630)
+   ```
+
+3. **Take a screenshot** and save directly to the PNG path:
+   ```
+   mcp__chrome-devtools__take_screenshot(
+     filePath="site/readme-banner-dark.png",
+     format="png"
+   )
+   ```
+
+4. **Repeat** for the remaining 3 banners. You can reuse the same tab by navigating to the next HTML file.
+
+## Notes
+
+- The Kestrel mascot image (`Kestrel.png`) is referenced by relative path in the HTML, so the file:// URL must point to the `site/` directory for it to render.
+- After capturing, the PNGs are ready to commit — no post-processing needed.
+- If the images look wrong (missing mascot, broken layout), check that the HTML references are correct relative to the `site/` directory.

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -52,7 +52,7 @@ rm -rf benchmark/scala3/.scalex
 ./scalex refs benchmark/scala3 Compiler --timings
 
 # JVM mode
-scala-cli run src/ -- index benchmark/scala3 --timings
+./mill run index benchmark/scala3 --timings
 ```
 
 ### Phases reported
@@ -185,9 +185,8 @@ Built into JDK 21. Near-zero overhead. Best for GC, file I/O, and thread analysi
 
 ```bash
 # Record with custom config
-scala-cli run src/ \
-  --java-opt "-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
-  -- index benchmark/scala3
+SCALEX_JAVA_OPTS="-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
+  ./mill run index benchmark/scala3
 
 # Quick summary
 jfr summary profiling/scalex.jfr
@@ -216,17 +215,17 @@ Isolate per-function costs with warmup and statistical measurement.
 
 ```bash
 # Specific benchmark
-scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3
-scala-cli run src/bench.scala src/*.scala -- bloom-build benchmark/scala3
-scala-cli run src/bench.scala src/*.scala -- persistence-load benchmark/scala3
-scala-cli run src/bench.scala src/*.scala -- search benchmark/scala3
-scala-cli run src/bench.scala src/*.scala -- refs benchmark/scala3
+./mill bench.run extract-single benchmark/scala3
+./mill bench.run bloom-build benchmark/scala3
+./mill bench.run persistence-load benchmark/scala3
+./mill bench.run search benchmark/scala3
+./mill bench.run refs benchmark/scala3
 
 # All benchmarks
-scala-cli run src/bench.scala src/*.scala -- all benchmark/scala3
+./mill bench.run all benchmark/scala3
 
 # Custom warmup/iterations
-scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3 --warmup 3 --iterations 10
+./mill bench.run extract-single benchmark/scala3 --warmup 3 --iterations 10
 ```
 
 ### Available benchmarks
@@ -247,7 +246,7 @@ Reports: mean, median, p99, stddev, min, max per benchmark.
 
 ## Layer 6: Memory profiling (`bench.sh memory`)
 
-Measures heap usage, GC pressure, and peak memory across three scenarios: cold index (full parse), warm index (cache load), and refs query. Uses JVM GC logging via `-Xlog:gc*` — requires scala-cli (JVM mode), not native binary.
+Measures heap usage, GC pressure, and peak memory across three scenarios: cold index (full parse), warm index (cache load), and refs query. Uses JVM GC logging via `-Xlog:gc*` through Mill JVM mode, not the native binary.
 
 ### Running
 
@@ -256,7 +255,7 @@ Measures heap usage, GC pressure, and peak memory across three scenarios: cold i
 .claude/skills/benchmark/scripts/bench.sh memory
 ```
 
-No prerequisites beyond scala-cli. Does not require hyperfine or native binary.
+No prerequisites beyond the Mill wrapper and JDK 21. Does not require hyperfine or native binary.
 
 ### Output
 
@@ -317,9 +316,8 @@ For one-off measurements without the script:
 
 ```bash
 # Run any scalex command with GC logging to a temp file
-scala-cli run src/ \
-  --java-opt "-Xlog:gc*=info:file=/tmp/scalex-gc.log" \
-  -- overview benchmark/scala3
+SCALEX_JAVA_OPTS="-Xlog:gc*=info:file=/tmp/scalex-gc.log" \
+  ./mill run overview benchmark/scala3
 
 # Check peak heap
 grep -o '[0-9]*M->' /tmp/scalex-gc.log | sed 's/M->//' | sort -n | tail -1

--- a/.claude/skills/benchmark/scripts/bench.sh
+++ b/.claude/skills/benchmark/scripts/bench.sh
@@ -132,9 +132,9 @@ run_query_diverse() {
 # ── Memory profiling (JVM only) ────────────────────────────────────────────
 
 run_memory() {
-  echo "=== Memory Profiling (JVM mode via scala-cli) ==="
+  echo "=== Memory Profiling (JVM mode via Mill) ==="
   echo ""
-  echo "Note: Runs via scala-cli (not native binary) to access JVM GC logs."
+  echo "Note: Runs via Mill (not native binary) to access JVM GC logs."
   echo ""
 
   local HEAP_LOG
@@ -168,9 +168,8 @@ run_memory() {
   # --- Cold index (full parse) ---
   echo "--- Cold index (full parse, ~17.7k files) ---"
   rm -rf "$SCALA3_DIR/.scalex"
-  scala-cli run "$PROJECT_ROOT/src/" \
-    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
-    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  SCALEX_JAVA_OPTS="-Xlog:gc*=info:file=$HEAP_LOG" \
+    "$PROJECT_ROOT/mill" run index "$SCALA3_DIR" --timings 2>&1 | grep -E '^\s'
   echo ""
   parse_gc_stats "$HEAP_LOG" "COLD"
   echo ""
@@ -178,9 +177,8 @@ run_memory() {
   # --- Warm index (cache load) ---
   echo "--- Warm index (cache load) ---"
   > "$HEAP_LOG"
-  scala-cli run "$PROJECT_ROOT/src/" \
-    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
-    -- --timings index "$SCALA3_DIR" 2>&1 | grep -E '^\s'
+  SCALEX_JAVA_OPTS="-Xlog:gc*=info:file=$HEAP_LOG" \
+    "$PROJECT_ROOT/mill" run index "$SCALA3_DIR" --timings 2>&1 | grep -E '^\s'
   echo ""
   parse_gc_stats "$HEAP_LOG" "WARM"
   echo ""
@@ -188,9 +186,8 @@ run_memory() {
   # --- Refs query (text search across files) ---
   echo "--- refs Phase (warm cache, text search) ---"
   > "$HEAP_LOG"
-  scala-cli run "$PROJECT_ROOT/src/" \
-    --java-opt "-Xlog:gc*=info:file=$HEAP_LOG" \
-    -- --timings refs "$SCALA3_DIR" Phase 2>&1 | grep -E '^\s'
+  SCALEX_JAVA_OPTS="-Xlog:gc*=info:file=$HEAP_LOG" \
+    "$PROJECT_ROOT/mill" run refs "$SCALA3_DIR" Phase --timings 2>&1 | grep -E '^\s'
   echo ""
   parse_gc_stats "$HEAP_LOG" "REFS"
   echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,6 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: VirtusLab/scala-cli-setup@59e308800210b0414d2d7190068c80021e1b3e5d # v1
-        with:
-          power: true
-          jvm: graalvm-java21
-
       - name: Build native image
         run: ./build-native.sh ${{ matrix.artifact }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## What is Scalex
+
+Scalex is a Scala code intelligence CLI for coding agents. It provides fast symbol search, find definitions, and find references — without requiring an IDE, build server, or compilation. Designed as a Codex plugin.
+
+## IMPORTANT: No company references
+
+NEVER mention any company names, internal project names, proprietary codebases, or organization-specific details in any output — including commit messages, PR descriptions, changelogs, roadmaps, documentation, code comments, or conversations. Always use generic examples (e.g. `HttpMessageService`, `UserServiceLive`) instead.
+
+## Search scope
+
+Source code lives in `src/` (production) and `tests/` (test suite). When searching for Scala code, scope searches to these directories. Avoid searching repo-wide — `benchmark/` contains ~17.7k Scala files from the scala3 compiler clone that will pollute results.
+
+## Workflow
+
+- Before planning or implementing any feature, first add it to `docs/ROADMAP.md` under the appropriate section
+- The roadmap is the source of truth for what's planned and what's done
+- **Bug fix workflow**: When receiving a bug report, always write a failing test that reproduces the bug *before* writing the fix. This validates the bug is real and ensures the fix is verifiable. Only then apply the code fix and confirm the test passes.
+
+## Build & Run
+
+```bash
+# Run via scala-cli (development)
+scala-cli run src/ -- <command> [args...]
+
+# Run tests
+scala-cli test src/ tests/
+
+# Build GraalVM native image (requires GraalVM + scala-cli)
+./build-native.sh
+# Output: ./scalex (26MB standalone binary)
+
+# Validate Codex plugin structure
+Codex plugin validate plugins/scalex/
+```
+
+## Architecture
+
+Source code is in `src/`, tests in `tests/` (Scala 3.8.2, JDK 21+). When searching the codebase, scope to these directories to avoid hitting benchmark data or build artifacts.
+
+```
+src/                           # Production source code
+├── project.scala              # scala-cli directives only
+├── model.scala                # Data types, enums, version constant
+├── extraction.scala           # AST parsing & single-file extraction functions
+├── index.scala                # Git integration, persistence, WorkspaceIndex, filtering
+├── analysis.scala             # Cross-index analysis (hierarchy, overrides, deps, diff, ast-pattern)
+├── format.scala               # Text formatters for symbols and references
+├── cli.scala                  # Arg parsing, workspace resolution, @main entry point
+├── command-helpers.scala      # Shared filters: filterSymbols, filterRefs, mkNotFoundWithSuggestions
+├── dispatch.scala             # Command map + runCommand
+└── commands/                  # One file per command (ls to discover all 25 commands)
+    ├── definition.scala       # cmdDef
+    ├── search.scala           # cmdSearch
+    ├── refs.scala             # cmdRefs
+    ├── hierarchy.scala        # cmdHierarchy
+    ├── overview.scala         # cmdOverview
+    └── ...                    # 25 commands total
+
+tests/                         # Test suite
+├── test-base.test.scala       # Shared test fixture (workspace setup)
+├── extraction.test.scala      # Extraction tests
+├── index.test.scala           # Index/search/persistence tests
+├── analysis.test.scala        # Analysis tests (hierarchy, overrides, deps, etc.)
+└── cli.test.scala             # CLI/formatting/command output tests
+
+benchmark/                     # Benchmark data (gitignored)
+├── scala3/                    # Shallow clone of scala/scala3 for benchmarks
+└── results/                   # Hyperfine JSON exports
+```
+
+### Pipeline
+
+```
+git ls-files --stage → Scalameta parse → in-memory index → query
+                              ↓
+                    .scalex/index.bin (binary cache, OID-keyed, bloom filters)
+```
+
+1. **Git discovery**: `git ls-files --stage` returns all tracked `.scala` files with their OIDs
+2. **Symbol extraction**: Scalameta parses source ASTs (Scala 3 first, falls back to Scala 2.13), extracts top-level symbols (class/trait/object/def/val/type/enum/given/extension)
+3. **OID caching**: On subsequent runs, compares OIDs — skips unchanged files entirely
+4. **Persistence**: Binary format with string interning at `.scalex/index.bin`
+5. **Bloom filters**: Per-file bloom filter of identifiers — `refs` and `imports` only read candidate files
+
+### Code style
+
+- **Named tuples**: Never use unnamed tuples. Whenever a tuple is needed — return types, local variables, collection elements — always use named tuples. E.g. `(results: List[Reference], timedOut: Boolean)` not `(List[Reference], Boolean)`.
+- **No `return` statements**: Never use `return` anywhere — not in methods, not in lambdas, not in `for`/`foreach`. Use `scala.util.boundary` + `boundary.break` for early exit, or restructure with `match`/`if-else`. The `return` keyword is deprecated in Scala 3 inside lambdas and is a footgun everywhere else. Existing `return` statements in the codebase are legacy — do not add new ones, and remove them when touching nearby code.
+
+### Key design choices
+
+- **Scalameta, not presentation compiler**: Scala 3's PC requires compiled `.class`/`.tasty` on classpath, which reintroduces build server dependency. Scalameta parses source directly.
+- **Git OIDs for caching**: Available free from `git ls-files --stage`, no disk reads needed to detect changes.
+- **No build server**: Coding agents can run `./mill __.compile` directly for error checking.
+- **No backwards compatibility**: This is a tool, not a library. Do the right thing and do it consistently. If the current way of printing data, formatting JSON, or structuring output is inconsistent, fix it to match the up-to-date pattern — don't preserve old behavior for backwards compatibility. Consistency across commands matters more than not breaking hypothetical consumers.
+- **Feature gate question**: "Is this better than grep, or does it introduce a worst case that grep never has?" If a feature risks being slower or less reliable than grep in any scenario, don't add it. The agent can always fall back to grep — scalex must never be the worse option.
+- **Performance budget**: Every new feature must be benchmarked before/after on a large codebase (e.g. scala3 compiler, 17.7k files). Measure: index size (`.scalex/index.bin`), cold index time, warm index time, and query latency. Accept <5% regression on index times, 0% index size growth for non-index features, <10% if index schema changes. Prefer on-the-fly source reads over index bloat for infrequent queries (e.g. `members`, `doc`).
+
+### Dependencies
+
+- `org.scalameta::scalameta:4.15.2` — AST parsing
+- `com.google.guava:guava:33.5.0-jre` — bloom filters
+- `org.scalameta::munit:1.2.4` — test framework (test only)
+
+## Plugin structure
+
+```
+plugins/
+└── scalex/                        # scalex plugin
+    ├── .Codex-plugin/plugin.json
+    └── skills/scalex/
+        ├── SKILL.md
+        ├── references/
+        └── scripts/scalex-cli     # Bootstrap: downloads + caches binary, forwards args
+```
+
+The bootstrap script `scalex-cli` contains `EXPECTED_VERSION` that must be bumped alongside `ScalexVersion` in `src/model.scala` when releasing.
+
+## Release workflow
+
+### Step 1: Release PR (merge first)
+1. Move `[Unreleased]` section in `CHANGELOG.md` to the new version with date
+2. Bump `ScalexVersion` in `src/model.scala`
+3. Create PR, get it merged to main
+
+### Step 2: Tag + release
+4. Tag as `vX.Y.Z` and push — GitHub Actions builds native binaries + creates release
+
+### Step 3: Plugin version bump
+5. Bump `EXPECTED_VERSION` in `plugins/scalex/skills/scalex/scripts/scalex-cli`
+6. Update `CHECKSUM_scalex_*` values in `scalex-cli` — get hashes from individual `.sha256` release assets (iterate: `gh release view vX.Y.Z --json assets --jq '.assets[] | select(.name | endswith(".sha256")) | .name'` then download each with `gh release download vX.Y.Z -p <name> -O -`)
+7. Bump `version` in `.Codex-plugin/marketplace.json` (plugin version is only managed here, not in `plugins/scalex/.Codex-plugin/plugin.json`)
+8. Commit, create PR, merge to main (main is protected — cannot push directly)
+
+Note: `marketplace.json` is at the repo root (`.Codex-plugin/marketplace.json`), NOT inside `plugins/`.
+
+## Feature checklist
+
+When adding or changing commands/flags in `src/cli.scala`:
+- Update help text in the `main` function
+- Update `plugins/scalex/skills/scalex/SKILL.md` (commands, options table, common workflows, description frontmatter) and `plugins/scalex/skills/scalex/references/commands.md` (command signature, description, examples, options table). Description must be double-quoted YAML and under 1024 chars (for GitHub Copilot CLI compatibility). **Always run `./scripts/check-skill-frontmatter.sh` after editing SKILL.md** to validate
+- Update `docs/ROADMAP.md`
+- Update `CHANGELOG.md`
+- Update `README.md` (commands block, Coding-Agent-Friendly Features, "Use it" examples). README does NOT duplicate the options table — it links to SKILL.md
+- Update `site/index.html` (command grid, command count heading)
+
+## Gotchas
+
+- **Protected main branch**: Cannot push directly to main — all changes require a PR
+- **Zero warnings policy**: Before creating a PR, run `scala-cli compile src/ 2>&1 | grep -i warn` and verify no output. Do not ship compiler warnings.
+- **Zero deprecations policy**: Also verify with `scala-cli compile --scalac-option "-deprecation" src/ 2>&1 | grep -i warn`. Do not use deprecated APIs — find and use the replacement immediately.
+
+- **Guava group ID**: `com.google.guava:guava`, NOT `com.google.common:guava`
+- **GraalVM native image**: Guava needs `--initialize-at-run-time=com.google.common.hash.Striped64,com.google.common.hash.LongAdder,com.google.common.hash.BloomFilter,com.google.common.hash.BloomFilterStrategies` (see `build-native.sh`)
+- **No `.par` in Scala 3.8**: Use `list.asJava.parallelStream()` instead of `list.par`
+- **No non-local `return` in Scala 3.8**: `return` inside lambdas/closures is deprecated. Use `scala.util.boundary` + `boundary.break` instead. This includes `return` inside `.foreach`, `.map`, `try`/`catch` blocks inside lambdas, etc.
+- **Scalameta `Pkg.children` wraps stats in `PkgBody`**: Use `pkg.stats` to access direct children (Import, Defn.Class, etc.), not `pkg.children` which nests them inside a `PkgBody` wrapper node.
+- **Scalameta Tree**: `.collect` doesn't work on Tree in Scala 3 — use manual `traverse` + `visit` pattern
+- **Anonymous givens**: Only named givens are indexed; anonymous givens are skipped
+- **`refs`/`imports` use text search**: They use bloom filters to shortlist candidate files, then do word-boundary text matching. They are NOT index-based and have a 20-second timeout.
+- **Scala 3 indentation in `WorkspaceIndex`**: Deeply nested code can break method boundaries — use brace syntax for nested blocks
+- **Test fixture file counts**: Tests hardcode file counts — adding/removing fixtures requires updating all count assertions
+- **GitHub Actions SHA pinning**: All actions in `release.yml` are pinned to commit SHAs. To verify/update: `git ls-remote --refs https://github.com/<owner>/<repo>.git refs/tags/<tag>`. Never trust SHAs from memory or LLM output without verifying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Migrated the project build from scala-cli directives to Mill, including CLI/test/benchmark modules and native image packaging.
+
 ## [1.39.0] — 2026-04-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,16 @@ Source code lives in `src/` (production) and `tests/` (test suite). When searchi
 ## Build & Run
 
 ```bash
-# Run via scala-cli (development)
-scala-cli run src/ -- <command> [args...]
+# Run via Mill (development)
+./mill run <command> [args...]
 
 # Run tests
-scala-cli test src/ tests/
+./mill test
 
-# Build GraalVM native image (requires GraalVM + scala-cli)
+# Run microbenchmarks
+./mill bench.run <benchmark> <workspace> [options]
+
+# Build GraalVM native image (requires GraalVM)
 ./build-native.sh
 # Output: ./scalex (26MB standalone binary)
 
@@ -39,11 +42,11 @@ claude plugin validate plugins/scalex/
 
 ## Architecture
 
-Source code is in `src/`, tests in `tests/` (Scala 3.8.2, JDK 21+). When searching the codebase, scope to these directories to avoid hitting benchmark data or build artifacts.
+Source code is in `src/`, tests in `tests/` (Scala 3.8.3, JDK 21+). When searching the codebase, scope to these directories to avoid hitting benchmark data or build artifacts.
 
 ```
+build.mill                      # Mill build: CLI, tests, benchmark module, native image
 src/                           # Production source code
-├── project.scala              # scala-cli directives only
 ├── model.scala                # Data types, enums, version constant
 ├── extraction.scala           # AST parsing & single-file extraction functions
 ├── index.scala                # Git integration, persistence, WorkspaceIndex, filtering
@@ -151,8 +154,8 @@ When adding or changing commands/flags in `src/cli.scala`:
 ## Gotchas
 
 - **Protected main branch**: Cannot push directly to main — all changes require a PR
-- **Zero warnings policy**: Before creating a PR, run `scala-cli compile src/ 2>&1 | grep -i warn` and verify no output. Do not ship compiler warnings.
-- **Zero deprecations policy**: Also verify with `scala-cli compile --scalac-option "-deprecation" src/ 2>&1 | grep -i warn`. Do not use deprecated APIs — find and use the replacement immediately.
+- **Zero warnings policy**: Before creating a PR, run `./mill __.compile 2>&1 | grep -i warn` and verify no output. Do not ship compiler warnings.
+- **Zero deprecations policy**: Deprecation warnings are enabled in Mill; also run `./mill __.compile 2>&1 | grep -i deprecat` and verify no output. Do not use deprecated APIs — find and use the replacement immediately.
 
 - **Guava group ID**: `com.google.guava:guava`, NOT `com.google.common:guava`
 - **GraalVM native image**: Guava needs `--initialize-at-run-time=com.google.common.hash.Striped64,com.google.common.hash.LongAdder,com.google.common.hash.BloomFilter,com.google.common.hash.BloomFilterStrategies` (see `build-native.sh`)

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Build scalex, place it anywhere on your `PATH`, then update `SKILL.md` to invoke
 **Option B: Edit the bootstrap script to use a local binary.**
 Set the `BINARY` variable in `scripts/scalex-cli` to point to your local build — the script will skip the download and exec your binary directly.
 
-#### Build from source
+#### Build From Source
 
-Requires [scala-cli](https://scala-cli.virtuslab.org/) + [GraalVM](https://www.graalvm.org/):
+Requires JDK 21. Native builds require [GraalVM](https://www.graalvm.org/). Mill is pinned by the checked-in `mill` wrapper:
 
 ```bash
 git clone https://github.com/nguyenyou/scalex.git
@@ -193,16 +193,17 @@ cd scalex
 # Output: ~30MB standalone binary, no JVM needed
 ```
 
-#### Run from source (no native image)
+#### Run From Source
 
-If you have [scala-cli](https://scala-cli.virtuslab.org/) installed, you can run directly from source without building a native image:
+Run directly from source without building a native image:
 
 ```bash
 git clone https://github.com/nguyenyou/scalex.git
-scala-cli run scalex/src/ -- search /path/to/project MyClass
+cd scalex
+./mill run search /path/to/project MyClass
 ```
 
-Downloads dependencies on first run (~5s), then starts in ~1s. Useful for development or quick testing.
+Mill downloads dependencies on first run, then reuses its local cache. Useful for development or quick testing.
 
 ## Usage Examples
 

--- a/build-native.sh
+++ b/build-native.sh
@@ -4,20 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT="${1:-$SCRIPT_DIR/scalex}"
 
-# -march=native is only safe for local builds (not portable across machines)
-MARCH_FLAG=()
-if [ -z "${CI:-}" ]; then
-  MARCH_FLAG=(-march=native)
-fi
-
 echo "Building Scalex native image..."
-scala-cli package --native-image \
-  "$SCRIPT_DIR/src/" \
-  -o "$OUT" \
-  --force \
-  -- --no-fallback \
-  --initialize-at-run-time=com.google.common.hash.Striped64,com.google.common.hash.LongAdder,com.google.common.hash.BloomFilter,com.google.common.hash.BloomFilterStrategies \
-  ${MARCH_FLAG[@]+"${MARCH_FLAG[@]}"}
+"$SCRIPT_DIR/mill" nativeCopy "$OUT"
 
 echo ""
 echo "Built: $OUT"

--- a/build.mill
+++ b/build.mill
@@ -1,0 +1,75 @@
+package build
+
+import mill.*
+import mill.javalib.NativeImageModule
+import mill.scalalib.*
+
+trait ScalexModule extends ScalaModule {
+  def scalaVersion: T[String] = "3.8.3"
+
+  def mvnDeps: T[Seq[Dep]] = Seq(
+    mvn"org.scalameta::scalameta:4.16.1",
+    mvn"com.google.guava:guava:33.6.0-jre",
+    mvn"com.github.javaparser:javaparser-core:3.28.0"
+  )
+
+  def mainClass: T[Option[String]] = Some("main")
+
+  def scalacOptions: T[Seq[String]] = Seq("-deprecation")
+
+  def scalexJavaOpts: T[Seq[String]] = Task.Input {
+    Task.env.get("SCALEX_JAVA_OPTS").toSeq
+  }
+
+  override def forkArgs: T[Seq[String]] = Task {
+    super.forkArgs() ++ scalexJavaOpts()
+  }
+}
+
+object `package` extends ScalexModule, NativeImageModule {
+  private def workspaceRoot: os.Path = moduleDir
+
+  override def allSourceFiles: T[Seq[PathRef]] = Task {
+    super.allSourceFiles().filterNot(_.path == moduleDir / "src" / "bench.scala")
+  }
+
+  def nativeMarchFlag: T[Seq[String]] = Task.Input {
+    if Task.env.contains("CI") then Seq.empty
+    else Seq("-march=native")
+  }
+
+  override def nativeImageOptions: T[Seq[String]] = Task {
+    super.nativeImageOptions() ++ Seq(
+      "--no-fallback",
+      "--initialize-at-run-time=com.google.common.hash.Striped64,com.google.common.hash.LongAdder,com.google.common.hash.BloomFilter,com.google.common.hash.BloomFilterStrategies"
+    ) ++ nativeMarchFlag()
+  }
+
+  def nativeCopy(dest: String): Command[PathRef] = Task.Command {
+    val output = os.Path(dest, workspaceRoot)
+    os.makeDir.all(output / os.up)
+    os.copy.over(nativeImage().path, output)
+    os.perms.set(output, "rwxr-xr-x")
+    PathRef(output)
+  }
+
+  object test extends ScalaTests {
+    override def moduleDir: os.Path = workspaceRoot
+
+    def sources: T[Seq[PathRef]] = Task.Sources("tests")
+
+    def mvnDeps: T[Seq[Dep]] = Seq(
+      mvn"org.scalameta::munit:1.3.0"
+    )
+
+    def testFramework: T[String] = "munit.Framework"
+  }
+
+  object bench extends ScalexModule {
+    override def moduleDir: os.Path = workspaceRoot
+
+    override def sources: T[Seq[PathRef]] = Task.Sources("src")
+
+    override def mainClass: T[Option[String]] = Some("bench")
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,8 +212,8 @@ How types flow from extraction through commands to output:
 ## File Layout
 
 ```
+build.mill                      Mill build: CLI, tests, benchmark module, native image
 src/
-├── project.scala              scala-cli directives
 ├── model.scala                SymbolInfo, CmdResult, CommandContext, all data types
 ├── cli.scala                  @main, flag parsing, workspace resolution
 ├── dispatch.scala             command name → handler map

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,12 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Mill build migration
+
+- [x] Add Mill build definition for Scalex CLI and tests
+- [x] Move local/native build commands from scala-cli to Mill
+- [x] Update docs and scripts to describe Mill workflows
+
 ### Community feedback: output budgets & package-scoped refs (#252)
 
 - [x] `--max-output N` global output budget — truncate any command's output at N characters with pagination hint; wraps `render()` centrally via `BudgetPrintStream` in `runCommand`; also serves as per-query budget in `batch` mode

--- a/mill
+++ b/mill
@@ -1,0 +1,199 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.5"; fi
+
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
+
+if [ -z "$MILL_MAIN_CLI" ] ; then MILL_MAIN_CLI="${0}"; fi
+
+MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
+
+MILL_BUILD_SCRIPT=""
+
+if [ -f "build.mill" ] ; then
+  MILL_BUILD_SCRIPT="build.mill"
+elif [ -f "build.mill.scala" ] ; then
+  MILL_BUILD_SCRIPT="build.mill.scala"
+elif [ -f "build.sc" ] ; then
+  MILL_BUILD_SCRIPT="build.sc"
+fi
+
+# `s/.*://`:
+#   This is a greedy match that removes everything from the beginning of the line up to (and including) the last
+#   colon (:). This effectively isolates the value part of the declaration.
+#
+#  `s/#.*//`:
+#    This removes any comments at the end of the line.
+#
+#  `s/['\"]//g`:
+#    This removes all single and double quotes from the string, wherever they appear (g is for "global").
+#
+#  `s/^[[:space:]]*//; s/[[:space:]]*$//`:
+#    These two expressions trim any leading or trailing whitespace ([[:space:]] matches spaces and tabs).
+TRIM_VALUE_SED="s/.*://; s/#.*//; s/['\"]//g; s/^[[:space:]]*//; s/[[:space:]]*$//"
+
+if [ -z "${MILL_VERSION}" ] ; then
+  if [ -f ".mill-version" ] ; then
+    MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
+  elif [ -f ".config/mill-version" ] ; then
+    MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
+  elif [ -f "build.mill.yaml" ] ; then
+    MILL_VERSION="$(grep -E "mill-version:" "build.mill.yaml" | sed -E "$TRIM_VALUE_SED")"
+  elif [ -n "${MILL_BUILD_SCRIPT}" ] ; then
+    MILL_VERSION="$(grep -E "//\|.*mill-version" "${MILL_BUILD_SCRIPT}" | sed -E "$TRIM_VALUE_SED")"
+  fi
+fi
+
+if [ -z "${MILL_VERSION}" ] ; then MILL_VERSION="${DEFAULT_MILL_VERSION}"; fi
+
+MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
+
+if [ -z "${MILL_FINAL_DOWNLOAD_FOLDER}" ] ; then MILL_FINAL_DOWNLOAD_FOLDER="${MILL_USER_CACHE_DIR}/download"; fi
+
+MILL_NATIVE_SUFFIX="-native"
+MILL_JVM_SUFFIX="-jvm"
+ARTIFACT_SUFFIX=""
+
+# Check if GLIBC version is at least the required version
+# Returns 0 (true) if GLIBC >= required version, 1 (false) otherwise
+check_glibc_version() {
+  required_version="2.39"
+  required_major=$(echo "$required_version" | cut -d. -f1)
+  required_minor=$(echo "$required_version" | cut -d. -f2)
+  # Get GLIBC version from ldd --version (first line contains version like "ldd (GNU libc) 2.31")
+  glibc_version=$(ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+$' || echo "")
+  if [ -z "$glibc_version" ]; then
+    # If we can't determine GLIBC version, assume it's too old
+    return 1
+  fi
+  glibc_major=$(echo "$glibc_version" | cut -d. -f1)
+  glibc_minor=$(echo "$glibc_version" | cut -d. -f2)
+  if [ "$glibc_major" -gt "$required_major" ]; then
+    return 0
+  elif [ "$glibc_major" -eq "$required_major" ] && [ "$glibc_minor" -ge "$required_minor" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+set_artifact_suffix() {
+  if [ "$(uname -s 2>/dev/null | cut -c 1-5)" = "Linux" ]; then
+    # Native binaries require new enough GLIBC; fall back to JVM launcher if older
+    if ! check_glibc_version; then
+      return
+    fi
+    if [ "$(uname -m)" = "aarch64" ]; then ARTIFACT_SUFFIX="-native-linux-aarch64"
+    else ARTIFACT_SUFFIX="-native-linux-amd64"; fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then ARTIFACT_SUFFIX="-native-mac-aarch64"
+    else ARTIFACT_SUFFIX="-native-mac-amd64"; fi
+  else
+    echo "This native mill launcher supports only Linux and macOS." 1>&2
+    exit 1
+  fi
+}
+
+case "$MILL_VERSION" in
+  *"$MILL_NATIVE_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+    set_artifact_suffix
+    ;;
+
+  *"$MILL_JVM_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
+    ;;
+
+  *)
+    case "$MILL_VERSION" in
+      0.1.* | 0.2.* | 0.3.* | 0.4.* | 0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.* | 0.12.*)
+        ;;
+      *)
+        set_artifact_suffix
+        ;;
+    esac
+    ;;
+esac
+
+MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
+
+# If not already downloaded, download it
+if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+  case $MILL_VERSION in
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.*)
+      MILL_DOWNLOAD_SUFFIX=""
+      MILL_DOWNLOAD_FROM_MAVEN=0
+      ;;
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M*)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=0
+      ;;
+    *)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=1
+      ;;
+  esac
+  case $MILL_VERSION in
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11)
+      MILL_DOWNLOAD_EXT="jar"
+      ;;
+    0.12.*)
+      MILL_DOWNLOAD_EXT="exe"
+      ;;
+    0.*)
+      MILL_DOWNLOAD_EXT="jar"
+      ;;
+    *)
+      MILL_DOWNLOAD_EXT="exe"
+      ;;
+  esac
+
+  MILL_TEMP_DOWNLOAD_FILE="${MILL_OUTPUT_DIR:-out}/mill-temp-download"
+  mkdir -p "$(dirname "${MILL_TEMP_DOWNLOAD_FILE}")"
+
+  if [ "$MILL_DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+    MILL_DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${MILL_DOWNLOAD_EXT}"
+  else
+    MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+    MILL_DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${MILL_DOWNLOAD_SUFFIX}"
+    unset MILL_VERSION_TAG
+  fi
+
+
+  if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+    echo "$MILL_DOWNLOAD_URL"
+    echo "$MILL"
+    exit 0
+  fi
+
+  echo "Downloading mill ${MILL_VERSION} from ${MILL_DOWNLOAD_URL} ..." 1>&2
+  curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"
+
+  chmod +x "${MILL_TEMP_DOWNLOAD_FILE}"
+
+  mkdir -p "${MILL_FINAL_DOWNLOAD_FOLDER}"
+  mv "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL}"
+
+  unset MILL_TEMP_DOWNLOAD_FILE
+  unset MILL_DOWNLOAD_SUFFIX
+fi
+
+MILL_FIRST_ARG=""
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--help" ] ; then
+  # Need to preserve the first position of those listed options
+  MILL_FIRST_ARG=$1
+  shift
+fi
+
+unset MILL_FINAL_DOWNLOAD_FOLDER
+unset MILL_OLD_DOWNLOAD_PATH
+unset OLD_MILL
+unset MILL_VERSION
+unset MILL_REPO_URL
+
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+# We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
+# shellcheck disable=SC2086
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -7,10 +7,10 @@ Multi-layered profiling tools for identifying performance bottlenecks.
 ```bash
 # Phase breakdown for cold index
 rm -rf benchmark/scala3/.scalex
-scala-cli run src/ -- index benchmark/scala3 --timings
+./mill run index benchmark/scala3 --timings
 
 # Phase breakdown for refs query
-scala-cli run src/ -- refs benchmark/scala3 Compiler --timings
+./mill run refs benchmark/scala3 Compiler --timings
 
 # Native image
 ./scalex index benchmark/scala3 --timings
@@ -51,9 +51,8 @@ brew install async-profiler
 
 ```bash
 # Record
-scala-cli run src/ \
-  --java-opt "-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
-  -- index benchmark/scala3
+SCALEX_JAVA_OPTS="-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
+  ./mill run index benchmark/scala3
 
 # Quick summary
 jfr summary profiling/scalex.jfr
@@ -75,13 +74,13 @@ open profiling/scalex.jfr
 
 ```bash
 # Run a specific benchmark
-scala-cli run src/bench.scala src/*.scala -- extract-single benchmark/scala3
+./mill bench.run extract-single benchmark/scala3
 
 # All benchmarks
-scala-cli run src/bench.scala src/*.scala -- all benchmark/scala3
+./mill bench.run all benchmark/scala3
 
 # Custom iterations
-scala-cli run src/bench.scala src/*.scala -- extract-batch benchmark/scala3 --warmup 3 --iterations 10
+./mill bench.run extract-batch benchmark/scala3 --warmup 3 --iterations 10
 ```
 
 ## Native Image Profiling

--- a/profiling/profile.sh
+++ b/profiling/profile.sh
@@ -30,6 +30,8 @@ if [ -z "$WORKSPACE" ]; then
   exit 1
 fi
 
+WORKSPACE="$(cd "$WORKSPACE" && pwd)"
+
 # ── Find async-profiler ──────────────────────────────────────────────────────
 
 if [ -n "${AP_HOME:-}" ]; then
@@ -56,9 +58,9 @@ echo ""
 # Delete cache to profile cold index
 rm -rf "$WORKSPACE/.scalex"
 
-scala-cli run "$PROJECT_ROOT/src/" \
-  --java-opt "-agentpath:$AP_LIB=start,event=$EVENT,file=$OUTPUT" \
-  -- index "$WORKSPACE"
+cd "$PROJECT_ROOT"
+SCALEX_JAVA_OPTS="-agentpath:$AP_LIB=start,event=$EVENT,file=$OUTPUT" \
+  ./mill run index "$WORKSPACE"
 
 echo ""
 echo "Flame graph written to: $OUTPUT"

--- a/profiling/scalex.jfc
+++ b/profiling/scalex.jfc
@@ -3,9 +3,8 @@
   JFR configuration for profiling scalex.
 
   Usage:
-    scala-cli run src/ \
-      - -java-opt "-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
-      - - index <workspace>
+    SCALEX_JAVA_OPTS="-XX:StartFlightRecording=filename=profiling/scalex.jfr,settings=profiling/scalex.jfc,duration=60s" \
+      ./mill run index <workspace>
 
     jfr summary profiling/scalex.jfr
     jfr print - -events jdk.ObjectAllocationSample profiling/scalex.jfr | head -100

--- a/src/bench.scala
+++ b/src/bench.scala
@@ -1,5 +1,4 @@
-//> using target.scope test
-// ^^ exclude from main compilation; run with: scala-cli run src/bench.scala src/*.scala -- <bench> <workspace>
+// Excluded from the main Mill module; run with: ./mill bench.run <bench> <workspace>
 
 import java.nio.file.{Files, Path}
 import scala.jdk.CollectionConverters.*
@@ -131,7 +130,7 @@ def benchIndexBuild(workspace: Path, warmup: Int, iters: Int): BenchResult =
   if argList.isEmpty || argList.contains("--help") then
     println("""scalex microbenchmark harness
       |
-      |Usage: scala-cli run src/bench.scala src/*.scala -- <benchmark> <workspace> [options]
+      |Usage: ./mill bench.run <benchmark> <workspace> [options]
       |
       |Benchmarks:
       |  extract-single     extractSymbols on one large file

--- a/src/project.scala
+++ b/src/project.scala
@@ -1,5 +1,0 @@
-//> using scala 3.8.3
-//> using dep org.scalameta::scalameta:4.16.1
-//> using dep com.google.guava:guava:33.6.0-jre
-//> using dep com.github.javaparser:javaparser-core:3.28.0
-//> using test.dep org.scalameta::munit:1.3.0


### PR DESCRIPTION
## Summary
- replace Scala CLI directives with a Mill build for the CLI, tests, benchmarks, and native image packaging
- route native build, release CI, profiling docs, and benchmark docs through the Mill wrapper
- update project docs, roadmap, and changelog for the new workflows

## Validation
- `./mill __.compile`
- `./mill test` (447 tests)
- `./mill __.compile 2>&1 | grep -i warn`
- `./mill __.compile 2>&1 | grep -i deprecat`
- `./mill run search . Scalex`
- `SCALEX_JAVA_OPTS=''-Xmx256m'' ./mill run --version`\n- `CI=true ./mill show nativeImageOptions`\n\nNative image generation was not run locally because `native-image` is unavailable on this machine; the Mill native-image options and CI/local option split were verified.