### PR TITLE
fix(scalex): pass nativeCopy dest argument

### DIFF
--- a/build-native.sh
+++ b/build-native.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT="${1:-$SCRIPT_DIR/scalex}"
 
 echo "Building Scalex native image..."
-"$SCRIPT_DIR/mill" nativeCopy "$OUT"
+"$SCRIPT_DIR/mill" nativeCopy --dest "$OUT"
 
 echo ""
 echo "Built: $OUT"


### PR DESCRIPTION
## Summary

- Update build-native.sh to pass Mill's nativeCopy command argument as --dest.

## Root Cause

The release workflow called ./build-native.sh with an artifact name. The script forwarded that value positionally to Mill as nativeCopy <artifact>, but the Mill command signature expects nativeCopy --dest <artifact>. As a result, every release build failed before native-image started.

## Impact

Release tag builds can reach the native image task instead of failing at Mill argument parsing.

## Validation

- bash -n build-native.sh
- ./mill nativeCopy --dest /tmp/scalex-native-arg-check
  - Confirmed the Mill argument parsing issue is fixed; local run then stopped at nativeImageTool because GRAALVM_HOME is not configured on this machine.