### PR TITLE
chord(scalex): bump version and dependencies

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -8,9 +8,9 @@ trait ScalexModule extends ScalaModule {
   def scalaVersion: T[String] = "3.8.3"
 
   def mvnDeps: T[Seq[Dep]] = Seq(
-    mvn"org.scalameta::scalameta:4.16.1",
+    mvn"org.scalameta::scalameta:4.17.0",
     mvn"com.google.guava:guava:33.6.0-jre",
-    mvn"com.github.javaparser:javaparser-core:3.28.0"
+    mvn"com.github.javaparser:javaparser-core:3.28.2"
   )
 
   def mainClass: T[Option[String]] = Some("main")
@@ -59,7 +59,7 @@ object `package` extends ScalexModule, NativeImageModule {
     def sources: T[Seq[PathRef]] = Task.Sources("tests")
 
     def mvnDeps: T[Seq[Dep]] = Seq(
-      mvn"org.scalameta::munit:1.3.0"
+      mvn"org.scalameta::munit:1.3.1"
     )
 
     def testFramework: T[String] = "munit.Framework"

--- a/src/model.scala
+++ b/src/model.scala
@@ -2,7 +2,7 @@ import java.nio.file.Path
 import com.google.common.hash.BloomFilter
 import java.util.concurrent.ConcurrentLinkedQueue as CLQ
 
-val ScalexVersion = "1.39.0"
+val ScalexVersion = "1.40.0"
 
 // ── Timings ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump Scalex version from 1.39.0 to 1.40.0.
- Update Scalameta, JavaParser, and MUnit dependency versions.

## Impact

Keeps the release version and parser/test dependencies current.

## Validation

- ./mill __.compile + test