### PR TITLE
refactor(scalex): deduplicate extraction, single-pass flag parser, value-returned timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+- A positional argument that equals a flag's value elsewhere in the arg list (e.g. `scalex def --kind class class`) is no longer dropped — flag parsing is now a single position-aware pass
+- Corrupted or truncated index caches now report the failure cause on stderr (`index load failed (EOFException: …) — rebuilding`) instead of a generic message
+- Git subprocess readers are closed after use; a missing `git` binary now produces a clear error instead of a stack trace
+
+### Changed (internal)
+- `findReferences`, `findImports`, and `categorizeReferences` return `timedOut` as part of their result instead of mutating shared state on `WorkspaceIndex` — concurrent queries can no longer clobber each other's timeout flag
+- Member extraction (`members`, `grep --each-method`) now shares one traversal; body extraction and the Scala 3 → 2.13 parse fallback are deduplicated
+- Removed all remaining `return` statements from production code (34) per the codebase-wide policy
+
 ## [1.40.0] — 2026-06-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ git ls-files --stage → Scalameta parse → in-memory index → query
 ### Code style
 
 - **Named tuples**: Never use unnamed tuples. Whenever a tuple is needed — return types, local variables, collection elements — always use named tuples. E.g. `(results: List[Reference], timedOut: Boolean)` not `(List[Reference], Boolean)`.
-- **No `return` statements**: Never use `return` anywhere — not in methods, not in lambdas, not in `for`/`foreach`. Use `scala.util.boundary` + `boundary.break` for early exit, or restructure with `match`/`if-else`. The `return` keyword is deprecated in Scala 3 inside lambdas and is a footgun everywhere else. Existing `return` statements in the codebase are legacy — do not add new ones, and remove them when touching nearby code.
+- **No `return` statements**: Never use `return` anywhere — not in methods, not in lambdas, not in `for`/`foreach`. Use `scala.util.boundary` + `boundary.break` for early exit, or restructure with `match`/`if-else`. The `return` keyword is deprecated in Scala 3 inside lambdas and is a footgun everywhere else. The codebase is `return`-free — keep it that way.
 
 ### Key design choices
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,18 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Maintainability refactor (internal, no behavior change)
+
+- [x] Unify the duplicated member-extraction traversals (`extractScalaMembers` / `extractMembersWithSpans`) behind one origin-tagged core (`extractScalaMemberTree`)
+- [x] Factor the repeated body-slice blocks in `extractScalaBody` into a single `addBody` helper with a `TypeDefn` extractor
+- [x] Deduplicate the Scala 3 → Scala 2.13 parse fallback into `parseSource`; add `readSource`/`readSourceLines` helpers
+- [x] Rewrite `parseFlags` as a single position-aware pass — fixes positional args being dropped when they equal a flag value elsewhere in the arg list
+- [x] Return `timedOut` from `findReferences`/`findImports`/`categorizeReferences` as a value instead of a shared mutable field on `WorkspaceIndex`
+- [x] Close git subprocess readers (`Using.resource`); shared `runGitLines` helper; survive a missing git binary
+- [x] Report the cause when the binary index fails to load (`ClassName: message`) instead of a generic message
+- [x] Remove all 34 `return` statements from `src/` (boundary/break or restructuring); zero-`return` policy now holds codebase-wide
+- [x] New tests: cache corruption/truncation/version-mismatch recovery, refs timeout reporting, flag-parser regressions, member-origin extraction
+
 ### Mill build migration
 
 - [x] Add Mill build definition for Scalex CLI and tests

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -1,91 +1,76 @@
 import scala.meta.*
 import scala.collection.mutable
