### PR TITLE
chord(scalex): bump plugin to 1.40.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "scalex",
       "source": "./plugins/scalex",
       "description": "Scala code intelligence for coding agents — search symbols, find definitions, find implementations, find references, explore imports. Works on Scala 2 and 3 codebases without a compiler or build server.",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "author": {
         "name": "Tu Nguyen"
       },

--- a/plugins/scalex/skills/scalex/scripts/scalex-cli
+++ b/plugins/scalex/skills/scalex/scripts/scalex-cli
@@ -7,13 +7,13 @@ if [ -z "${BASH_VERSION:-}" ] && [ -f "$0" ]; then
 fi
 set -euo pipefail
 
-EXPECTED_VERSION="1.39.0"
+EXPECTED_VERSION="1.40.0"
 REPO="nguyenyou/scalex"
 
 # Expected SHA-256 checksums for each artifact (updated each release alongside EXPECTED_VERSION)
-CHECKSUM_scalex_macos_arm64="1b00d2fc1717f4f8717ea59ee5073aacebf0a426b53a23ab31806558f6b2cbd5"
-CHECKSUM_scalex_macos_x64="f00dba4ecb0afdf90b6e965bb759c7620ff021b1b68abe5b3ed202befca6cce3"
-CHECKSUM_scalex_linux_x64="3f8fb6faf5c7f534ad49fbd7efa0d24abaacd8a224b4691c45dc9e1c5b82d5f2"
+CHECKSUM_scalex_macos_arm64="cc31285cc905e28ba464a2caa6e45db16e58341c964421632eacf6c282972781"
+CHECKSUM_scalex_macos_x64="f3ee999b8075618cc913c5fc996bf5c0ca263e35ba18dc98bd039f3698be9468"
+CHECKSUM_scalex_linux_x64="d7a75abe6dd831982d164e69ff3cf5e8d83cd9ffacd34686878c4cbf40b54f86"
 
 # Cache location: follow XDG spec (like Mill uses ~/.cache/mill/download/)
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/scalex"


### PR DESCRIPTION
## Summary

- Bump the plugin marketplace version to 1.40.0.
- Update the scalex bootstrap EXPECTED_VERSION to 1.40.0.
- Refresh macOS arm64, macOS x64, and Linux x64 SHA-256 checksums from the v1.40.0 release assets.

## Impact

Plugin users will download and verify the v1.40.0 native binaries.

## Validation

- gh run view 26736253548 --json status,conclusion,jobs
- gh release view v1.40.0 --json assets
- bash -n plugins/scalex/skills/scalex/scripts/scalex-cli
- jq empty .claude-plugin/marketplace.json plugins/scalex/.claude-plugin/plugin.json
- XDG_CACHE_HOME=/tmp/scalex-plugin-cache-LN1TqH plugins/scalex/skills/scalex/scripts/scalex-cli --version
  - Output: 1.40.0