### PR TITLE
fix(scalex): make native build self-contained

### DIFF
--- a/build-native.sh
+++ b/build-native.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OUT="${1:-$SCRIPT_DIR/scalex}"
 
 echo "Building Scalex native image..."
-"$SCRIPT_DIR/mill" nativeCopy --dest "$OUT"
+"$SCRIPT_DIR/mill" --no-daemon nativeCopy --dest "$OUT"
 
 echo ""
 echo "Built: $OUT"

--- a/build.mill
+++ b/build.mill
@@ -29,6 +29,8 @@ trait ScalexModule extends ScalaModule {
 object `package` extends ScalexModule, NativeImageModule {
   private def workspaceRoot: os.Path = moduleDir
 
+  override def jvmVersion: T[String] = "graalvm-community:21.0.2"
+
   override def allSourceFiles: T[Seq[PathRef]] = Task {
     super.allSourceFiles().filterNot(_.path == moduleDir / "src" / "bench.scala")
   }


### PR DESCRIPTION
## Summary

- Configure the Mill native-image module to resolve GraalVM via jvmVersion.
- Run build-native.sh with --no-daemon so stale Mill daemon environments cannot affect native builds.

## Root Cause

The native-image task relied on either Mill javaHome or GRAALVM_HOME. Scalex did not configure a GraalVM jvmVersion, so local native builds needed shell environment setup and could still fail if an existing Mill daemon had started without that environment.

## Impact

Developers can run ./build-native.sh scalex or ./mill nativeCopy --dest scalex without manually exporting GRAALVM_HOME.

## Validation

- bash -n build-native.sh
- env -u GRAALVM_HOME -u JAVA_HOME ./build-native.sh scalex
- ./scalex --version
  - Output: 1.40.0