### PR TITLE
chord(scalex): document 1.40.0 release metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ git ls-files --stage → Scalameta parse → in-memory index → query
 
 ### Dependencies
 
-- `org.scalameta::scalameta:4.15.2` — AST parsing
-- `com.google.guava:guava:33.5.0-jre` — bloom filters
-- `org.scalameta::munit:1.2.4` — test framework (test only)
+- `org.scalameta::scalameta:4.17.0` — AST parsing
+- `com.google.guava:guava:33.6.0-jre` — bloom filters
+- `com.github.javaparser:javaparser-core:3.28.2` — Java source parsing
+- `org.scalameta::munit:1.3.1` — test framework (test only)
 
 ## Plugin structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased]
 
+## [1.40.0] — 2026-06-01
+
 ### Changed
 - Migrated the project build from scala-cli directives to Mill, including CLI/test/benchmark modules and native image packaging.
+- Bumped Scalex to 1.40.0, Scalameta to 4.17.0, JavaParser to 3.28.2, and munit to 1.3.1.
 
 ## [1.39.0] — 2026-04-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,10 @@ git ls-files --stage → Scalameta parse → in-memory index → query
 
 ### Dependencies
 
-- `org.scalameta::scalameta:4.15.2` — AST parsing
-- `com.google.guava:guava:33.5.0-jre` — bloom filters
-- `org.scalameta::munit:1.2.4` — test framework (test only)
+- `org.scalameta::scalameta:4.17.0` — AST parsing
+- `com.google.guava:guava:33.6.0-jre` — bloom filters
+- `com.github.javaparser:javaparser-core:3.28.2` — Java source parsing
+- `org.scalameta::munit:1.3.1` — test framework (test only)
 
 ## Plugin structure
 


### PR DESCRIPTION
## Summary

- Move the current changelog entry under the 1.40.0 release date: 2026-06-01.
- Add the Scalex, Scalameta, JavaParser, and munit version updates to the 1.40.0 changelog entry.
- Refresh AGENTS.md and CLAUDE.md dependency lists for the 1.40.0 dependency versions.

## Impact

This is a documentation and release metadata update. No runtime code changed in this PR.

## Validation

- Not run; documentation-only change.