-import java.nio.file.{Files, Path}
+import scala.util.Using
+import java.nio.file.Path
 import java.io.{BufferedReader, InputStreamReader}
 import scala.jdk.CollectionConverters.*
 
 // ── Hierarchy building ──────────────────────────────────────────────────────
 
 def buildHierarchy(idx: WorkspaceIndex, symbolName: String, goUp: Boolean, goDown: Boolean, maxDepth: Int, workspace: Path): Option[HierarchyTree] = {
-  val defs = idx.findDefinition(symbolName)
-  if defs.isEmpty then return None
-
-  val sym = defs.head
-  val rootNode = HierarchyNode(sym.name, Some(sym.kind), Some(sym.file), Some(sym.line), sym.packageName, isExternal = false)
-
   def walkUp(name: String, visited: Set[String], depth: Int): List[HierarchyTree] = {
-    if depth >= maxDepth || visited.contains(name.toLowerCase) then return Nil
-    val newVisited = visited + name.toLowerCase
-    val defs = idx.findDefinition(name)
-    if defs.isEmpty then Nil
+    if depth >= maxDepth || visited.contains(name.toLowerCase) then Nil
     else {
-      val s = defs.head
-      s.parents.map { parentName =>
-        val parentDefs = idx.findDefinition(parentName)
-        if parentDefs.isEmpty then {
-          val extNode = HierarchyNode(parentName, None, None, None, "", isExternal = true)
-          HierarchyTree(extNode, Nil, Nil)
-        } else {
-          val pd = parentDefs.head
-          val pNode = HierarchyNode(pd.name, Some(pd.kind), Some(pd.file), Some(pd.line), pd.packageName, isExternal = false)
-          val grandParents = walkUp(pd.name, newVisited, depth + 1)
-          HierarchyTree(pNode, grandParents, Nil)
+      val newVisited = visited + name.toLowerCase
+      idx.findDefinition(name).headOption.toList.flatMap { s =>
+        s.parents.map { parentName =>
+          idx.findDefinition(parentName).headOption match {
+            case None =>
+              val extNode = HierarchyNode(parentName, None, None, None, "", isExternal = true)
+              HierarchyTree(extNode, Nil, Nil)
+            case Some(pd) =>
+              val pNode = HierarchyNode(pd.name, Some(pd.kind), Some(pd.file), Some(pd.line), pd.packageName, isExternal = false)
+              val grandParents = walkUp(pd.name, newVisited, depth + 1)
+              HierarchyTree(pNode, grandParents, Nil)
+          }
         }
       }
     }
   }
 
   def walkDown(name: String, visited: Set[String], depth: Int): List[HierarchyTree] = {
-    if depth >= maxDepth || visited.contains(name.toLowerCase) then return Nil
-    val newVisited = visited + name.toLowerCase
-    val impls = idx.findImplementations(name)
-    impls.map { s =>
-      val node = HierarchyNode(s.name, Some(s.kind), Some(s.file), Some(s.line), s.packageName, isExternal = false)
-      if depth + 1 >= maxDepth then {
-        val truncated = idx.findImplementations(s.name).size
-        HierarchyTree(node, Nil, Nil, truncatedChildren = truncated)
-      } else {
-        val grandChildren = walkDown(s.name, newVisited, depth + 1)
-        HierarchyTree(node, Nil, grandChildren)
+    if depth >= maxDepth || visited.contains(name.toLowerCase) then Nil
+    else {
+      val newVisited = visited + name.toLowerCase
+      idx.findImplementations(name).map { s =>
+        val node = HierarchyNode(s.name, Some(s.kind), Some(s.file), Some(s.line), s.packageName, isExternal = false)
+        if depth + 1 >= maxDepth then {
+          val truncated = idx.findImplementations(s.name).size
+          HierarchyTree(node, Nil, Nil, truncatedChildren = truncated)
+        } else {
+          val grandChildren = walkDown(s.name, newVisited, depth + 1)
+          HierarchyTree(node, Nil, grandChildren)
+        }
       }
     }
   }
 
-  val parents = if goUp then walkUp(sym.name, Set.empty, 0) else Nil
-  val children = if goDown then walkDown(sym.name, Set.empty, 0) else Nil
-  Some(HierarchyTree(rootNode, parents, children))
+  idx.findDefinition(symbolName).headOption.map { sym =>
+    val rootNode = HierarchyNode(sym.name, Some(sym.kind), Some(sym.file), Some(sym.line), sym.packageName, isExternal = false)
+    val parents = if goUp then walkUp(sym.name, Set.empty, 0) else Nil
+    val children = if goDown then walkDown(sym.name, Set.empty, 0) else Nil
+    HierarchyTree(rootNode, parents, children)
+  }
 }
 
 // ── Override finding ────────────────────────────────────────────────────────
 
 def findOverrides(idx: WorkspaceIndex, methodName: String, ofTrait: Option[String], limit: Int): List[OverrideInfo] = {
   val buf = mutable.ListBuffer.empty[OverrideInfo]
-  val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+
+  def addMatchingMembers(s: SymbolInfo): Unit =
+    extractMembers(s.file, s.name).filter(_.name == methodName).foreach { m =>
+      buf += OverrideInfo(s.file, m.line, s.name, s.kind, m.signature, s.packageName)
+    }
 
   ofTrait match
     case Some(traitName) =>
-      val impls = idx.findImplementations(traitName)
-      impls.foreach { s =>
-        if typeKinds.contains(s.kind) then {
-          val members = extractMembers(s.file, s.name)
-          members.filter(_.name == methodName).foreach { m =>
-            buf += OverrideInfo(s.file, m.line, s.name, s.kind, m.signature, s.packageName)
-          }
-        }
-      }
+      idx.findImplementations(traitName).filter(s => typeKinds.contains(s.kind)).foreach(addMatchingMembers)
     case None =>
-      // Find the method's defining type first
-      val methodDefs = idx.findDefinition(methodName).filter(s => s.kind == SymbolKind.Def || s.kind == SymbolKind.Val)
-      // Also search all types that have a member with this name
+      // No declaring trait given: scan all types for a member with this name, capped by limit
       val allTypes = idx.symbols.filter(s => typeKinds.contains(s.kind))
       val iter = allTypes.iterator
-      while iter.hasNext && buf.size < limit do {
-        val s = iter.next()
-        val members = extractMembers(s.file, s.name)
-        members.filter(_.name == methodName).foreach { m =>
-          buf += OverrideInfo(s.file, m.line, s.name, s.kind, m.signature, s.packageName)
-        }
-      }
+      while iter.hasNext && buf.size < limit do addMatchingMembers(iter.next())
 
   buf.toList
 }
@@ -98,105 +83,77 @@ def extractDeps(idx: WorkspaceIndex, symbolName: String, workspace: Path, maxDep
   val visited = mutable.HashSet.empty[String]
 
   def extractSingle(name: String, depth: Int): Unit = {
-    if depth >= maxDepth || visited.contains(name.toLowerCase) then return
-    visited += name.toLowerCase
+    if depth < maxDepth && !visited.contains(name.toLowerCase) then {
+      visited += name.toLowerCase
+      idx.findDefinition(name).headOption.filterNot(sym => isJavaFile(sym.file)).foreach { sym =>
+        val seenNames = mutable.HashSet.empty[String]
+        seenNames += name // avoid self-reference
 
-    val defs = idx.findDefinition(name)
-    if defs.isEmpty then return
-
-    val sym = defs.head
-    if isJavaFile(sym.file) then return
-    val seenNames = mutable.HashSet.empty[String]
-    seenNames += name // avoid self-reference
-
-    parseFile(sym.file) match {
-      case None => ()
-      case Some(tree) =>
-        def findNode(t: Tree): Option[Tree] = {
-          t match
-            case d: Defn.Class if d.name.value == name => Some(d)
-            case d: Defn.Trait if d.name.value == name => Some(d)
-            case d: Defn.Object if d.name.value == name => Some(d)
-            case d: Defn.Enum if d.name.value == name => Some(d)
-            case d: Defn.Def if d.name.value == name => Some(d)
-            case _ =>
-              var result: Option[Tree] = None
-              t.children.foreach { c =>
-                if result.isEmpty then result = findNode(c)
-              }
-              result
+        // Record a dependency on `depName` (resolved via the index) into `sink`
+        def addDep(depName: String, sink: mutable.ListBuffer[DepInfo]): Unit = {
+          if !seenNames.contains(depName) then {
+            seenNames += depName
+            idx.findDefinition(depName).headOption.foreach { f =>
+              if !visited.contains(f.name.toLowerCase) then
+                sink += DepInfo(f.name, f.kind.toString.toLowerCase, Some(f.file), Some(f.line), f.packageName, depth)
+            }
+          }
         }
 
-        // Collect imports at the file level
-        def collectImports(t: Tree): Unit = {
-          t match
-            case i: Import =>
-              i.importers.foreach { importer =>
-                importer.importees.foreach {
-                  case importee: Importee.Name =>
-                    val iname = importee.name.value
-                    if !seenNames.contains(iname) then {
-                      seenNames += iname
-                      val found = idx.findDefinition(iname)
-                      if found.nonEmpty then {
-                        val f = found.head
-                        if !visited.contains(f.name.toLowerCase) then
-                          allImportDeps += DepInfo(f.name, f.kind.toString.toLowerCase, Some(f.file), Some(f.line), f.packageName, depth)
-                      }
-                    }
-                  case importee: Importee.Rename =>
-                    val iname = importee.name.value
-                    if !seenNames.contains(iname) then {
-                      seenNames += iname
-                      val found = idx.findDefinition(iname)
-                      if found.nonEmpty then {
-                        val f = found.head
-                        if !visited.contains(f.name.toLowerCase) then
-                          allImportDeps += DepInfo(f.name, f.kind.toString.toLowerCase, Some(f.file), Some(f.line), f.packageName, depth)
-                      }
-                    }
-                  case _ =>
-                }
-              }
-            case _ =>
-          t.children.foreach(collectImports)
-        }
-        collectImports(tree)
-
-        // Collect type/term references in the symbol's body
-        findNode(tree).foreach { node =>
-          def collectRefs(t: Tree): Unit = {
+        parseFile(sym.file).foreach { tree =>
+          def findNode(t: Tree): Option[Tree] = {
             t match
-              case Type.Name(typeName) if typeName != name && !seenNames.contains(typeName) =>
-                seenNames += typeName
-                val found = idx.findDefinition(typeName)
-                if found.nonEmpty then {
-                  val f = found.head
-                  if !visited.contains(f.name.toLowerCase) then
-                    allBodyDeps += DepInfo(f.name, f.kind.toString.toLowerCase, Some(f.file), Some(f.line), f.packageName, depth)
+              case d: Defn.Class if d.name.value == name => Some(d)
+              case d: Defn.Trait if d.name.value == name => Some(d)
+              case d: Defn.Object if d.name.value == name => Some(d)
+              case d: Defn.Enum if d.name.value == name => Some(d)
+              case d: Defn.Def if d.name.value == name => Some(d)
+              case _ =>
+                var result: Option[Tree] = None
+                t.children.foreach { c =>
+                  if result.isEmpty then result = findNode(c)
                 }
-              case Term.Name(termName) if termName != name && !seenNames.contains(termName) =>
-                seenNames += termName
-                val found = idx.findDefinition(termName)
-                if found.nonEmpty then {
-                  val f = found.head
-                  if !visited.contains(f.name.toLowerCase) then
-                    allBodyDeps += DepInfo(f.name, f.kind.toString.toLowerCase, Some(f.file), Some(f.line), f.packageName, depth)
+                result
+          }
+
+          // Collect imports at the file level
+          def collectImports(t: Tree): Unit = {
+            t match
+              case i: Import =>
+                i.importers.foreach { importer =>
+                  importer.importees.foreach {
+                    case importee: Importee.Name => addDep(importee.name.value, allImportDeps)
+                    case importee: Importee.Rename => addDep(importee.name.value, allImportDeps)
+                    case _ =>
+                  }
                 }
               case _ =>
-            t.children.foreach(collectRefs)
+            t.children.foreach(collectImports)
           }
-          collectRefs(node)
-        }
+          collectImports(tree)
 
-        // Recurse into discovered deps at the next depth level
-        if depth + 1 < maxDepth then {
-          val newDeps = (allImportDeps.toList ++ allBodyDeps.toList)
-            .filter(_.depth == depth)
-            .map(_.name)
-            .distinct
-          newDeps.foreach(dep => extractSingle(dep, depth + 1))
+          // Collect type/term references in the symbol's body
+          findNode(tree).foreach { node =>
+            def collectRefs(t: Tree): Unit = {
+              t match
+                case Type.Name(typeName) if typeName != name => addDep(typeName, allBodyDeps)
+                case Term.Name(termName) if termName != name => addDep(termName, allBodyDeps)
+                case _ =>
+              t.children.foreach(collectRefs)
+            }
+            collectRefs(node)
+          }
+
+          // Recurse into discovered deps at the next depth level
+          if depth + 1 < maxDepth then {
+            val newDeps = (allImportDeps.toList ++ allBodyDeps.toList)
+              .filter(_.depth == depth)
+              .map(_.name)
+              .distinct
+            newDeps.foreach(dep => extractSingle(dep, depth + 1))
+          }
         }
+      }
     }
   }
 
@@ -206,16 +163,11 @@ def extractDeps(idx: WorkspaceIndex, symbolName: String, workspace: Path, maxDep
 
 // ── Diff extraction ─────────────────────────────────────────────────────────
 
-def runGitDiff(workspace: Path, ref: String): List[String] = {
-  val pb = ProcessBuilder("git", "diff", "--name-only", ref)
-  pb.directory(workspace.toFile)
-  pb.redirectErrorStream(true)
-  val proc = pb.start()
-  val reader = BufferedReader(InputStreamReader(proc.getInputStream))
-  val files = reader.lines().iterator().asScala.filter(f => f.endsWith(".scala") || f.endsWith(".java")).toList
-  proc.waitFor()
-  files
-}
+def runGitDiff(workspace: Path, ref: String): List[String] =
+  runGitLines(workspace, "diff", "--name-only", ref) match {
+    case None => Nil
+    case Some(result) => result.lines.filter(f => f.endsWith(".scala") || f.endsWith(".java"))
+  }
 
 def gitShowFile(workspace: Path, ref: String, relPath: String): Option[String] = {
   try {
@@ -223,8 +175,9 @@ def gitShowFile(workspace: Path, ref: String, relPath: String): Option[String] =
     pb.directory(workspace.toFile)
     pb.redirectErrorStream(false)
     val proc = pb.start()
-    val reader = BufferedReader(InputStreamReader(proc.getInputStream))
-    val content = reader.lines().iterator().asScala.mkString("\n")
+    val content = Using.resource(BufferedReader(InputStreamReader(proc.getInputStream))) { reader =>
+      reader.lines().iterator().asScala.mkString("\n")
+    }
     val exitCode = proc.waitFor()
     if exitCode == 0 then Some(content) else None
   } catch {
@@ -232,25 +185,13 @@ def gitShowFile(workspace: Path, ref: String, relPath: String): Option[String] =
   }
 }
 
-def extractSymbolsFromSource(source: String, filePath: String): List[DiffSymbol] = {
-  val input = Input.VirtualFile(filePath, source)
-  val tree = try {
-    given scala.meta.Dialect = scala.meta.dialects.Scala3
-    input.parse[Source].get
-  } catch {
-    case _: Exception =>
-      try {
-        given scala.meta.Dialect = scala.meta.dialects.Scala213
-        input.parse[Source].get
-      } catch {
-        case _: Exception =>
-          return Nil
-      }
+def extractSymbolsFromSource(source: String, filePath: String): List[DiffSymbol] =
+  parseSource(source, filePath) match {
+    case None => Nil
+    case Some(tree) =>
+      val (rawSymbols, pkg) = extractRawSymbols(tree)
+      rawSymbols.map(r => DiffSymbol(r.name, r.kind, filePath, r.line, pkg, r.signature))
   }
-
-  val (rawSymbols, pkg) = extractRawSymbols(tree)
-  rawSymbols.map(r => DiffSymbol(r.name, r.kind, filePath, r.line, pkg, r.signature))
-}
 
 // ── AST pattern search ──────────────────────────────────────────────────────
 
@@ -259,7 +200,6 @@ def astPatternSearch(idx: WorkspaceIndex, workspace: Path,
                      bodyContains: Option[String], noTests: Boolean,
                      pathFilter: Option[String], excludePath: Option[String] = None,
                      limit: Int): List[AstPatternMatch] = {
-  val typeKinds = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
   var candidates = idx.symbols.filter(s => typeKinds.contains(s.kind))
   if noTests then candidates = candidates.filter(s => !isTestFile(s.file, workspace))
   pathFilter.foreach { p => candidates = candidates.filter(s => matchesPath(s.file, p, workspace)) }

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -164,10 +164,9 @@ def extractDeps(idx: WorkspaceIndex, symbolName: String, workspace: Path, maxDep
 // ── Diff extraction ─────────────────────────────────────────────────────────
 
 def runGitDiff(workspace: Path, ref: String): List[String] =
-  runGitLines(workspace, "diff", "--name-only", ref) match {
-    case None => Nil
-    case Some(result) => result.lines.filter(f => f.endsWith(".scala") || f.endsWith(".java"))
-  }
+  runGitLines(workspace, "diff", "--name-only", ref) { lines =>
+    lines.filter(f => f.endsWith(".scala") || f.endsWith(".java")).toList
+  }.getOrElse(Nil)
 
 def gitShowFile(workspace: Path, ref: String, relPath: String): Option[String] = {
   try {

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -44,134 +44,98 @@ case class ParsedFlags(
   cleanArgs: List[String] = Nil,
 )
 
-private val flagsWithArgs = Set("--limit", "--kind", "--workspace", "-w", "--path", "--exclude-path", "-C", "-e", "--category",
-                         "--in", "--of", "--impl-limit", "--depth", "--has-method", "--extends", "--body-contains", "--focus-package", "--expand",
-                         "--members-limit", "--used-by", "--returns", "--takes", "--top", "--max-lines", "--offset",
-                         "--max-output", "--in-package")
+/** Single left-to-right pass over the arg list. Each token is classified exactly
+  * once as a flag, a flag's value, or a positional arg — so a positional that
+  * happens to equal a flag's value elsewhere in the list is never misclassified. */
+def parseFlags(argList: List[String]): ParsedFlags = {
+  var f = ParsedFlags()
+  val positional = List.newBuilder[String]
+  // Paired flags are resolved after the pass
+  var sawUp = false
+  var sawDown = false
+  var sawExact = false
+  var sawPrefix = false
+  var wsLong: Option[String] = None
+  var wsShort: Option[String] = None
 
-def parseFlags(argList: List[String]): ParsedFlags =
-  val limit = argList.indexOf("--limit") match
-    case -1 => 20
-    case i =>
-      val v = argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(20)
-      if v == 0 then Int.MaxValue else v
-  val kindFilter = argList.indexOf("--kind") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val verbose = argList.contains("--verbose")
-  val categorize = !argList.contains("--flat")
-  val includeTests = argList.contains("--include-tests")
-  val noTests = argList.contains("--no-tests")
-  val pathFilter: Option[String] = argList.indexOf("--path") match
-    case -1 => None
-    case i => argList.lift(i + 1).map(p => p.stripPrefix("/"))
-  val contextLines: Int = argList.indexOf("-C") match
-    case -1 => 0
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
-  val jsonOutput = argList.contains("--json")
-  val countOnly = argList.contains("--count")
-  val searchMode: Option[String] =
-    if argList.contains("--exact") then Some("exact")
-    else if argList.contains("--prefix") then Some("prefix")
-    else None
-  val definitionsOnly = argList.contains("--definitions-only")
-  val categoryFilter: Option[String] = argList.indexOf("--category") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val grepPatterns: List[String] = argList.zipWithIndex.collect {
-    case ("-e", i) if argList.lift(i + 1).exists(a => !a.startsWith("-")) => argList(i + 1)
+  val args = argList.toVector
+  var i = 0
+  while i < args.length do {
+    // For flags that take a value: read the next token and consume it
+    def value: Option[String] = {
+      i += 1
+      args.lift(i)
+    }
+    def intValue(default: Int): Int = value.flatMap(_.toIntOption).getOrElse(default)
+
+    args(i) match {
+      case "--limit"          => val v = intValue(20); f = f.copy(limit = if v == 0 then Int.MaxValue else v)
+      case "--kind"           => f = f.copy(kindFilter = value)
+      case "--workspace"      => wsLong = value
+      case "-w"               => wsShort = value
+      case "--path"           => f = f.copy(pathFilter = value.map(_.stripPrefix("/")))
+      case "--exclude-path"   => f = f.copy(excludePath = value.map(_.stripPrefix("/")))
+      case "-C"               => f = f.copy(contextLines = intValue(0))
+      case "-e"               => value.filterNot(_.startsWith("-")).foreach(p => f = f.copy(grepPatterns = f.grepPatterns :+ p))
+      case "--category"       => f = f.copy(categoryFilter = value)
+      case "--in"             => f = f.copy(inOwner = value)
+      case "--of"             => f = f.copy(ofTrait = value)
+      case "--impl-limit"     => f = f.copy(implLimit = intValue(5))
+      case "--depth"          => f = f.copy(maxDepth = intValue(-1))
+      case "--has-method"     => f = f.copy(hasMethodFilter = value)
+      case "--extends"        => f = f.copy(extendsFilter = value)
+      case "--body-contains"  => f = f.copy(bodyContainsFilter = value)
+      case "--focus-package"  => f = f.copy(focusPackage = value)
+      case "--expand"         => f = f.copy(expandDepth = intValue(1))
+      case "--members-limit"  => f = f.copy(membersLimit = intValue(10))
+      case "--used-by"        => f = f.copy(usedByFilter = value)
+      case "--returns"        => f = f.copy(returnsFilter = value)
+      case "--takes"          => f = f.copy(takesFilter = value)
+      case "--top"            => f = f.copy(topN = value.flatMap(_.toIntOption))
+      case "--max-lines"      => f = f.copy(maxBodyLines = intValue(0))
+      case "--offset"         => f = f.copy(offset = intValue(0))
+      case "--max-output"     => f = f.copy(maxOutput = intValue(0))
+      case "--in-package"     => f = f.copy(inPackageFilter = value)
+      case "--verbose"        => f = f.copy(verbose = true)
+      case "--flat"           => f = f.copy(categorize = false)
+      case "--include-tests"  => f = f.copy(includeTests = true)
+      case "--no-tests"       => f = f.copy(noTests = true)
+      case "--json"           => f = f.copy(jsonOutput = true)
+      case "--count"          => f = f.copy(countOnly = true)
+      case "--exact"          => sawExact = true
+      case "--prefix"         => sawPrefix = true
+      case "--definitions-only" => f = f.copy(definitionsOnly = true)
+      case "--up"             => sawUp = true
+      case "--down"           => sawDown = true
+      case "--inherited"      => f = f.copy(inherited = true)
+      case "--architecture"   => f = f.copy(architecture = true)
+      case "--brief"          => f = f.copy(brief = true)
+      case "--strict"         => f = f.copy(strict = true)
+      case "--shallow"        => f = f.copy(shallow = true)
+      case "--no-doc"         => f = f.copy(noDoc = true)
+      case "--summary"        => f = f.copy(summaryMode = true)
+      case "--timings"        => f = f.copy(timingsEnabled = true)
+      case "--body" | "--with-bodies" => f = f.copy(withBody = true)
+      case "--imports"        => f = f.copy(showImports = true)
+      case "--related"        => f = f.copy(related = true)
+      case "--explain"        => f = f.copy(explainMode = true)
+      case "--concise"        => f = f.copy(concise = true)
+      case "--each-method"    => f = f.copy(eachMethod = true)
+      case "--categorize" | "-c" => () // categorized output is the default; kept for backwards compatibility
+      case other if other.startsWith("--") => () // unknown long flags are ignored
+      case other => positional += other
+    }
+    i += 1
   }
-  val explicitWorkspace: Option[String] =
-    val longIdx = argList.indexOf("--workspace")
-    val shortIdx = argList.indexOf("-w")
-    val idx = if longIdx >= 0 then longIdx else shortIdx
-    if idx >= 0 then argList.lift(idx + 1) else None
-  val inOwner: Option[String] = argList.indexOf("--in") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val ofTrait: Option[String] = argList.indexOf("--of") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val implLimit: Int = argList.indexOf("--impl-limit") match
-    case -1 => 5
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(5)
-  val goUp = !argList.contains("--down") || argList.contains("--up")
-  val goDown = !argList.contains("--up") || argList.contains("--down")
-  val maxDepth: Int = argList.indexOf("--depth") match
-    case -1 => -1
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(-1)
-  val inherited = argList.contains("--inherited")
-  val architecture = argList.contains("--architecture")
-  val hasMethodFilter: Option[String] = argList.indexOf("--has-method") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val extendsFilter: Option[String] = argList.indexOf("--extends") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val bodyContainsFilter: Option[String] = argList.indexOf("--body-contains") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val focusPackage: Option[String] = argList.indexOf("--focus-package") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val expandDepth: Int = argList.indexOf("--expand") match
-    case -1 => 0
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(1)
-  val membersLimit: Int = argList.indexOf("--members-limit") match
-    case -1 => 10
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(10)
-  val brief = argList.contains("--brief")
-  val strict = argList.contains("--strict")
-  val usedByFilter: Option[String] = argList.indexOf("--used-by") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val returnsFilter: Option[String] = argList.indexOf("--returns") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val takesFilter: Option[String] = argList.indexOf("--takes") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val shallow = argList.contains("--shallow")
-  val noDoc = argList.contains("--no-doc")
-  val excludePath: Option[String] = argList.indexOf("--exclude-path") match
-    case -1 => None
-    case i => argList.lift(i + 1).map(p => p.stripPrefix("/"))
-  val topN: Option[Int] = argList.indexOf("--top") match
-    case -1 => None
-    case i => argList.lift(i + 1).flatMap(_.toIntOption)
-  val summaryMode = argList.contains("--summary")
-  val timingsEnabled = argList.contains("--timings")
-  val withBody = argList.contains("--body") || argList.contains("--with-bodies")
-  val maxBodyLines: Int = argList.indexOf("--max-lines") match
-    case -1 => 0
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
-  val showImports = argList.contains("--imports")
-  val offset: Int = argList.indexOf("--offset") match
-    case -1 => 0
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
-  val related = argList.contains("--related")
-  val explainMode = argList.contains("--explain")
-  val concise = argList.contains("--concise")
-  val maxOutput: Int = argList.indexOf("--max-output") match
-    case -1 => 0
-    case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(0)
-  val inPackageFilter: Option[String] = argList.indexOf("--in-package") match
-    case -1 => None
-    case i => argList.lift(i + 1)
-  val eachMethod = argList.contains("--each-method")
 
-  val cleanArgs = argList.filterNot(a => a.startsWith("--") || a == "-w" || a == "-C" || a == "-e" || a == "-c" || {
-    val prev = argList.indexOf(a) - 1
-    prev >= 0 && flagsWithArgs.contains(argList(prev))
-  })
-
-  ParsedFlags(limit, kindFilter, verbose, categorize, includeTests, noTests, pathFilter,
-    contextLines, jsonOutput, countOnly, searchMode, definitionsOnly, categoryFilter, grepPatterns,
-    explicitWorkspace, inOwner, ofTrait, implLimit, goUp, goDown, maxDepth, inherited, architecture,
-    hasMethodFilter, extendsFilter, bodyContainsFilter, focusPackage, expandDepth, membersLimit,
-    brief, strict, usedByFilter, returnsFilter, takesFilter, shallow, noDoc, excludePath, topN,
-    summaryMode, timingsEnabled, withBody, maxBodyLines, showImports, offset, related, explainMode,
-    concise, maxOutput, inPackageFilter, eachMethod, cleanArgs)
+  f.copy(
+    searchMode = if sawExact then Some("exact") else if sawPrefix then Some("prefix") else None,
+    goUp = !sawDown || sawUp,
+    goDown = !sawUp || sawDown,
+    explicitWorkspace = wsLong.orElse(wsShort),
+    cleanArgs = positional.result(),
+  )
+}
 
 private def flagsToContext(f: ParsedFlags, idx: WorkspaceIndex, workspace: Path,
                            batchMode: Boolean = false, effectiveNoTests: Option[Boolean] = None): CommandContext =
@@ -195,12 +159,10 @@ private def flagsToContext(f: ParsedFlags, idx: WorkspaceIndex, workspace: Path,
     eachMethod = f.eachMethod)
 
 @main def main(args: String*): Unit =
-  val f = parseFlags(args.toList)
+  if args.contains("--version") then println(ScalexVersion)
+  else runCli(parseFlags(args.toList), args.toList)
 
-  if args.contains("--version") then
-    println(ScalexVersion)
-    return
-
+private def runCli(f: ParsedFlags, args: List[String]): Unit =
   Timings.enabled = f.timingsEnabled
 
   f.cleanArgs match

--- a/src/command-helpers.scala
+++ b/src/command-helpers.scala
@@ -123,7 +123,14 @@ def collectInheritedMembers(sym: SymbolInfo, ctx: CommandContext): (
   inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
   parentMemberKeys: Set[(name: String, kind: SymbolKind)]
 ) = {
-  if !ctx.inherited then return (inherited = Nil, parentMemberKeys = Set.empty)
+  if !ctx.inherited then (inherited = Nil, parentMemberKeys = Set.empty)
+  else collectInheritedMembersImpl(sym, ctx)
+}
+
+private def collectInheritedMembersImpl(sym: SymbolInfo, ctx: CommandContext): (
+  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
+  parentMemberKeys: Set[(name: String, kind: SymbolKind)]
+) = {
   val visited = mutable.HashSet.empty[String]
   visited += sym.name.toLowerCase
   val ownMembers = extractMembers(sym.file, sym.name, Some(sym.kind)).map(m => (name = m.name, kind = m.kind)).toSet

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -29,21 +29,22 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
         extractBody(f, symbol, effectiveOwner).map(b => (file = f, body = b))
       }
       // Fallback: if no results and symbol has a dot, split into Owner.member
-      if blocks.isEmpty && symbol.contains(".") && ctx.inOwner.isEmpty then
-        val lastDot = symbol.lastIndexOf('.')
-        if lastDot > 0 then
+      val (displayName, effectiveBlocks) =
+        if blocks.isEmpty && symbol.contains(".") && ctx.inOwner.isEmpty && symbol.lastIndexOf('.') > 0 then
+          val lastDot = symbol.lastIndexOf('.')
           val ownerName = symbol.substring(0, lastDot)
           val memberName = symbol.substring(lastDot + 1)
-          val ownerFiles = filterSymbols(ctx.idx.findDefinition(ownerName), ctx)
+          val dottedOwnerFiles = filterSymbols(ctx.idx.findDefinition(ownerName), ctx)
             .filter(s => typeKinds.contains(s.kind))
             .map(_.file).distinct
-          val dottedBlocks = ownerFiles.flatMap { f =>
+          val dottedBlocks = dottedOwnerFiles.flatMap { f =>
             extractBody(f, memberName, Some(ownerName)).map(b => (file = f, body = b))
           }
-          if dottedBlocks.nonEmpty then
-            return CmdResult.SourceBlocks(memberName, dottedBlocks, ctx.contextLines, ctx.showImports)
+          if dottedBlocks.nonEmpty then (displayName = memberName, effectiveBlocks = dottedBlocks)
+          else (displayName = symbol, effectiveBlocks = blocks)
+        else (displayName = symbol, effectiveBlocks = blocks)
 
-      if blocks.isEmpty then
+      if effectiveBlocks.isEmpty then
         val msg = ctx.inOwner match
           case Some(owner) => s"""No body found for "$symbol" in $owner"""
           case None => s"""No body found for "$symbol""""
@@ -56,4 +57,4 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
           case None => hint
         CmdResult.NotFound(msg, scopedHint)
       else
-        CmdResult.SourceBlocks(symbol, blocks, ctx.contextLines, ctx.showImports)
+        CmdResult.SourceBlocks(displayName, effectiveBlocks, ctx.contextLines, ctx.showImports)

--- a/src/commands/coverage.scala
+++ b/src/commands/coverage.scala
@@ -2,7 +2,7 @@ def cmdCoverage(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex coverage <symbol>")
     case Some(symbol) =>
-      val refs = ctx.idx.findReferences(symbol)
+      val refs = ctx.idx.findReferences(symbol).results
       val testRefs = refs.filter(r => isTestFile(r.file, ctx.workspace))
       val testFiles = testRefs.map(r => ctx.workspace.relativize(r.file).toString).distinct
       CmdResult.CoverageReport(symbol, refs.size, testRefs, testFiles)

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -29,25 +29,26 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
 /** Resolve Owner.member syntax: if Owner is a type, extract its members and filter to the member name */
 private def resolveDottedMember(symbol: String, ctx: CommandContext): Option[List[SymbolInfo]] = {
   val lastDot = symbol.lastIndexOf('.')
-  if lastDot <= 0 then return None
-  val ownerName = symbol.substring(0, lastDot)
-  val memberName = symbol.substring(lastDot + 1)
-  val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
-  if ownerDefs.isEmpty then return None
-  val memberResults = ownerDefs.flatMap { owner =>
-    val simpleName = if ownerName.contains(".") then ownerName.substring(ownerName.lastIndexOf('.') + 1) else ownerName
-    val members = extractMembers(owner.file, simpleName)
-    members.filter(_.name.equalsIgnoreCase(memberName)).map { m =>
-      SymbolInfo(
-        name = m.name,
-        kind = m.kind,
-        file = owner.file,
-        line = m.line,
-        packageName = owner.packageName,
-        signature = m.signature,
-        annotations = m.annotations
-      )
+  if lastDot <= 0 then None
+  else {
+    val ownerName = symbol.substring(0, lastDot)
+    val memberName = symbol.substring(lastDot + 1)
+    val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
+    val memberResults = ownerDefs.flatMap { owner =>
+      val simpleName = if ownerName.contains(".") then ownerName.substring(ownerName.lastIndexOf('.') + 1) else ownerName
+      val members = extractMembers(owner.file, simpleName)
+      members.filter(_.name.equalsIgnoreCase(memberName)).map { m =>
+        SymbolInfo(
+          name = m.name,
+          kind = m.kind,
+          file = owner.file,
+          line = m.line,
+          packageName = owner.packageName,
+          signature = m.signature,
+          annotations = m.annotations
+        )
+      }
     }
+    if memberResults.nonEmpty then Some(memberResults) else None
   }
-  if memberResults.nonEmpty then Some(memberResults) else None
 }

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -1,4 +1,6 @@
-def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
+import scala.util.boundary, boundary.break
+
+def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex explain <symbol>")
     case Some(symbol) =>
@@ -10,7 +12,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
           case Some(memberResults) =>
             val msym = memberResults.head
             val doc = if ctx.noDoc then None else extractDoc(msym.file, msym.line)
-            return CmdResult.Explanation(msym, doc, Nil, Nil, Nil)
+            break(CmdResult.Explanation(msym, doc, Nil, Nil, Nil))
           case None => ()
       if defs.isEmpty then
         // Fuzzy fallback: try search and auto-show best match if unambiguous
@@ -100,10 +102,11 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult =
             if ctx.expandDepth > 0 then expandImpls(impls, ctx, 1, Set(s"${sym.packageName}.${sym.name}".toLowerCase))
             else Nil
           // Import refs (apply path/exclude/noTests filters)
-          val importRefs = filterRefs(ctx.idx.findImports(simpleName, timeoutMs = 3000), ctx)
+          val importRefs = filterRefs(ctx.idx.findImports(simpleName, timeoutMs = 3000).results, ctx)
           CmdResult.Explanation(sym, doc, members, impls, importRefs, companion, expandedImpls,
             otherMatches = otherMatches, totalImpls = totalImpls, inherited = inherited,
             relatedTypes = relatedTypes)
+}
 
 private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,
                         depth: Int, visited: Set[String]): List[ExplainedImpl] =

--- a/src/commands/imports.scala
+++ b/src/commands/imports.scala
@@ -2,15 +2,16 @@ def cmdImports(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex imports <symbol>")
     case Some(symbol) =>
-      val results = filterRefs(ctx.idx.findImports(symbol, strict = ctx.strict), ctx)
+      val (rawResults, timedOut) = ctx.idx.findImports(symbol, strict = ctx.strict)
+      val results = filterRefs(rawResults, ctx)
       if results.isEmpty then
         CmdResult.NotFound(
           s"""No imports of "$symbol" found""",
-          mkNotFoundWithSuggestions(symbol, ctx, "imports"))
+          mkNotFoundWithSuggestions(symbol, ctx, "imports").copy(timedOut = timedOut))
       else
-        val suffix = if ctx.idx.timedOut then " (timed out — partial results)" else ""
+        val suffix = if timedOut then " (timed out — partial results)" else ""
         CmdResult.RefList(
           header = s"""Imports of "$symbol" — ${results.size} found:$suffix""",
           refs = results,
-          timedOut = ctx.idx.timedOut,
+          timedOut = timedOut,
           useContext = false)

--- a/src/commands/refs.scala
+++ b/src/commands/refs.scala
@@ -15,12 +15,14 @@ def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
           case None => (grouped, None)
       if ctx.topN.isDefined then
         val n = ctx.topN.get
-        val allRefs = filterRefs(ctx.idx.findReferences(symbol, strict = ctx.strict), ctx)
+        val (rawRefs, timedOut) = ctx.idx.findReferences(symbol, strict = ctx.strict)
+        val allRefs = filterRefs(rawRefs, ctx)
         val byFile = allRefs.groupBy(_.file).toList.map((f, rs) => (file = f, count = rs.size))
           .sortBy(-_.count).take(n)
-        CmdResult.RefsTop(symbol, byFile, allRefs.size, ctx.idx.timedOut)
+        CmdResult.RefsTop(symbol, byFile, allRefs.size, timedOut)
       else if ctx.countOnly then
-        val rawGrouped = ctx.idx.categorizeReferences(symbol, strict = ctx.strict).map((cat, refs) => (cat, filterRefs(refs, ctx)))
+        val (categorized, timedOut) = ctx.idx.categorizeReferences(symbol, strict = ctx.strict)
+        val rawGrouped = categorized.map((cat, refs) => (cat, filterRefs(refs, ctx)))
         val counts = rawGrouped.toList.map((cat, refs) => (category = cat, count = refs.size)).filter(_.count > 0)
           .sortBy { entry =>
             val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
@@ -28,11 +30,13 @@ def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
             order.indexOf(entry.category)
           }
         val total = counts.map(_.count).sum
-        CmdResult.RefsSummary(symbol, counts, total, ctx.idx.timedOut)
+        CmdResult.RefsSummary(symbol, counts, total, timedOut)
       else if ctx.categorize then
-        val rawGrouped = ctx.idx.categorizeReferences(symbol, strict = ctx.strict).map((cat, refs) => (cat, filterRefs(refs, ctx)))
+        val (categorized, timedOut) = ctx.idx.categorizeReferences(symbol, strict = ctx.strict)
+        val rawGrouped = categorized.map((cat, refs) => (cat, filterRefs(refs, ctx)))
         val (grouped, stderrHint) = filterByCategory(rawGrouped)
-        CmdResult.CategorizedRefs(symbol, grouped, targetPkgs, ctx.idx.timedOut, stderrHint)
+        CmdResult.CategorizedRefs(symbol, grouped, targetPkgs, timedOut, stderrHint)
       else
-        val results = filterRefs(ctx.idx.findReferences(symbol, strict = ctx.strict), ctx)
-        CmdResult.FlatRefs(symbol, results, targetPkgs, ctx.idx.timedOut)
+        val (rawRefs, timedOut) = ctx.idx.findReferences(symbol, strict = ctx.strict)
+        val results = filterRefs(rawRefs, ctx)
+        CmdResult.FlatRefs(symbol, results, targetPkgs, timedOut)

--- a/src/commands/tests.scala
+++ b/src/commands/tests.scala
@@ -15,17 +15,18 @@ def cmdTests(args: List[String], ctx: CommandContext): CmdResult =
     val suitesWithContent = extractedSuites.filter(s => s.tests.nonEmpty || s.dynamicSites > 0)
     val totalTests = suitesWithContent.map(_.tests.size).sum
     val totalDynamic = suitesWithContent.map(_.dynamicSites).sum
-    return CmdResult.TestCount(suitesWithContent.size, totalTests, totalDynamic)
-  val allSuites = extractedSuites.filter(_.tests.nonEmpty)
-  val showBody = nameFilter.isDefined
-  val suiteResults = allSuites.map { suite =>
-    val tests = suite.tests.map { tc =>
-      val body = if showBody || ctx.verbose then
-        extractBody(suite.file, tc.name, Some(suite.name)).headOption
-      else None
-      TestCaseResult(tc.name, tc.line, body)
+    CmdResult.TestCount(suitesWithContent.size, totalTests, totalDynamic)
+  else
+    val allSuites = extractedSuites.filter(_.tests.nonEmpty)
+    val showBody = nameFilter.isDefined
+    val suiteResults = allSuites.map { suite =>
+      val tests = suite.tests.map { tc =>
+        val body = if showBody || ctx.verbose then
+          extractBody(suite.file, tc.name, Some(suite.name)).headOption
+        else None
+        TestCaseResult(tc.name, tc.line, body)
+      }
+      TestSuiteResult(suite.name, suite.file, suite.line, tests)
     }
-    TestSuiteResult(suite.name, suite.file, suite.line, tests)
-  }
-  val emptyMsg = if nameFilter.isDefined then s"""No tests matching "${nameFilter.get}"""" else "No test suites found"
-  CmdResult.TestSuites(suiteResults, showBody, emptyMsg)
+    val emptyMsg = if nameFilter.isDefined then s"""No tests matching "${nameFilter.get}"""" else "No test suites found"
+    CmdResult.TestSuites(suiteResults, showBody, emptyMsg)

--- a/src/dispatch.scala
+++ b/src/dispatch.scala
@@ -62,7 +62,7 @@ private class BudgetPrintStream(baos: ByteArrayOutputStream, budget: Int) extend
 
   override def write(buf: Array[Byte], off: Int, len: Int): Unit =
     val remaining = hardCap - baos.size()
-    if remaining <= 0 then { exceeded = true; return }
-    if len <= remaining then super.write(buf, off, len)
-    else super.write(buf, off, remaining)
+    if remaining > 0 then
+      if len <= remaining then super.write(buf, off, len)
+      else super.write(buf, off, remaining)
     if baos.size() >= budget then exceeded = true

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -1,4 +1,5 @@
 import scala.meta.*
+import scala.meta.parsers.Parsed
 import scala.collection.mutable
 import java.nio.file.{Files, Path}
 import com.google.common.hash.{BloomFilter, Funnels}
@@ -6,6 +7,50 @@ import scala.jdk.CollectionConverters.*
 import com.github.javaparser.{JavaParser as JP, ParserConfiguration}
 import com.github.javaparser.ast.{CompilationUnit as JavaCU}
 import com.github.javaparser.ast.body.*
+
+// ── Source reading & parsing helpers ─────────────────────────────────────────
+
+/** Read a source file as UTF-8, or None if unreadable. */
+def readSource(path: Path): Option[String] =
+  try Some(Files.readString(path)) catch { case _: java.io.IOException => None }
+
+/** Read a source file as an array of lines, or None if unreadable. */
+def readSourceLines(path: Path): Option[Array[String]] =
+  try Some(Files.readAllLines(path).asScala.toArray) catch { case _: java.io.IOException => None }
+
+private def tryParse(input: Input.VirtualFile, dialect: Dialect): Option[Source] = {
+  try {
+    given Dialect = dialect
+    input.parse[Source] match {
+      case Parsed.Success(tree) => Some(tree)
+      case _: Parsed.Error => None
+    }
+  } catch { case _: Exception => None }
+}
+
+/** Parse Scala source, trying the Scala 3 dialect first, falling back to Scala 2.13. */
+def parseSource(source: String, virtualPath: String): Option[Source] = {
+  val input = Input.VirtualFile(virtualPath, source)
+  tryParse(input, dialects.Scala3).orElse(tryParse(input, dialects.Scala213))
+}
+
+def parseFile(path: Path): Option[Source] =
+  readSource(path).flatMap(source => parseSource(source, path.toString))
+
+/** Names bound by `Pat.Var` patterns (ignores tuple/extractor patterns). */
+private def patVarNames(pats: List[Pat]): List[String] =
+  pats.collect { case Pat.Var(name) => name.value }
+
+/** Matches any type-introducing definition that carries a template body. */
+private object TypeDefn {
+  def unapply(t: Tree): Option[(name: String, templ: Template)] = t match {
+    case d: Defn.Class  => Some((name = d.name.value, templ = d.templ))
+    case d: Defn.Trait  => Some((name = d.name.value, templ = d.templ))
+    case d: Defn.Object => Some((name = d.name.value, templ = d.templ))
+    case d: Defn.Enum   => Some((name = d.name.value, templ = d.templ))
+    case _ => None
+  }
+}
 
 // ── File type routing ────────────────────────────────────────────────────────
 
@@ -97,12 +142,9 @@ def extractImports(tree: Tree): (imports: List[String], aliases: Map[String, Str
 
 // ── Import line extraction ───────────────────────────────────────────────────
 
-def extractImportLines(file: Path): Option[String] =
-  val lines = try Files.readAllLines(file).asScala.toArray catch
-    case _: java.io.IOException => return None
-  parseFile(file) match
-    case None => None
-    case Some(tree) =>
+def extractImportLines(file: Path): Option[String] = {
+  (readSourceLines(file), parseFile(file)) match {
+    case (Some(lines), Some(tree)) =>
       val importRanges = mutable.ListBuffer.empty[(startLine: Int, endLine: Int)]
       // Only collect top-level imports — use .stats (not .children which wraps in PkgBody)
       def collectImports(stats: List[Stat]): Unit =
@@ -114,11 +156,15 @@ def extractImportLines(file: Path): Option[String] =
         }
       collectImports(tree.stats)
       if importRanges.isEmpty then None
-      else
+      else {
         val importText = importRanges.flatMap { (sl, el) =>
           (sl to el).filter(_ < lines.length).map(lines(_))
         }.mkString("\n")
         Some(importText)
+      }
+    case _ => None
+  }
+}
 
 // ── Shared raw symbol extraction ─────────────────────────────────────────────
 
@@ -177,11 +223,9 @@ def extractRawSymbols(tree: Tree): (symbols: List[RawSymbol], packageName: Strin
       buf += RawSymbol(d.name.value, SymbolKind.Def, d.pos.startLine + 1, Nil, Nil, sig, annots)
     case d: Defn.Val =>
       val annots = extractAnnotations(d.mods)
-      d.pats.foreach {
-        case Pat.Var(name) =>
-          val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-          buf += RawSymbol(name.value, SymbolKind.Val, d.pos.startLine + 1, Nil, Nil, s"val ${name.value}$tpe", annots)
-        case _ =>
+      patVarNames(d.pats).foreach { name =>
+        val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
+        buf += RawSymbol(name, SymbolKind.Val, d.pos.startLine + 1, Nil, Nil, s"val $name$tpe", annots)
       }
     case d: Defn.ExtensionGroup =>
       val recv = d.paramClauses.headOption.flatMap(_.values.headOption).map(p =>
@@ -205,231 +249,147 @@ def extractSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomF
   if isJavaFile(file) then extractJavaSymbols(file)
   else extractScalaSymbols(file)
 
-private def extractScalaSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomFilter[CharSequence]], imports: List[String], aliases: Map[String, String], parseFailed: Boolean) =
-  val source = try Files.readString(file) catch
-    case _: java.io.IOException =>
-      return (Nil, None, Nil, Map.empty, true)
-
-  val bloom = buildBloomFilterFromSource(source)
-
-  val input = Input.VirtualFile(file.toString, source)
-  val tree = try
-    given scala.meta.Dialect = scala.meta.dialects.Scala3
-    input.parse[Source].get
-  catch
-    case _: Exception =>
-      try
-        given scala.meta.Dialect = scala.meta.dialects.Scala213
-        input.parse[Source].get
-      catch
-        case _: Exception =>
-          return (Nil, Some(bloom), Nil, Map.empty, true)
-
-  val (imports, aliases) = extractImports(tree)
-  val (rawSymbols, pkg) = extractRawSymbols(tree)
-  val symbols = rawSymbols.map(r => SymbolInfo(r.name, r.kind, file, r.line, pkg, r.parents, r.typeParamParents, r.signature, r.annotations))
-  (symbols, Some(bloom), imports, aliases, false)
-
-// ── Source parsing helper ────────────────────────────────────────────────────
-
-def parseFile(path: Path): Option[Source] =
-  val source = try Files.readString(path) catch
-    case _: java.io.IOException => return None
-  val input = Input.VirtualFile(path.toString, source)
-  try
-    given scala.meta.Dialect = scala.meta.dialects.Scala3
-    Some(input.parse[Source].get)
-  catch
-    case _: Exception =>
-      try
-        given scala.meta.Dialect = scala.meta.dialects.Scala213
-        Some(input.parse[Source].get)
-      catch
-        case _: Exception =>
-          None
+private def extractScalaSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomFilter[CharSequence]], imports: List[String], aliases: Map[String, String], parseFailed: Boolean) = {
+  readSource(file) match {
+    case None => (Nil, None, Nil, Map.empty, true)
+    case Some(source) =>
+      val bloom = buildBloomFilterFromSource(source)
+      parseSource(source, file.toString) match {
+        case None => (Nil, Some(bloom), Nil, Map.empty, true)
+        case Some(tree) =>
+          val (imports, aliases) = extractImports(tree)
+          val (rawSymbols, pkg) = extractRawSymbols(tree)
+          val symbols = rawSymbols.map(r => SymbolInfo(r.name, r.kind, file, r.line, pkg, r.parents, r.typeParamParents, r.signature, r.annotations))
+          (symbols, Some(bloom), imports, aliases, false)
+      }
+  }
+}
 
 // ── Member extraction ───────────────────────────────────────────────────────
 
+/** Where a member came from. Lets callers include or exclude constructor
+  * params and abstract declarations without re-implementing the traversal. */
+enum MemberOrigin {
+  case Definition, AbstractDecl, CtorParam
+}
+
+case class ExtractedMember(member: MemberInfo, startLine: Int, endLine: Int, origin: MemberOrigin)
+
 def extractMembers(file: Path, symbolName: String, filterKind: Option[SymbolKind] = None): List[MemberInfo] =
   if isJavaFile(file) then extractJavaMembers(file, symbolName)
-  else extractScalaMembers(file, symbolName, filterKind)
+  else extractScalaMemberTree(file, symbolName, filterKind).map(_.member)
 
-private def extractScalaMembers(file: Path, symbolName: String, filterKind: Option[SymbolKind] = None): List[MemberInfo] =
-  parseFile(file) match
+/** Members with their body line spans, for span-scoped grep. Excludes constructor
+  * params and abstract val/type declarations (no body to grep). Java not supported. */
+def extractMembersWithSpans(file: Path, symbolName: String, filterKind: Option[SymbolKind] = None): List[(member: MemberInfo, startLine: Int, endLine: Int)] =
+  if isJavaFile(file) then Nil
+  else extractScalaMemberTree(file, symbolName, filterKind).collect {
+    case em if em.origin == MemberOrigin.Definition || em.member.kind == SymbolKind.Def =>
+      (member = em.member, startLine = em.startLine, endLine = em.endLine)
+  }
+
+/** Single traversal behind extractMembers and extractMembersWithSpans: finds the
+  * type named `symbolName` and extracts its constructor params and template members. */
+private def extractScalaMemberTree(file: Path, symbolName: String, filterKind: Option[SymbolKind]): List[ExtractedMember] =
+  parseFile(file) match {
     case None => Nil
     case Some(tree) =>
-      val buf = mutable.ListBuffer.empty[MemberInfo]
+      val buf = mutable.ListBuffer.empty[ExtractedMember]
+
+      def add(t: Tree, m: MemberInfo, origin: MemberOrigin = MemberOrigin.Definition): Unit =
+        buf += ExtractedMember(m, t.pos.startLine + 1, t.pos.endLine + 1, origin)
+
+      def declaredType(decltpe: Option[scala.meta.Type]): String =
+        decltpe.map(t => s": ${t.toString()}").getOrElse("")
 
       def extractFromTemplate(templ: Template): Unit =
         templ.body.stats.foreach {
           case d: Defn.Def =>
-            val params = formatParamClauses(d.paramClauses)
-            val ret = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots)
+            val sig = s"def ${d.name.value}${formatParamClauses(d.paramClauses)}${declaredType(d.decltpe)}"
+            add(d, MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, sig, extractAnnotations(d.mods)))
           case d: Defn.Val =>
             val annots = extractAnnotations(d.mods)
-            d.pats.foreach {
-              case Pat.Var(name) =>
-                val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-                buf += MemberInfo(name.value, SymbolKind.Val, d.pos.startLine + 1, s"val ${name.value}$tpe", annots)
-              case _ =>
+            patVarNames(d.pats).foreach { name =>
+              add(d, MemberInfo(name, SymbolKind.Val, d.pos.startLine + 1, s"val $name${declaredType(d.decltpe)}", annots))
             }
           case d: Defn.Var =>
             val annots = extractAnnotations(d.mods)
-            d.pats.foreach {
-              case Pat.Var(name) =>
-                val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-                buf += MemberInfo(name.value, SymbolKind.Var, d.pos.startLine + 1, s"var ${name.value}$tpe", annots)
-              case _ =>
+            patVarNames(d.pats).foreach { name =>
+              add(d, MemberInfo(name, SymbolKind.Var, d.pos.startLine + 1, s"var $name${declaredType(d.decltpe)}", annots))
             }
           case d: Defn.Type =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value} = ${d.body.toString().take(60)}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value} = ${d.body.toString().take(60)}", extractAnnotations(d.mods)))
           case d: Decl.Def =>
-            val params = formatParamClauses(d.paramClauses)
-            val ret = s": ${d.decltpe.toString()}"
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots)
+            val sig = s"def ${d.name.value}${formatParamClauses(d.paramClauses)}: ${d.decltpe.toString()}"
+            add(d, MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, sig, extractAnnotations(d.mods)), MemberOrigin.AbstractDecl)
           case d: Decl.Val =>
             val annots = extractAnnotations(d.mods)
-            d.pats.foreach {
-              case p: Pat.Var =>
-                val tpe = s": ${d.decltpe.toString()}"
-                buf += MemberInfo(p.name.value, SymbolKind.Val, d.pos.startLine + 1, s"val ${p.name.value}$tpe", annots)
-              case _ =>
+            patVarNames(d.pats).foreach { name =>
+              add(d, MemberInfo(name, SymbolKind.Val, d.pos.startLine + 1, s"val $name: ${d.decltpe.toString()}", annots), MemberOrigin.AbstractDecl)
             }
           case d: Decl.Type =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value}", extractAnnotations(d.mods)), MemberOrigin.AbstractDecl)
           case d: Defn.Class =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Class, d.pos.startLine + 1, s"class ${d.name.value}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Class, d.pos.startLine + 1, s"class ${d.name.value}", extractAnnotations(d.mods)))
           case d: Defn.Trait =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Trait, d.pos.startLine + 1, s"trait ${d.name.value}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Trait, d.pos.startLine + 1, s"trait ${d.name.value}", extractAnnotations(d.mods)))
           case d: Defn.Object =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Object, d.pos.startLine + 1, s"object ${d.name.value}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Object, d.pos.startLine + 1, s"object ${d.name.value}", extractAnnotations(d.mods)))
           case d: Defn.Enum =>
-            val annots = extractAnnotations(d.mods)
-            buf += MemberInfo(d.name.value, SymbolKind.Enum, d.pos.startLine + 1, s"enum ${d.name.value}", annots)
+            add(d, MemberInfo(d.name.value, SymbolKind.Enum, d.pos.startLine + 1, s"enum ${d.name.value}", extractAnnotations(d.mods)))
           case _ =>
         }
 
-      def kindMatches(k: SymbolKind): Boolean = filterKind.forall(_ == k)
-
-      def findAndExtract(t: Tree): Unit = t match
-        case d: Defn.Class if d.name.value == symbolName && kindMatches(SymbolKind.Class) =>
-          // Constructor params: case class params are public vals; regular class params only if marked val/var
-          val isCaseClass = d.mods.exists(_.isInstanceOf[Mod.Case])
-          d.ctor.paramClauses.foreach { clause =>
-            clause.values.foreach { p =>
-              val isVal = isCaseClass || p.mods.exists(m => m.isInstanceOf[Mod.ValParam] || m.isInstanceOf[Mod.VarParam])
-              if isVal then
-                val tpe = p.decltpe.map(t => s": ${t.toString}").getOrElse("")
-                val kind = if p.mods.exists(_.isInstanceOf[Mod.VarParam]) then SymbolKind.Var else SymbolKind.Val
-                buf += MemberInfo(p.name.value, kind, p.pos.startLine + 1, s"val ${p.name.value}$tpe")
+      // Case class params are public vals; regular class params only if marked val/var
+      def addCtorParams(d: Defn.Class): Unit = {
+        val isCaseClass = d.mods.exists(_.isInstanceOf[Mod.Case])
+        d.ctor.paramClauses.foreach { clause =>
+          clause.values.foreach { p =>
+            val isVal = isCaseClass || p.mods.exists(m => m.isInstanceOf[Mod.ValParam] || m.isInstanceOf[Mod.VarParam])
+            if isVal then {
+              val tpe = p.decltpe.map(t => s": ${t.toString}").getOrElse("")
+              val kind = if p.mods.exists(_.isInstanceOf[Mod.VarParam]) then SymbolKind.Var else SymbolKind.Val
+              add(p, MemberInfo(p.name.value, kind, p.pos.startLine + 1, s"val ${p.name.value}$tpe"), MemberOrigin.CtorParam)
             }
           }
+        }
+      }
+
+      def kindMatches(k: SymbolKind): Boolean = filterKind.forall(_ == k)
+
+      def findAndExtract(t: Tree): Unit = t match {
+        case d: Defn.Class if d.name.value == symbolName && kindMatches(SymbolKind.Class) =>
+          addCtorParams(d)
           extractFromTemplate(d.templ)
         case d: Defn.Trait if d.name.value == symbolName && kindMatches(SymbolKind.Trait) => extractFromTemplate(d.templ)
         case d: Defn.Object if d.name.value == symbolName && kindMatches(SymbolKind.Object) => extractFromTemplate(d.templ)
         case d: Defn.Enum if d.name.value == symbolName && kindMatches(SymbolKind.Enum) => extractFromTemplate(d.templ)
         case _ => t.children.foreach(findAndExtract)
+      }
 
       findAndExtract(tree)
       buf.toList
-
-/** Extract members with their body line spans in a single parse.
-  * Returns (member info, 1-indexed startLine, 1-indexed endLine) for each member. */
-def extractMembersWithSpans(file: Path, symbolName: String, filterKind: Option[SymbolKind] = None): List[(member: MemberInfo, startLine: Int, endLine: Int)] =
-  if isJavaFile(file) then return Nil // Java not supported for this path
-  parseFile(file) match
-    case None => Nil
-    case Some(tree) =>
-      val buf = mutable.ListBuffer.empty[(member: MemberInfo, startLine: Int, endLine: Int)]
-
-      def extractFromTemplate(templ: Template): Unit =
-        templ.body.stats.foreach {
-          case d: Defn.Def =>
-            val params = formatParamClauses(d.paramClauses)
-            val ret = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Defn.Val =>
-            val annots = extractAnnotations(d.mods)
-            d.pats.foreach {
-              case Pat.Var(name) =>
-                val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-                buf += ((member = MemberInfo(name.value, SymbolKind.Val, d.pos.startLine + 1, s"val ${name.value}$tpe", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-              case _ =>
-            }
-          case d: Defn.Var =>
-            val annots = extractAnnotations(d.mods)
-            d.pats.foreach {
-              case Pat.Var(name) =>
-                val tpe = d.decltpe.map(t => s": ${t.toString()}").getOrElse("")
-                buf += ((member = MemberInfo(name.value, SymbolKind.Var, d.pos.startLine + 1, s"var ${name.value}$tpe", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-              case _ =>
-            }
-          case d: Defn.Type =>
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Type, d.pos.startLine + 1, s"type ${d.name.value} = ${d.body.toString().take(60)}", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Decl.Def =>
-            val params = formatParamClauses(d.paramClauses)
-            val ret = s": ${d.decltpe.toString()}"
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Def, d.pos.startLine + 1, s"def ${d.name.value}$params$ret", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Defn.Class =>
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Class, d.pos.startLine + 1, s"class ${d.name.value}", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Defn.Trait =>
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Trait, d.pos.startLine + 1, s"trait ${d.name.value}", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Defn.Object =>
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Object, d.pos.startLine + 1, s"object ${d.name.value}", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case d: Defn.Enum =>
-            val annots = extractAnnotations(d.mods)
-            buf += ((member = MemberInfo(d.name.value, SymbolKind.Enum, d.pos.startLine + 1, s"enum ${d.name.value}", annots), startLine = d.pos.startLine + 1, endLine = d.pos.endLine + 1))
-          case _ =>
-        }
-
-      def kindMatches(k: SymbolKind): Boolean = filterKind.forall(_ == k)
-
-      def findAndExtract(t: Tree): Unit = t match
-        case d: Defn.Class if d.name.value == symbolName && kindMatches(SymbolKind.Class) => extractFromTemplate(d.templ)
-        case d: Defn.Trait if d.name.value == symbolName && kindMatches(SymbolKind.Trait) => extractFromTemplate(d.templ)
-        case d: Defn.Object if d.name.value == symbolName && kindMatches(SymbolKind.Object) => extractFromTemplate(d.templ)
-        case d: Defn.Enum if d.name.value == symbolName && kindMatches(SymbolKind.Enum) => extractFromTemplate(d.templ)
-        case _ => t.children.foreach(findAndExtract)
-
-      findAndExtract(tree)
-      buf.toList
+  }
 
 // ── Doc extraction (Scaladoc / Javadoc) ─────────────────────────────────────
 
-def extractDoc(file: Path, targetLine: Int): Option[String] =
-  if isJavaFile(file) then return None
-  val lines = try Files.readAllLines(file).asScala.toArray catch
-    case _: java.io.IOException => return None
-  // targetLine is 1-indexed, array is 0-indexed
-  var i = targetLine - 2 // line before the symbol
-  // skip blank lines between doc and symbol
-  while i >= 0 && lines(i).trim.isEmpty do i -= 1
-  if i < 0 then return None
-  // Check if this line ends a scaladoc
-  val endLine = i
-  if lines(endLine).trim == "*/" || lines(endLine).trim.endsWith("*/") then
-    // Multi-line or single-line: find the opening /**
-    while i >= 0 && !lines(i).trim.startsWith("/**") do i -= 1
-    if i >= 0 then Some((i to endLine).map(lines(_)).mkString("\n"))
-    else None
-  else if lines(endLine).trim.startsWith("/**") && lines(endLine).trim.endsWith("*/") then
-    // Single-line /** brief */
-    Some(lines(endLine))
-  else None
+def extractDoc(file: Path, targetLine: Int): Option[String] = {
+  val lines = if isJavaFile(file) then None else readSourceLines(file)
+  lines.flatMap { lines =>
+    // targetLine is 1-indexed, array is 0-indexed
+    var i = targetLine - 2 // line before the symbol
+    // skip blank lines between doc and symbol
+    while i >= 0 && lines(i).trim.isEmpty do i -= 1
+    if i < 0 || !lines(i).trim.endsWith("*/") then None
+    else {
+      // The line ends a scaladoc — walk up to the opening /** (which may be the same line)
+      val endLine = i
+      while i >= 0 && !lines(i).trim.startsWith("/**") do i -= 1
+      if i >= 0 then Some((i to endLine).map(lines(_)).mkString("\n"))
+      else None
+    }
+  }
+}
 
 // ── Test extraction ─────────────────────────────────────────────────────
 
@@ -467,8 +427,8 @@ private def classifyTestCall(t: Tree): TestCallMatch =
     case _ => TestCallMatch.NotATest
 
 def extractTests(file: Path): List[TestSuiteInfo] = {
-  if isJavaFile(file) then return Nil
-  parseFile(file) match
+  if isJavaFile(file) then Nil
+  else parseFile(file) match
     case None => Nil
     case Some(tree) =>
       val suites = mutable.ListBuffer.empty[TestSuiteInfo]
@@ -517,130 +477,47 @@ def extractBody(file: Path, symbolName: String, ownerName: Option[String]): List
   else extractScalaBody(file, symbolName, ownerName)
 
 private def extractScalaBody(file: Path, symbolName: String, ownerName: Option[String]): List[BodyInfo] = {
-  val lines = try Files.readAllLines(file).asScala.toArray catch
-    case _: java.io.IOException => return Nil
-  parseFile(file) match
-    case None => Nil
-    case Some(tree) =>
+  (readSourceLines(file), parseFile(file)) match {
+    case (Some(lines), Some(tree)) =>
       val buf = mutable.ListBuffer.empty[BodyInfo]
 
+      // Slice the node's source span if it defines `symbolName` under an accepted owner
+      def addBody(t: Tree, owner: String, name: String, isAbstract: Boolean = false): Unit = {
+        if name == symbolName && (ownerName.isEmpty || ownerName.contains(owner)) then {
+          val sl = t.pos.startLine
+          val el = t.pos.endLine
+          val body = (sl to el).map(lines(_)).mkString("\n")
+          buf += BodyInfo(owner, name, body, sl + 1, el + 1, isAbstract)
+        }
+      }
+
       def extractFromTree(t: Tree, currentOwner: String): Unit = {
-        t match
+        t match {
           case d: Defn.Def =>
-            if d.name.value == symbolName then
-              if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                val sl = d.pos.startLine
-                val el = d.pos.endLine
-                val body = (sl to el).map(lines(_)).mkString("\n")
-                buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-            // Recurse into def body to find nested local defs
+            addBody(d, currentOwner, d.name.value)
+            // Recurse into the def body to find nested local defs
             d.body.children.foreach(c => extractFromTree(c, currentOwner))
-          case d: Decl.Def =>
-            if d.name.value == symbolName then
-              if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                val sl = d.pos.startLine
-                val el = d.pos.endLine
-                val body = (sl to el).map(lines(_)).mkString("\n")
-                buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1, isAbstract = true)
-          case d: Decl.Val =>
-            d.pats.foreach {
-              case Pat.Var(name) if name.value == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = d.pos.startLine
-                  val el = d.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name.value, body, sl + 1, el + 1, isAbstract = true)
-              case _ =>
-            }
-          case d: Decl.Var =>
-            d.pats.foreach {
-              case Pat.Var(name) if name.value == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = d.pos.startLine
-                  val el = d.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name.value, body, sl + 1, el + 1, isAbstract = true)
-              case _ =>
-            }
-          case d: Decl.Type if d.name.value == symbolName =>
-            if ownerName.isEmpty || ownerName.contains(currentOwner) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1, isAbstract = true)
-          case d: Defn.Val =>
-            d.pats.foreach {
-              case Pat.Var(name) if name.value == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = d.pos.startLine
-                  val el = d.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name.value, body, sl + 1, el + 1)
-              case _ =>
-            }
-          case d: Defn.Var =>
-            d.pats.foreach {
-              case Pat.Var(name) if name.value == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = d.pos.startLine
-                  val el = d.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name.value, body, sl + 1, el + 1)
-              case _ =>
-            }
-          case d: Defn.Type if d.name.value == symbolName =>
-            if ownerName.isEmpty || ownerName.contains(currentOwner) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-          case d: Defn.Class =>
-            if d.name.value == symbolName && (ownerName.isEmpty || ownerName.contains(currentOwner)) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-            d.templ.body.stats.foreach(s => extractFromTree(s, d.name.value))
-          case d: Defn.Trait =>
-            if d.name.value == symbolName && (ownerName.isEmpty || ownerName.contains(currentOwner)) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-            d.templ.body.stats.foreach(s => extractFromTree(s, d.name.value))
-          case d: Defn.Object =>
-            if d.name.value == symbolName && (ownerName.isEmpty || ownerName.contains(currentOwner)) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-            d.templ.body.stats.foreach(s => extractFromTree(s, d.name.value))
-          case d: Defn.Enum =>
-            if d.name.value == symbolName && (ownerName.isEmpty || ownerName.contains(currentOwner)) then
-              val sl = d.pos.startLine
-              val el = d.pos.endLine
-              val body = (sl to el).map(lines(_)).mkString("\n")
-              buf += BodyInfo(currentOwner, d.name.value, body, sl + 1, el + 1)
-            d.templ.body.stats.foreach(s => extractFromTree(s, d.name.value))
+          case d: Decl.Def => addBody(d, currentOwner, d.name.value, isAbstract = true)
+          case d: Decl.Val => patVarNames(d.pats).foreach(n => addBody(d, currentOwner, n, isAbstract = true))
+          case d: Decl.Var => patVarNames(d.pats).foreach(n => addBody(d, currentOwner, n, isAbstract = true))
+          case d: Decl.Type => addBody(d, currentOwner, d.name.value, isAbstract = true)
+          case d: Defn.Val => patVarNames(d.pats).foreach(n => addBody(d, currentOwner, n))
+          case d: Defn.Var => patVarNames(d.pats).foreach(n => addBody(d, currentOwner, n))
+          case d: Defn.Type => addBody(d, currentOwner, d.name.value)
+          case TypeDefn(name, templ) =>
+            addBody(t, currentOwner, name)
+            templ.body.stats.foreach(s => extractFromTree(s, name))
           case app: Term.Apply =>
-            classifyTestCall(app) match
-              case TestCallMatch.Literal(name, _) if name == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = app.pos.startLine
-                  val el = app.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name, body, sl + 1, el + 1)
+            classifyTestCall(app) match {
+              case TestCallMatch.Literal(name, _) => addBody(app, currentOwner, name)
               case _ =>
+            }
             app.children.foreach(c => extractFromTree(c, currentOwner))
           case infix: Term.ApplyInfix =>
-            classifyTestCall(infix) match
-              case TestCallMatch.Literal(name, _) if name == symbolName =>
-                if ownerName.isEmpty || ownerName.contains(currentOwner) then
-                  val sl = infix.pos.startLine
-                  val el = infix.pos.endLine
-                  val body = (sl to el).map(lines(_)).mkString("\n")
-                  buf += BodyInfo(currentOwner, name, body, sl + 1, el + 1)
+            classifyTestCall(infix) match {
+              case TestCallMatch.Literal(name, _) => addBody(infix, currentOwner, name)
               case _ =>
+            }
             infix.children.foreach(c => extractFromTree(c, currentOwner))
           case p: Pkg =>
             p.body.stats.foreach(s => extractFromTree(s, currentOwner))
@@ -648,17 +525,20 @@ private def extractScalaBody(file: Path, symbolName: String, ownerName: Option[S
             // Recurse into all other nodes (Term.Block, Term.If, etc.)
             // to find nested local defs, vals, and vars
             other.children.foreach(c => extractFromTree(c, currentOwner))
+        }
       }
 
       tree.children.foreach(c => extractFromTree(c, ""))
       buf.toList
+    case _ => Nil
+  }
 }
 
 // ── Scope extraction (context) ──────────────────────────────────────────────
 
 def extractScopes(file: Path, targetLine: Int): List[ScopeInfo] = {
-  if isJavaFile(file) then return Nil
-  parseFile(file) match
+  if isJavaFile(file) then Nil
+  else parseFile(file) match
     case None => Nil
     case Some(tree) =>
       val buf = mutable.ListBuffer.empty[ScopeInfo]
@@ -710,9 +590,7 @@ private def parseJavaSource(source: String, path: Path): Option[JavaCU] =
     case _: Exception | _: Error => None
 
 private def parseJavaFile(path: Path): Option[JavaCU] =
-  val source = try Files.readString(path) catch
-    case _: java.io.IOException => return None
-  parseJavaSource(source, path)
+  readSource(path).flatMap(source => parseJavaSource(source, path))
 
 private def javaTypeToString(tpe: com.github.javaparser.ast.`type`.Type): String =
   tpe.asString()
@@ -767,70 +645,75 @@ private def javaKindAndSig(td: TypeDeclaration[?]): (kind: SymbolKind, sig: Stri
 
 // ── Java symbol extraction (JavaParser-based) ──────────────────────────────
 
-private def extractJavaSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomFilter[CharSequence]], imports: List[String], aliases: Map[String, String], parseFailed: Boolean) =
-  val source = try Files.readString(file) catch
-    case _: java.io.IOException =>
-      return (Nil, None, Nil, Map.empty, true)
-
-  val bloom = buildBloomFilterFromSource(source)
-
-  parseJavaSource(source, file) match
-    case None =>
-      return (Nil, Some(bloom), Nil, Map.empty, true)
-    case Some(cu) =>
-      val buf = mutable.ListBuffer.empty[SymbolInfo]
-      val importBuf = mutable.ListBuffer.empty[String]
-
-      val pkg = if cu.getPackageDeclaration.isPresent then cu.getPackageDeclaration.get().getNameAsString else ""
-
-      cu.getImports.forEach { imp =>
-        importBuf += s"import ${imp.getNameAsString}${if imp.isAsterisk then ".*" else ""}"
+private def extractJavaSymbols(file: Path): (symbols: List[SymbolInfo], bloom: Option[BloomFilter[CharSequence]], imports: List[String], aliases: Map[String, String], parseFailed: Boolean) = {
+  readSource(file) match {
+    case None => (Nil, None, Nil, Map.empty, true)
+    case Some(source) =>
+      val bloom = buildBloomFilterFromSource(source)
+      parseJavaSource(source, file) match {
+        case None => (Nil, Some(bloom), Nil, Map.empty, true)
+        case Some(cu) =>
+          val (symbols, imports) = javaSymbolsFromCu(cu, file)
+          (symbols, Some(bloom), imports, Map.empty, false)
       }
+  }
+}
 
-      def visitType(td: TypeDeclaration[?]): Unit =
-        val name = td.getNameAsString
-        val parents = javaParentsFromType(td)
-        val annots = javaAnnotations(td)
-        val (kind, sig) = javaKindAndSig(td)
-        val line = td.getBegin.map(_.line).orElse(0)
-        buf += SymbolInfo(name, kind, file, line, pkg, parents, Nil, sig, annots)
+private def javaSymbolsFromCu(cu: JavaCU, file: Path): (symbols: List[SymbolInfo], imports: List[String]) = {
+  val buf = mutable.ListBuffer.empty[SymbolInfo]
+  val importBuf = mutable.ListBuffer.empty[String]
 
-        // Extract methods
-        td.getMethods.forEach { m =>
-          val mName = m.getNameAsString
-          val params = mutable.ListBuffer.empty[String]
-          m.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
-          val ret = javaTypeToString(m.getType)
-          val mSig = s"def $mName(${params.mkString(", ")}): $ret"
-          val mAnnots = javaAnnotations(m)
-          val mLine = m.getBegin.map(_.line).orElse(0)
-          buf += SymbolInfo(mName, SymbolKind.Def, file, mLine, pkg, Nil, Nil, mSig, mAnnots)
-        }
+  val pkg = if cu.getPackageDeclaration.isPresent then cu.getPackageDeclaration.get().getNameAsString else ""
 
-        // Extract fields
-        td.getFields.forEach { f =>
-          f.getVariables.forEach { v =>
-            val vName = v.getNameAsString
-            val vType = javaTypeToString(f.getCommonType)
-            val isFinal = f.isFinal
-            val fKind = if isFinal then SymbolKind.Val else SymbolKind.Var
-            val prefix = if isFinal then "val" else "var"
-            val fSig = s"$prefix $vName: $vType"
-            val fAnnots = javaAnnotations(f)
-            val fLine = f.getBegin.map(_.line).orElse(0)
-            buf += SymbolInfo(vName, fKind, file, fLine, pkg, Nil, Nil, fSig, fAnnots)
-          }
-        }
+  cu.getImports.forEach { imp =>
+    importBuf += s"import ${imp.getNameAsString}${if imp.isAsterisk then ".*" else ""}"
+  }
 
-        // Recurse into nested types
-        td.getMembers.forEach {
-          case nested: TypeDeclaration[?] => visitType(nested)
-          case _ =>
-        }
+  def visitType(td: TypeDeclaration[?]): Unit = {
+    val name = td.getNameAsString
+    val parents = javaParentsFromType(td)
+    val annots = javaAnnotations(td)
+    val (kind, sig) = javaKindAndSig(td)
+    val line = td.getBegin.map(_.line).orElse(0)
+    buf += SymbolInfo(name, kind, file, line, pkg, parents, Nil, sig, annots)
 
-      cu.getTypes.forEach(td => visitType(td))
+    // Extract methods
+    td.getMethods.forEach { m =>
+      val mName = m.getNameAsString
+      val params = mutable.ListBuffer.empty[String]
+      m.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
+      val ret = javaTypeToString(m.getType)
+      val mSig = s"def $mName(${params.mkString(", ")}): $ret"
+      val mAnnots = javaAnnotations(m)
+      val mLine = m.getBegin.map(_.line).orElse(0)
+      buf += SymbolInfo(mName, SymbolKind.Def, file, mLine, pkg, Nil, Nil, mSig, mAnnots)
+    }
 
-      (buf.toList, Some(bloom), importBuf.toList, Map.empty, false)
+    // Extract fields
+    td.getFields.forEach { f =>
+      f.getVariables.forEach { v =>
+        val vName = v.getNameAsString
+        val vType = javaTypeToString(f.getCommonType)
+        val isFinal = f.isFinal
+        val fKind = if isFinal then SymbolKind.Val else SymbolKind.Var
+        val prefix = if isFinal then "val" else "var"
+        val fSig = s"$prefix $vName: $vType"
+        val fAnnots = javaAnnotations(f)
+        val fLine = f.getBegin.map(_.line).orElse(0)
+        buf += SymbolInfo(vName, fKind, file, fLine, pkg, Nil, Nil, fSig, fAnnots)
+      }
+    }
+
+    // Recurse into nested types
+    td.getMembers.forEach {
+      case nested: TypeDeclaration[?] => visitType(nested)
+      case _ =>
+    }
+  }
+
+  cu.getTypes.forEach(td => visitType(td))
+  (symbols = buf.toList, imports = importBuf.toList)
+}
 
 // ── Java member extraction ──────────────────────────────────────────────────
 
@@ -910,11 +793,9 @@ private def extractJavaMembers(file: Path, symbolName: String): List[MemberInfo]
 // ── Java body extraction ────────────────────────────────────────────────────
 
 private def extractJavaBody(file: Path, symbolName: String, ownerName: Option[String]): List[BodyInfo] =
-  val sourceLines = try Files.readAllLines(file).asScala.toArray catch
-    case _: java.io.IOException => return Nil
-  parseJavaFile(file) match
-    case None => Nil
-    case Some(cu) =>
+  (readSourceLines(file), parseJavaFile(file)) match
+    case (None, _) | (_, None) => Nil
+    case (Some(sourceLines), Some(cu)) =>
       val buf = mutable.ListBuffer.empty[BodyInfo]
 
       def extractFromType(td: TypeDeclaration[?], currentOwner: String): Unit =

--- a/src/format.scala
+++ b/src/format.scala
@@ -63,20 +63,23 @@ def formatRefWithContext(r: Reference, workspace: Path, contextN: Int): String =
   val rel = workspace.relativize(r.file)
   val alias = r.aliasInfo.map(a => s" [$a]").getOrElse("")
   val header = s"  $rel:${r.line}$alias"
-  val lines = try java.nio.file.Files.readAllLines(r.file).asScala catch
-    case _: Exception => return s"$header\n    > ${r.contextLine}"
-  val total = lines.size
-  val startLine = math.max(1, r.line - contextN)
-  val endLine = math.min(total, r.line + contextN)
-  val buf = new StringBuilder(header)
-  var i = startLine
-  while i <= endLine do
-    val lineContent = lines(i - 1)
-    val marker = if i == r.line then ">" else " "
-    val lineNum = i.toString.reverse.padTo(4, ' ').reverse
-    buf.append(s"\n    $marker $lineNum | $lineContent")
-    i += 1
-  buf.toString
+  val readLines = try Some(java.nio.file.Files.readAllLines(r.file).asScala) catch
+    case _: Exception => None
+  readLines match
+    case None => s"$header\n    > ${r.contextLine}"
+    case Some(lines) =>
+      val total = lines.size
+      val startLine = math.max(1, r.line - contextN)
+      val endLine = math.min(total, r.line + contextN)
+      val buf = new StringBuilder(header)
+      var i = startLine
+      while i <= endLine do
+        val lineContent = lines(i - 1)
+        val marker = if i == r.line then ">" else " "
+        val lineNum = i.toString.reverse.padTo(4, ' ').reverse
+        buf.append(s"\n    $marker $lineNum | $lineContent")
+        i += 1
+      buf.toString
 
 // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -1303,7 +1306,7 @@ private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
         println(r.message)
         renderHint(r.hint)
       case "explain" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
-      case "imports" => println(s"""{"results":[],"timedOut":${ctx.idx.timedOut},"suggestions":$suggestionsJson}""")
+      case "imports" => println(s"""{"results":[],"timedOut":${r.hint.timedOut},"suggestions":$suggestionsJson}""")
       case "deps" => println(s"""{"imports":[],"bodyReferences":[],"suggestions":$suggestionsJson}""")
       case "package" | "api" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
       case _ => println(s"""{"results":[],"suggestions":$suggestionsJson}""")

--- a/src/index.scala
+++ b/src/index.scala
@@ -1,4 +1,5 @@
 import scala.collection.mutable
+import scala.util.Using
 import java.nio.file.{Files, Path}
 import java.io.{BufferedReader, BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream, InputStreamReader}
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -7,24 +8,43 @@ import com.google.common.hash.{BloomFilter, Funnels}
 
 // ── Git ─────────────────────────────────────────────────────────────────────
 
-def gitLsFiles(workspace: Path): List[GitFile] =
-  val pb = ProcessBuilder("git", "ls-files", "--stage")
-  pb.directory(workspace.toFile)
-  pb.redirectErrorStream(true)
-  val proc = pb.start()
-  val reader = BufferedReader(InputStreamReader(proc.getInputStream))
-  val files = reader.lines().iterator().asScala.flatMap { line =>
-    val tabIdx = line.indexOf('\t')
-    if tabIdx < 0 then None
-    else
-      val parts = line.substring(0, tabIdx).split("\\s+")
-      val path = line.substring(tabIdx + 1)
-      if parts.length >= 2 && (path.endsWith(".scala") || path.endsWith(".java")) then
-        Some(GitFile(workspace.resolve(path), parts(1)))
-      else None
-  }.toList
-  proc.waitFor()
-  files
+/** Run a git command in `workspace` and collect its stdout lines.
+  * Returns None if the process cannot be started (e.g. git not installed). */
+def runGitLines(workspace: Path, args: String*): Option[(lines: List[String], exitCode: Int)] = {
+  try {
+    val pb = ProcessBuilder(("git" +: args)*)
+    pb.directory(workspace.toFile)
+    pb.redirectErrorStream(true)
+    val proc = pb.start()
+    val lines = Using.resource(BufferedReader(InputStreamReader(proc.getInputStream))) { reader =>
+      reader.lines().iterator().asScala.toList
+    }
+    val exitCode = proc.waitFor()
+    Some((lines = lines, exitCode = exitCode))
+  } catch {
+    case e: java.io.IOException =>
+      System.err.println(s"scalex: failed to run git ${args.headOption.getOrElse("")} (${e.getMessage})")
+      None
+  }
+}
+
+def gitLsFiles(workspace: Path): List[GitFile] = {
+  runGitLines(workspace, "ls-files", "--stage") match {
+    case None => Nil
+    case Some(result) =>
+      result.lines.flatMap { line =>
+        val tabIdx = line.indexOf('\t')
+        if tabIdx < 0 then None
+        else {
+          val parts = line.substring(0, tabIdx).split("\\s+")
+          val path = line.substring(tabIdx + 1)
+          if parts.length >= 2 && (path.endsWith(".scala") || path.endsWith(".java")) then
+            Some(GitFile(workspace.resolve(path), parts(1)))
+          else None
+        }
+      }
+  }
+}
 
 // ── Binary persistence ──────────────────────────────────────────────────────
 
@@ -115,16 +135,20 @@ object IndexPersistence:
 
   def load(workspace: Path, loadBlooms: Boolean = true): Option[Map[String, IndexedFile]] =
     val p = indexPath(workspace)
-    if !Files.exists(p) then return None
+    if !Files.exists(p) then None
+    else try
+      Using.resource(DataInputStream(BufferedInputStream(Files.newInputStream(p), 1 << 16))) { in =>
+        if in.readInt() != MAGIC then None
+        else if in.readByte() != VERSION then None
+        else Some(loadBody(workspace, in, loadBlooms))
+      }
+    catch
+      case e: Exception =>
+        System.err.println(s"scalex: index load failed (${e.getClass.getSimpleName}: ${e.getMessage}) — rebuilding")
+        None
 
-    try
-      val in = DataInputStream(BufferedInputStream(Files.newInputStream(p), 1 << 16))
-      try
-        val magic = in.readInt()
-        if magic != MAGIC then return None
-        val version = in.readByte()
-        if version != VERSION then return None
-
+  /** Read the index body after the magic/version header has been validated. */
+  private def loadBody(workspace: Path, in: DataInputStream, loadBlooms: Boolean): Map[String, IndexedFile] =
         val strCount = in.readInt()
         val strings = Array.fill(strCount)(in.readUTF())
 
@@ -186,12 +210,7 @@ object IndexPersistence:
           result(relPath) = IndexedFile(relPath, oid, syms.result(), bloom, imports, aliases, parseFailed)
           fi += 1
 
-        Some(result.toMap)
-      finally in.close()
-    catch
-      case _: Exception =>
-        System.err.println("scalex: index load failed, rebuilding")
-        None
+        result.toMap
 
 // ── Workspace index ─────────────────────────────────────────────────────────
 
@@ -437,34 +456,39 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   def grepFiles(pattern: String, noTests: Boolean, pathFilter: Option[String],
                 excludePath: Option[String] = None,
                 timeoutMs: Long = defaultTimeoutMs): (results: List[Reference], timedOut: Boolean) =
-    val regex = try java.util.regex.Pattern.compile(pattern)
+    compileRegex(pattern) match
+      case None => (Nil, false)
+      case Some(regex) =>
+        var candidates = gitFiles
+        if noTests then candidates = candidates.filter(gf => !isTestFile(gf.path, workspace))
+        pathFilter.foreach { p => candidates = candidates.filter(gf => matchesPath(gf.path, p, workspace)) }
+        excludePath.foreach { p => candidates = candidates.filter(gf => !matchesPath(gf.path, p, workspace)) }
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        var grepTimedOut = false
+        val results = ConcurrentLinkedQueue[Reference]()
+        val grepUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
+        candidates.asJava.parallelStream().forEach { gf =>
+          if System.nanoTime() < deadline then {
+            try {
+              val lines = Files.readAllLines(gf.path).asScala
+              lines.zipWithIndex.foreach { case (line, idx) =>
+                if System.nanoTime() < deadline then {
+                  if regex.matcher(line).find() then
+                    results.add(Reference(gf.path, idx + 1, line.trim))
+                } else grepTimedOut = true
+              }
+            } catch { case _: java.io.IOException => grepUnreadable.incrementAndGet(); () }
+          } else grepTimedOut = true
+        }
+        if grepUnreadable.get() > 0 then System.err.println(s"scalex: ${grepUnreadable.get()} file(s) unreadable during grep")
+        (results.asScala.toList.sortBy(r => (workspace.relativize(r.file).toString, r.line)), grepTimedOut)
+
+  private def compileRegex(pattern: String): Option[java.util.regex.Pattern] =
+    try Some(java.util.regex.Pattern.compile(pattern))
     catch
       case e: java.util.regex.PatternSyntaxException =>
         Console.err.println(s"Invalid regex: ${e.getMessage}")
-        return (Nil, false)
-    var candidates = gitFiles
-    if noTests then candidates = candidates.filter(gf => !isTestFile(gf.path, workspace))
-    pathFilter.foreach { p => candidates = candidates.filter(gf => matchesPath(gf.path, p, workspace)) }
-    excludePath.foreach { p => candidates = candidates.filter(gf => !matchesPath(gf.path, p, workspace)) }
-    val deadline = System.nanoTime() + timeoutMs * 1_000_000
-    var grepTimedOut = false
-    val results = ConcurrentLinkedQueue[Reference]()
-    val grepUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
-    candidates.asJava.parallelStream().forEach { gf =>
-      if System.nanoTime() < deadline then {
-        try {
-          val lines = Files.readAllLines(gf.path).asScala
-          lines.zipWithIndex.foreach { case (line, idx) =>
-            if System.nanoTime() < deadline then {
-              if regex.matcher(line).find() then
-                results.add(Reference(gf.path, idx + 1, line.trim))
-            } else grepTimedOut = true
-          }
-        } catch { case _: java.io.IOException => grepUnreadable.incrementAndGet(); () }
-      } else grepTimedOut = true
-    }
-    if grepUnreadable.get() > 0 then System.err.println(s"scalex: ${grepUnreadable.get()} file(s) unreadable during grep")
-    (results.asScala.toList.sortBy(r => (workspace.relativize(r.file).toString, r.line)), grepTimedOut)
+        None
 
   def search(query: String): List[SymbolInfo] =
     val lower = query.toLowerCase
@@ -524,9 +548,8 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     exact.toList ++ prefix.toList ++ contains.toList ++ fuzzy.sortBy(_.length).toList
 
   private val defaultTimeoutMs = 20_000L
-  var timedOut: Boolean = false
 
-  def findReferences(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): List[Reference] =
+  def findReferences(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): (results: List[Reference], timedOut: Boolean) =
     val wordMatch: (String, String) => Boolean = if strict then containsWordStrict else containsWord
     val (candidates, allCandidates, fileAliasMap) = Timings.phase("bloom-screen") {
       val candidates = indexedFiles.filter(f => f.identifierBloom.forall(_.mightContain(name)))
@@ -541,7 +564,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     }
 
     val deadline = System.nanoTime() + timeoutMs * 1_000_000
-    timedOut = false
+    var timedOut = false
     val results = ConcurrentLinkedQueue[Reference]()
     val seen = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
     val refsUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
@@ -567,11 +590,11 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       }
     }
     if refsUnreadable.get() > 0 then System.err.println(s"scalex: ${refsUnreadable.get()} file(s) unreadable during refs")
-    results.asScala.toList
+    (results.asScala.toList, timedOut)
 
-  def categorizeReferences(name: String, strict: Boolean = false): Map[RefCategory, List[Reference]] =
-    val refs = findReferences(name, strict = strict)
-    refs.groupBy { r =>
+  def categorizeReferences(name: String, strict: Boolean = false): (grouped: Map[RefCategory, List[Reference]], timedOut: Boolean) =
+    val (refs, timedOut) = findReferences(name, strict = strict)
+    val grouped = refs.groupBy { r =>
       val line = r.contextLine
       if line.matches("""^\s*(trait|class|object|enum|given|type|def|val|var)\s+.*""") && containsWord(line, name) &&
          (line.contains(s"trait $name") || line.contains(s"class $name") || line.contains(s"object $name") ||
@@ -589,12 +612,13 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       else
         RefCategory.Usage
     }
+    (grouped, timedOut)
 
-  def findImports(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): List[Reference] =
+  def findImports(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): (results: List[Reference], timedOut: Boolean) =
     val wordMatch: (String, String) => Boolean = if strict then containsWordStrict else containsWord
     val candidates = indexedFiles.filter(f => f.identifierBloom.forall(_.mightContain(name)))
     val deadline = System.nanoTime() + timeoutMs * 1_000_000
-    timedOut = false
+    var timedOut = false
     val results = ConcurrentLinkedQueue[Reference]()
     val resultPaths = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
     val importsUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
@@ -634,7 +658,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
               } catch { case _: java.io.IOException => importsUnreadable.incrementAndGet(); () }
 
     if importsUnreadable.get() > 0 then System.err.println(s"scalex: ${importsUnreadable.get()} file(s) unreadable during imports")
-    results.asScala.toList
+    (results.asScala.toList, timedOut)
 
   private def filePackage(idxFile: IndexedFile): String =
     idxFile.symbols.headOption.map(_.packageName).getOrElse("")
@@ -674,28 +698,40 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     i == 0 || name(i).isUpper || (i > 0 && name(i - 1) == '_')
 
   private def camelCaseMatch(query: String, name: String): Boolean =
-    if query.length < 2 then return false
-    val qLower = query.toLowerCase
-    val nLower = name.toLowerCase
-    var qi = 0
-    var ni = 0
-    while qi < qLower.length && ni < nLower.length do
-      if qLower(qi) == nLower(ni) then
-        qi += 1
-        ni += 1
-      else
-        ni += 1
-        while ni < nLower.length && !isSegmentStart(name, ni) do ni += 1
-    qi == qLower.length
+    query.length >= 2 && {
+      val qLower = query.toLowerCase
+      val nLower = name.toLowerCase
+      var qi = 0
+      var ni = 0
+      while qi < qLower.length && ni < nLower.length do
+        if qLower(qi) == nLower(ni) then
+          qi += 1
+          ni += 1
+        else
+          ni += 1
+          while ni < nLower.length && !isSegmentStart(name, ni) do ni += 1
+      qi == qLower.length
+    }
+
+  /** True if `word` occurs in `line` with no word character (per `isWordChar`)
+    * directly before or after the occurrence. */
+  private def containsWordWith(line: String, word: String, isWordChar: Char => Boolean): Boolean = {
+    var i = line.indexOf(word)
+    var found = false
+    while !found && i >= 0 do {
+      val before = i == 0 || !isWordChar(line(i - 1))
+      val after = i + word.length >= line.length || !isWordChar(line(i + word.length))
+      if before && after then found = true
+      else i = line.indexOf(word, i + 1)
+    }
+    found
+  }
 
   private def containsWord(line: String, word: String): Boolean =
-    var i = line.indexOf(word)
-    while i >= 0 do
-      val before = i == 0 || !line(i - 1).isLetterOrDigit
-      val after = i + word.length >= line.length || !line(i + word.length).isLetterOrDigit
-      if before && after then return true
-      i = line.indexOf(word, i + 1)
-    false
+    containsWordWith(line, word, _.isLetterOrDigit)
+
+  private def containsWordStrict(line: String, word: String): Boolean =
+    containsWordWith(line, word, isIdentChar)
 
   private def isIdentChar(c: Char): Boolean =
     c.isLetterOrDigit || c == '_' || c == '$'
@@ -783,15 +819,6 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
         if name == "_" || name == "*" then Some((pkg, Nil, true))
         else Some((pkg, List(name), false))
     }
-
-  private def containsWordStrict(line: String, word: String): Boolean =
-    var i = line.indexOf(word)
-    while i >= 0 do
-      val before = i == 0 || !isIdentChar(line(i - 1))
-      val after = i + word.length >= line.length || !isIdentChar(line(i + word.length))
-      if before && after then return true
-      i = line.indexOf(word, i + 1)
-    false
 
 // ── Filtering helpers ────────────────────────────────────────────────────────
 

--- a/src/index.scala
+++ b/src/index.scala
@@ -8,19 +8,20 @@ import com.google.common.hash.{BloomFilter, Funnels}
 
 // ── Git ─────────────────────────────────────────────────────────────────────
 
-/** Run a git command in `workspace` and collect its stdout lines.
+/** Run a git command in `workspace`, streaming its stdout lines through `consume`
+  * (single pass, no intermediate list — `git ls-files` output can be large).
   * Returns None if the process cannot be started (e.g. git not installed). */
-def runGitLines(workspace: Path, args: String*): Option[(lines: List[String], exitCode: Int)] = {
+def runGitLines[A](workspace: Path, args: String*)(consume: Iterator[String] => A): Option[A] = {
   try {
     val pb = ProcessBuilder(("git" +: args)*)
     pb.directory(workspace.toFile)
     pb.redirectErrorStream(true)
     val proc = pb.start()
-    val lines = Using.resource(BufferedReader(InputStreamReader(proc.getInputStream))) { reader =>
-      reader.lines().iterator().asScala.toList
+    val result = Using.resource(BufferedReader(InputStreamReader(proc.getInputStream))) { reader =>
+      consume(reader.lines().iterator().asScala)
     }
-    val exitCode = proc.waitFor()
-    Some((lines = lines, exitCode = exitCode))
+    proc.waitFor()
+    Some(result)
   } catch {
     case e: java.io.IOException =>
       System.err.println(s"scalex: failed to run git ${args.headOption.getOrElse("")} (${e.getMessage})")
@@ -28,11 +29,16 @@ def runGitLines(workspace: Path, args: String*): Option[(lines: List[String], ex
   }
 }
 
+/** Runs on every invocation over potentially huge output — kept as a direct
+  * implementation rather than going through runGitLines (measurably faster). */
 def gitLsFiles(workspace: Path): List[GitFile] = {
-  runGitLines(workspace, "ls-files", "--stage") match {
-    case None => Nil
-    case Some(result) =>
-      result.lines.flatMap { line =>
+  try {
+    val pb = ProcessBuilder("git", "ls-files", "--stage")
+    pb.directory(workspace.toFile)
+    pb.redirectErrorStream(true)
+    val proc = pb.start()
+    val files = Using.resource(BufferedReader(InputStreamReader(proc.getInputStream))) { reader =>
+      reader.lines().iterator().asScala.flatMap { line =>
         val tabIdx = line.indexOf('\t')
         if tabIdx < 0 then None
         else {
@@ -42,7 +48,14 @@ def gitLsFiles(workspace: Path): List[GitFile] = {
             Some(GitFile(workspace.resolve(path), parts(1)))
           else None
         }
-      }
+      }.toList
+    }
+    proc.waitFor()
+    files
+  } catch {
+    case e: java.io.IOException =>
+      System.err.println(s"scalex: failed to run git ls-files (${e.getMessage})")
+      Nil
   }
 }
 

--- a/src/model.scala
+++ b/src/model.scala
@@ -19,20 +19,22 @@ object Timings:
       result
 
   def report(): Unit =
-    if !enabled then return
-    import scala.jdk.CollectionConverters.*
-    val items = entries.asScala.toList
-    entries.clear()
-    if items.isEmpty then return
-    val total = items.map(_._2).sum
-    System.err.println("Timings:")
-    items.foreach { (name, nanos) =>
-      val ms = nanos / 1_000_000.0
-      val pct = if total > 0 then (nanos * 100.0 / total).round else 0
-      System.err.println(f"  $name%-22s $ms%8.1f ms  ($pct%2d%%)")
+    if enabled then {
+      import scala.jdk.CollectionConverters.*
+      val items = entries.asScala.toList
+      entries.clear()
+      if items.nonEmpty then {
+        val total = items.map(_._2).sum
+        System.err.println("Timings:")
+        items.foreach { (name, nanos) =>
+          val ms = nanos / 1_000_000.0
+          val pct = if total > 0 then (nanos * 100.0 / total).round else 0
+          System.err.println(f"  $name%-22s $ms%8.1f ms  ($pct%2d%%)")
+        }
+        val totalMs = total / 1_000_000.0
+        System.err.println(f"  ${"total"}%-22s $totalMs%8.1f ms")
+      }
     }
-    val totalMs = total / 1_000_000.0
-    System.err.println(f"  ${"total"}%-22s $totalMs%8.1f ms")
 
   def reset(): Unit = entries.clear()
 
@@ -172,7 +174,7 @@ case class CommandContext(
 
 // ── CmdResult types ────────────────────────────────────────────────────────
 
-case class NotFoundHint(symbol: String, fileCount: Int, parseFailures: Int, cmd: String, batchMode: Boolean, looksLikePath: Boolean, suggestions: List[String] = Nil)
+case class NotFoundHint(symbol: String, fileCount: Int, parseFailures: Int, cmd: String, batchMode: Boolean, looksLikePath: Boolean, suggestions: List[String] = Nil, timedOut: Boolean = false)
 
 case class MemberSectionData(
   file: Path, ownerKind: SymbolKind, packageName: String, line: Int,

--- a/tests/analysis.test.scala
+++ b/tests/analysis.test.scala
@@ -317,7 +317,7 @@ class AnalysisSuite extends ScalexTestBase:
   test("coverage excludes non-test file refs") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val allFiles = refs.map(r => workspace.relativize(r.file).toString).distinct
     val testFiles = refs.filter(r => isTestFile(r.file, workspace)).map(r => workspace.relativize(r.file).toString).distinct
     // There should be refs in non-test files too

--- a/tests/cli.test.scala
+++ b/tests/cli.test.scala
@@ -60,7 +60,7 @@ class CliSuite extends ScalexTestBase:
   test("formatRefWithContext shows context lines") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val ref = refs.find(r => workspace.relativize(r.file).toString.contains("UserService.scala")).get
     val output = formatRefWithContext(ref, workspace, 1)
     // Should have the header line and context lines
@@ -268,7 +268,7 @@ class CliSuite extends ScalexTestBase:
   test("--no-tests excludes test file results from refs") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val all = idx.findReferences("UserService")
+    val all = idx.findReferences("UserService").results
     val allFiles = all.map(r => workspace.relativize(r.file).toString).distinct
     assert(allFiles.exists(_.contains("UserServiceSpec")), "Should have test file in unfiltered")
     val filtered = all.filter(r => !isTestFile(r.file, workspace))
@@ -1853,6 +1853,47 @@ class CliSuite extends ScalexTestBase:
     assert(!flags.noTests)
     assert(!flags.verbose)
     assertEquals(flags.cleanArgs, List("UserService"))
+  }
+
+  test("parseFlags keeps a positional arg that equals a flag value") {
+    // Regression: the old indexOf-based cleanArgs dropped every occurrence of
+    // a token that appeared anywhere as a flag value
+    val flags = parseFlags(List("def", "--kind", "class", "class"))
+    assertEquals(flags.kindFilter, Some("class"))
+    assertEquals(flags.cleanArgs, List("def", "class"))
+  }
+
+  test("parseFlags --limit 0 means unlimited") {
+    assertEquals(parseFlags(List("--limit", "0")).limit, Int.MaxValue)
+  }
+
+  test("parseFlags collects repeated -e patterns in order") {
+    val flags = parseFlags(List("grep", "-e", "foo", "-e", "bar"))
+    assertEquals(flags.grepPatterns, List("foo", "bar"))
+    assertEquals(flags.cleanArgs, List("grep"))
+  }
+
+  test("parseFlags --workspace takes precedence over -w regardless of order") {
+    assertEquals(parseFlags(List("-w", "short", "--workspace", "long")).explicitWorkspace, Some("long"))
+    assertEquals(parseFlags(List("--workspace", "long", "-w", "short")).explicitWorkspace, Some("long"))
+  }
+
+  test("parseFlags --up and --down together keep both directions") {
+    val both = parseFlags(List("Foo", "--up", "--down"))
+    assert(both.goUp)
+    assert(both.goDown)
+    val onlyUp = parseFlags(List("Foo", "--up"))
+    assert(onlyUp.goUp)
+    assert(!onlyUp.goDown)
+  }
+
+  test("parseFlags --exact wins over --prefix") {
+    assertEquals(parseFlags(List("Foo", "--prefix", "--exact")).searchMode, Some("exact"))
+    assertEquals(parseFlags(List("Foo", "--prefix")).searchMode, Some("prefix"))
+  }
+
+  test("parseFlags ignores unknown long flags without treating them as positionals") {
+    assertEquals(parseFlags(List("Foo", "--does-not-exist")).cleanArgs, List("Foo"))
   }
 
   test("batch per-line flags override: --path applied to per-line context") {

--- a/tests/extraction.test.scala
+++ b/tests/extraction.test.scala
@@ -818,3 +818,35 @@ class ExtractionSuite extends ScalexTestBase:
     val imports = result.get
     assert(imports.contains("import com.example.UserService"), s"Should contain import: $imports")
   }
+
+  // ── Member extraction origins (shared core for members + spans) ───────
+
+  test("extractMembers includes case class ctor params as vals") {
+    val file = workspace.resolve("src/main/scala/com/example/Model.scala")
+    val members = extractMembers(file, "User", Some(SymbolKind.Class))
+    assert(members.exists(m => m.name == "id" && m.kind == SymbolKind.Val), s"ctor param id should be a val member: ${members.map(_.name)}")
+    assert(members.exists(m => m.name == "name" && m.kind == SymbolKind.Val))
+  }
+
+  test("extractMembersWithSpans excludes ctor params but keeps abstract defs") {
+    val modelFile = workspace.resolve("src/main/scala/com/example/Model.scala")
+    val userSpans = extractMembersWithSpans(modelFile, "User", Some(SymbolKind.Class))
+    assert(!userSpans.exists(_.member.name == "id"), s"ctor params should not get grep spans: ${userSpans.map(_.member.name)}")
+
+    val docFile = workspace.resolve("src/main/scala/com/example/Documented.scala")
+    val traitSpans = extractMembersWithSpans(docFile, "PaymentService", Some(SymbolKind.Trait))
+    assert(traitSpans.exists(_.member.name == "processPayment"), s"abstract defs keep their span: ${traitSpans.map(_.member.name)}")
+  }
+
+  test("extractMembersWithSpans agrees with extractMembers on concrete members") {
+    val file = workspace.resolve("src/main/scala/com/example/Documented.scala")
+    val memberNames = extractMembers(file, "PaymentServiceLive", Some(SymbolKind.Class)).map(_.name).toSet
+    val spans = extractMembersWithSpans(file, "PaymentServiceLive", Some(SymbolKind.Class))
+    spans.foreach { s =>
+      assert(memberNames.contains(s.member.name), s"span member ${s.member.name} missing from extractMembers")
+      assert(s.startLine <= s.member.line && s.member.line <= s.endLine, s"member line should fall within span for ${s.member.name}")
+    }
+    assert(spans.exists(_.member.name == "maxRetries"), "concrete val keeps its span")
+    assert(spans.exists(_.member.name == "lastError"), "concrete var keeps its span")
+    assert(spans.exists(_.member.name == "TransactionId"), "concrete type alias keeps its span")
+  }

--- a/tests/index.test.scala
+++ b/tests/index.test.scala
@@ -114,7 +114,7 @@ class IndexSuite extends ScalexTestBase:
   test("findReferences finds usages across files") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
 
     assert(refs.size >= 3, s"Expected >= 3 refs, got ${refs.size}")
     // Should find in: UserService.scala (definition + usage), UserServiceSpec.scala
@@ -126,7 +126,7 @@ class IndexSuite extends ScalexTestBase:
   test("findReferences respects word boundaries") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("User")
+    val refs = idx.findReferences("User").results
 
     // "User" should match standalone "User" but NOT "UserService" or "UserServiceLive"
     refs.foreach { r =>
@@ -143,7 +143,7 @@ class IndexSuite extends ScalexTestBase:
     idx.index()
 
     // Search for something only in Helper.scala
-    val refs = idx.findReferences("formatUser")
+    val refs = idx.findReferences("formatUser").results
     assert(refs.size >= 1)
     assert(refs.forall(_.file.toString.contains("Helper.scala")))
   }
@@ -273,7 +273,7 @@ class IndexSuite extends ScalexTestBase:
   test("containsWord matches whole words only") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("live")
+    val refs = idx.findReferences("live").results
     refs.foreach { r =>
       assert(
         r.contextLine.matches(".*(?<![a-zA-Z0-9])live(?![a-zA-Z0-9]).*"),
@@ -310,7 +310,7 @@ class IndexSuite extends ScalexTestBase:
   test("findImports returns only import lines") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val results = idx.findImports("UserService")
+    val results = idx.findImports("UserService").results
     // All results should be import lines
     results.foreach { r =>
       assert(r.contextLine.startsWith("import "),
@@ -323,7 +323,7 @@ class IndexSuite extends ScalexTestBase:
   test("findImports finds wildcard imports that match target package") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val results = idx.findImports("UserService")
+    val results = idx.findImports("UserService").results
     // Should find explicit import in ExplicitClient AND wildcard import in WildcardClient
     val files = results.map(r => workspace.relativize(r.file).toString)
     assert(files.exists(_.contains("ExplicitClient.scala")),
@@ -335,7 +335,7 @@ class IndexSuite extends ScalexTestBase:
   test("findImports wildcard result contains the wildcard import line") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val results = idx.findImports("UserService")
+    val results = idx.findImports("UserService").results
     val wcResult = results.find(r => workspace.relativize(r.file).toString.contains("WildcardClient.scala"))
     assert(wcResult.isDefined, "Should find wildcard import result")
     assert(wcResult.get.contextLine.contains("import com.example._"),
@@ -348,7 +348,7 @@ class IndexSuite extends ScalexTestBase:
     val idx = WorkspaceIndex(workspace)
     idx.index()
     // UserServiceSpec is in com.example, same as UserService definition
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val specRef = refs.find(r => workspace.relativize(r.file).toString.contains("UserServiceSpec.scala"))
     assert(specRef.isDefined, "Should find ref in UserServiceSpec")
     val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
@@ -359,7 +359,7 @@ class IndexSuite extends ScalexTestBase:
   test("resolveConfidence returns High for explicit import") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val clientRef = refs.find(r => workspace.relativize(r.file).toString.contains("ExplicitClient.scala"))
     assert(clientRef.isDefined, "Should find ref in ExplicitClient")
     val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
@@ -370,7 +370,7 @@ class IndexSuite extends ScalexTestBase:
   test("resolveConfidence returns Medium for wildcard import") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val wcRef = refs.find(r => workspace.relativize(r.file).toString.contains("WildcardClient.scala"))
     assert(wcRef.isDefined, "Should find ref in WildcardClient")
     val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
@@ -381,7 +381,7 @@ class IndexSuite extends ScalexTestBase:
   test("resolveConfidence returns Low for no matching import") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val noImpRef = refs.find(r => workspace.relativize(r.file).toString.contains("NoImportClient.scala"))
     assert(noImpRef.isDefined, "Should find ref in NoImportClient")
     val targetPkgs = idx.symbolsByName.getOrElse("userservice", Nil).map(_.packageName).toSet
@@ -401,7 +401,7 @@ class IndexSuite extends ScalexTestBase:
   test("findReferences follows aliases") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val aliasRefs = refs.filter(r =>
       workspace.relativize(r.file).toString.contains("AliasClient.scala"))
     // Should find import line (contains "UserService") AND usage lines (contain "US")
@@ -412,7 +412,7 @@ class IndexSuite extends ScalexTestBase:
   test("findReferences follows aliases for Database") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("Database")
+    val refs = idx.findReferences("Database").results
     val aliasRefs = refs.filter(r =>
       workspace.relativize(r.file).toString.contains("AliasClient.scala"))
     assert(aliasRefs.exists(_.contextLine.contains("DB")),
@@ -422,7 +422,7 @@ class IndexSuite extends ScalexTestBase:
   test("resolveConfidence returns High for alias imports") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val aliasRef = refs.find { r =>
       val rel = workspace.relativize(r.file).toString
       rel.contains("AliasClient.scala") && r.contextLine.contains("US")
@@ -450,7 +450,7 @@ class IndexSuite extends ScalexTestBase:
   test("findReferences annotates aliasInfo for alias matches") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val refs = idx.findReferences("UserService")
+    val refs = idx.findReferences("UserService").results
     val aliasRef = refs.find { r =>
       workspace.relativize(r.file).toString.contains("AliasClient.scala") &&
       r.contextLine.contains("US") && !r.contextLine.contains("UserService")
@@ -634,7 +634,7 @@ class IndexSuite extends ScalexTestBase:
   test("categorizeReferences groups by category") {
     val idx = WorkspaceIndex(workspace)
     idx.index()
-    val grouped = idx.categorizeReferences("UserService")
+    val grouped = idx.categorizeReferences("UserService").grouped
 
     // Should have at least definition and some usages
     assert(grouped.nonEmpty, "Should have at least one category")
@@ -802,7 +802,63 @@ class IndexSuite extends ScalexTestBase:
     idx.index()
     // Add a file with underscore-prefixed symbols to test strict matching
     // This is an integration-level check that the strict flag passes through
-    val results = idx.findReferences("User", strict = true)
+    val results = idx.findReferences("User", strict = true).results
     // strict = true means _User would NOT match at _ boundary
     assert(results.nonEmpty, "Should still find normal references to User")
+  }
+
+  // ── Cache corruption resilience ───────────────────────────────────────
+
+  test("load returns None on a corrupted index file and reindexing recovers") {
+    val idx1 = WorkspaceIndex(workspace)
+    idx1.index() // ensure a cache file exists
+    val binPath = IndexPersistence.indexPath(workspace)
+    Files.write(binPath, Array.fill[Byte](64)(0x42))
+    assertEquals(IndexPersistence.load(workspace), None)
+    // Rebuild path: a fresh index must still work and restore a valid cache
+    val idx2 = WorkspaceIndex(workspace)
+    idx2.index()
+    assert(idx2.symbols.nonEmpty, "Reindex after corruption should produce symbols")
+    assert(IndexPersistence.load(workspace).isDefined, "Reindex should write a valid cache")
+  }
+
+  test("load returns None on a truncated index file") {
+    val idx1 = WorkspaceIndex(workspace)
+    idx1.index()
+    val binPath = IndexPersistence.indexPath(workspace)
+    val bytes = Files.readAllBytes(binPath)
+    Files.write(binPath, bytes.take(bytes.length / 2))
+    assertEquals(IndexPersistence.load(workspace), None)
+    // Restore a valid cache for subsequent tests
+    val idx2 = WorkspaceIndex(workspace)
+    idx2.index()
+  }
+
+  test("load returns None when the version byte does not match") {
+    val idx1 = WorkspaceIndex(workspace)
+    idx1.index()
+    val binPath = IndexPersistence.indexPath(workspace)
+    val bytes = Files.readAllBytes(binPath)
+    bytes(4) = (bytes(4) + 1).toByte // flip the version byte after the 4-byte magic
+    Files.write(binPath, bytes)
+    assertEquals(IndexPersistence.load(workspace), None)
+    val idx2 = WorkspaceIndex(workspace)
+    idx2.index()
+  }
+
+  // ── Timeout reporting ─────────────────────────────────────────────────
+
+  test("findReferences reports timedOut with an expired deadline") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val (results, timedOut) = idx.findReferences("UserService", timeoutMs = 0)
+    assert(timedOut, "Zero timeout should report timedOut")
+  }
+
+  test("findReferences with the default timeout does not report timedOut") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val (results, timedOut) = idx.findReferences("UserService")
+    assert(!timedOut)
+    assert(results.nonEmpty)
   }


### PR DESCRIPTION
## Summary

Internal restructuring for maintainability — no intended behavior change. Production code shrinks by 167 lines (698 added, 865 deleted) while picking up 15 new tests. All 462 tests pass; zero compiler warnings; zero deprecations.

### Deduplication

- **One member-extraction traversal instead of two.** `extractScalaMembers` and `extractMembersWithSpans` were ~60-line near-twins. They now share an origin-tagged core, `extractScalaMemberTree`: `extractMembers` takes everything; `extractMembersWithSpans` filters out constructor params and abstract val/type declarations via a `MemberOrigin` tag, preserving prior behavior exactly.
- **One body-slice helper instead of ten copies.** `extractScalaBody`'s ten repeated slice-and-append blocks collapse into a single `addBody` helper plus a `TypeDefn` extractor matching any class/trait/object/enum.
- **One parse fallback instead of three.** The Scala 3 → Scala 2.13 dialect fallback (copy-pasted in `extraction.scala` ×2 and `analysis.scala`) is now `parseSource`, matching `Parsed.Success`/`Parsed.Error` instead of calling `.get` and catching the throw. New `readSource`/`readSourceLines` helpers replace scattered try/catch file reads.

### Flag parsing rewritten as a single position-aware pass

`parseFlags` previously scanned the arg list ~30 times with `indexOf` and ended in a 50-field positional constructor. It is now one left-to-right pass where every token is classified exactly once (flag / flag value / positional), built with named `copy`.

**Bug fixed:** the old `cleanArgs` used `indexOf`, so a positional argument equal to a flag's value anywhere in the list was dropped — `scalex def --kind class class` lost the positional `class`. Covered by a regression test.

### Timeout state is no longer shared mutable state

`findReferences`, `findImports`, and `categorizeReferences` now return `(results, timedOut)` named tuples — consistent with `grepFiles` — instead of writing a `var timedOut` field on `WorkspaceIndex` that interleaved calls could clobber. The `imports` not-found JSON carries `timedOut` through `NotFoundHint` instead of reaching into the index at render time.

### Failures explain themselves

- Corrupt/truncated index caches now report the cause: `scalex: index load failed (EOFException: null) — rebuilding`.
- Git subprocess readers are closed via `Using.resource` (shared `runGitLines` helper); a missing `git` binary produces a one-line error instead of a stack trace.

### Policy debt cleared

All 34 remaining `return` statements removed from `src/` (restructured, or `boundary`/`break` where a genuine early exit was needed). CLAUDE.md updated: the codebase is now `return`-free. Also removed: a dead `methodDefs` computation in `findOverrides`, two locally re-declared copies of `typeKinds`.

## New tests (15)

- **Cache resilience:** corrupted, truncated, and version-mismatched `index.bin` each return `None` and re-indexing recovers — previously untested.
- **Timeout reporting:** expired deadline → `timedOut = true`; default path → `false`.
- **Parser regressions:** duplicate-token positional, `--limit 0` → unlimited, repeated `-e` ordering, `--workspace`/`-w` precedence both orders, `--up --down` interaction, `--exact` vs `--prefix`, unknown long flags.
- **Member-origin contract:** spans exclude ctor params but keep abstract defs; span extraction agrees with member extraction on concrete members.

## Verification

- `./mill test`: 462 tests, 0 failures (GraphSuite 22, AnalysisSuite 25, ExtractionSuite 76, IndexSuite 76, CliSuite 263)
- `./mill __.compile`: zero warnings, zero deprecations
- CLI smoke-tested on this repo: `search`, `def`, `refs --json --max-output`, `grep --count`, batch mode, `--version` all unchanged; cold index 55 files/787ms, warm 53ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)