### PR TITLE
refactor(scalex): deduplicate command-layer logic into shared helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - When both `-w` and `--workspace` are passed, the last occurrence now wins (previously `--workspace` always took precedence regardless of position)
+- `refs --top` now uses the same timed-out suffix as every other command (`(timed out — partial results)` instead of `(timed out — results may be incomplete)`)
 
 ### Fixed
 - `--expand` without a numeric value no longer consumes a following flag (e.g. `explain Foo --expand --no-doc` now applies `--no-doc`; bare `--expand` still means depth 1)
@@ -19,6 +20,7 @@
 - `findReferences`, `findImports`, and `categorizeReferences` return `timedOut` as part of their result instead of mutating shared state on `WorkspaceIndex` — concurrent queries can no longer clobber each other's timeout flag
 - Member extraction (`members`, `grep --each-method`) now shares one traversal; body extraction and the Scala 3 → 2.13 parse fallback are deduplicated
 - Removed all remaining `return` statements from production code (34) per the codebase-wide policy
+- Deduplicated command-layer logic into shared helpers: dotted-name splitting (`simpleNameOf`, `splitOwnerMember`), member decoration (`decorateMembers`), body-size gating (`bodyWithinLimit`), package resolve-or-not-found (`withResolvedPackage`), stdlib package detection/ranking (`isStdlibPackage`, `stdlibPkgRank`), timed-out suffix, and kind counting (`countByKind`); `grep` shares one owner-lookup and span-scan path, and `overview` computes its parent ranking once for both most-extended and hub types
 
 ## [1.40.0] — 2026-06-01
 

--- a/src/command-helpers.scala
+++ b/src/command-helpers.scala
@@ -6,6 +6,20 @@ import scala.collection.mutable
 def hasRegexHint(pattern: String): Boolean =
   pattern.contains("\\|")
 
+// ── Dotted-name helpers ──────────────────────────────────────────────────────
+
+/** "Outer.Inner.member" → "member"; names without a dot pass through unchanged. */
+def simpleNameOf(s: String): String =
+  if s.contains(".") then s.substring(s.lastIndexOf('.') + 1) else s
+
+/** Split "Owner.member" at the last dot. None when there is no usable split
+  * (no dot, or a leading dot like ".foo"). */
+def splitOwnerMember(s: String): Option[(owner: String, member: String)] = {
+  val lastDot = s.lastIndexOf('.')
+  if lastDot <= 0 then None
+  else Some((owner = s.substring(0, lastDot), member = s.substring(lastDot + 1)))
+}
+
 def fixPosixRegex(pattern: String): (pattern: String, wasFixed: Boolean) =
   // Only \| needs unconditional conversion: POSIX alternation vs Java literal pipe.
   // \( and \) mean "literal paren" in both POSIX and Java — leave them alone.
@@ -80,6 +94,17 @@ def mkPackageNotFound(pkg: String, ctx: CommandContext, cmd: String): NotFoundHi
   else Nil
   NotFoundHint(pkg, ctx.idx.fileCount, ctx.idx.parseFailures, cmd, ctx.batchMode, false, pkgSuggestions)
 
+/** Resolve a package name and run `f` on it, or produce the standard not-found result. */
+def withResolvedPackage(pkg: String, ctx: CommandContext, cmd: String)(f: String => CmdResult): CmdResult = {
+  resolvePackage(pkg, ctx) match {
+    case None =>
+      CmdResult.NotFound(
+        s"""Package "$pkg" not found""",
+        mkPackageNotFound(pkg, ctx, cmd))
+    case Some(resolvedPkg) => f(resolvedPkg)
+  }
+}
+
 // ── Shared filters ──────────────────────────────────────────────────────────
 
 def filterSymbols(symbols: List[SymbolInfo], ctx: CommandContext): List[SymbolInfo] =
@@ -116,6 +141,30 @@ def filterRefs(refs: List[Reference], ctx: CommandContext): List[Reference] =
 // ── Shared constants ─────────────────────────────────────────────────────────
 
 val typeKinds: Set[SymbolKind] = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+
+// ── Stdlib package detection ─────────────────────────────────────────────────
+
+/** True for java/javax/scala standard-library packages. Expects lowercase. */
+def isStdlibPackage(pkg: String): Boolean =
+  pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg.startsWith("scala.") ||
+    pkg == "java" || pkg == "javax" || pkg == "scala"
+
+/** Ranking weight that deprioritizes stdlib packages: java/javax (2), scala (1),
+  * project code (0). Expects lowercase. */
+def stdlibPkgRank(pkg: String): Int =
+  if pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg == "java" || pkg == "javax" then 2
+  else if pkg.startsWith("scala.") || pkg == "scala" then 1
+  else 0
+
+// ── Shared output fragments ──────────────────────────────────────────────────
+
+def timedOutSuffix(timedOut: Boolean): String =
+  if timedOut then " (timed out — partial results)" else ""
+
+// ── Kind grouping ────────────────────────────────────────────────────────────
+
+def countByKind(symbols: List[SymbolInfo]): List[(kind: SymbolKind, count: Int)] =
+  symbols.groupBy(_.kind).toList.sortBy(-_._2.size).map((k, v) => (kind = k, count = v.size))
 
 // ── Inherited member collection (shared by members + explain) ──────────────
 
@@ -159,12 +208,25 @@ private def collectInheritedMembersImpl(sym: SymbolInfo, ctx: CommandContext): (
 
 // ── Body enrichment (shared by members, overrides, explain) ─────────────────
 
-def enrichMemberWithBody(m: MemberInfo, file: java.nio.file.Path, ownerName: String, maxBodyLines: Int): MemberInfo =
-  val bodies = extractBody(file, m.name, Some(ownerName))
-  bodies.headOption match
-    case Some(b) if maxBodyLines <= 0 || (b.endLine - b.startLine + 1) <= maxBodyLines =>
-      m.copy(body = Some(b))
-    case _ => m
+/** Extract the body of `name` (optionally scoped to `owner`), kept only when it
+  * fits within `maxBodyLines` (<= 0 means no limit). */
+def bodyWithinLimit(file: Path, name: String, owner: Option[String], maxBodyLines: Int): Option[BodyInfo] =
+  extractBody(file, name, owner).headOption
+    .filter(b => maxBodyLines <= 0 || (b.endLine - b.startLine + 1) <= maxBodyLines)
+
+def enrichMemberWithBody(m: MemberInfo, file: Path, ownerName: String, maxBodyLines: Int): MemberInfo =
+  bodyWithinLimit(file, m.name, Some(ownerName), maxBodyLines) match {
+    case Some(b) => m.copy(body = Some(b))
+    case None => m
+  }
+
+/** Decorate raw members: mark inherited overrides (--inherited) and attach bodies (--with-body). */
+def decorateMembers(raw: List[MemberInfo], parentKeys: Set[(name: String, kind: SymbolKind)],
+                    file: Path, ownerName: String, ctx: CommandContext): List[MemberInfo] =
+  raw.map { m =>
+    val m2 = if ctx.inherited && parentKeys.contains((name = m.name, kind = m.kind)) then m.copy(isOverride = true) else m
+    if ctx.withBody then enrichMemberWithBody(m2, file, ownerName, ctx.maxBodyLines) else m2
+  }
 
 // ── Ranking / sorting ────────────────────────────────────────────────────────
 
@@ -175,14 +237,8 @@ def rankSymbols(symbols: List[SymbolInfo], workspace: Path): List[SymbolInfo] =
       case SymbolKind.Type | SymbolKind.Given => 1
       case _ => 2
     val testRank = if isTestFile(s.file, workspace) then 1 else 0
-    // Deprioritize java.*/javax.*/scala.* standard library packages
-    val pkg = s.packageName.toLowerCase
-    val stdlibRank =
-      if pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg == "java" || pkg == "javax" then 2
-      else if pkg.startsWith("scala.") || pkg == "scala" then 1
-      else 0
     val pathLen = workspace.relativize(s.file).toString.length
-    (kindRank = kindRank, testRank = testRank, stdlibRank = stdlibRank, pathLen = pathLen)
+    (kindRank = kindRank, testRank = testRank, stdlibRank = stdlibPkgRank(s.packageName.toLowerCase), pathLen = pathLen)
   }
 
 def memberKindRank(m: MemberInfo): Int = m.kind match
@@ -230,11 +286,7 @@ private def isStdlibType(lowerName: String, symbolsByName: Map[String, List[Symb
   predefTypeNames.contains(lowerName) || {
     symbolsByName.get(lowerName) match
       case None => true // not in index → unindexed stdlib type
-      case Some(syms) => syms.forall { s =>
-        val pkg = s.packageName.toLowerCase
-        pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg.startsWith("scala.") ||
-          pkg == "java" || pkg == "javax" || pkg == "scala"
-      }
+      case Some(syms) => syms.forall(s => isStdlibPackage(s.packageName.toLowerCase))
   }
 
 def extractRelatedTypes(members: List[MemberInfo], sym: SymbolInfo, idx: WorkspaceIndex): List[SymbolInfo] =

--- a/src/commands/api.scala
+++ b/src/commands/api.scala
@@ -2,22 +2,18 @@ def cmdApi(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex api <package>")
     case Some(pkg) =>
-      resolvePackage(pkg, ctx) match
-        case None =>
-          CmdResult.NotFound(
-            s"""Package "$pkg" not found""",
-            mkPackageNotFound(pkg, ctx, "api"))
-        case Some(resolvedPkg) =>
-          val surface = ctx.idx.findApiSurface(resolvedPkg, ctx.usedByFilter)
-          // Apply kind/test/path filters to the symbols
-          val filteredSymbols = filterSymbols(surface.map(_.symbol), ctx).toSet
-          val filtered = surface.filter(e => filteredSymbols.contains(e.symbol))
-          val (exported, internal) = filtered.partition(_.importerCount > 0)
-          val sorted = exported.sortBy(e => -e.importerCount)
-          val allPkgSymbols = ctx.idx.packageToSymbols.getOrElse(resolvedPkg, Set.empty)
-          CmdResult.ApiSurface(
-            pkg = resolvedPkg,
-            symbols = sorted,
-            totalInPackage = allPkgSymbols.size,
-            internalOnly = internal.map(_.symbol.name).sorted
-          )
+      withResolvedPackage(pkg, ctx, "api") { resolvedPkg =>
+        val surface = ctx.idx.findApiSurface(resolvedPkg, ctx.usedByFilter)
+        // Apply kind/test/path filters to the symbols
+        val filteredSymbols = filterSymbols(surface.map(_.symbol), ctx).toSet
+        val filtered = surface.filter(e => filteredSymbols.contains(e.symbol))
+        val (exported, internal) = filtered.partition(_.importerCount > 0)
+        val sorted = exported.sortBy(e => -e.importerCount)
+        val allPkgSymbols = ctx.idx.packageToSymbols.getOrElse(resolvedPkg, Set.empty)
+        CmdResult.ApiSurface(
+          pkg = resolvedPkg,
+          symbols = sorted,
+          totalInPackage = allPkgSymbols.size,
+          internalOnly = internal.map(_.symbol.name).sorted
+        )
+      }

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -22,27 +22,24 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
       }
       // Collect (file, body) pairs
       // For dotted --in owners like "Outer.Inner", use simple name for body extraction
-      val effectiveOwner = ctx.inOwner.map { o =>
-        if o.contains(".") then o.substring(o.lastIndexOf('.') + 1) else o
-      }
+      val effectiveOwner = ctx.inOwner.map(simpleNameOf)
       val blocks = filesToSearch.flatMap { f =>
         extractBody(f, symbol, effectiveOwner).map(b => (file = f, body = b))
       }
       // Fallback: if no results and symbol has a dot, split into Owner.member
       val (displayName, effectiveBlocks) =
-        if blocks.isEmpty && symbol.contains(".") && ctx.inOwner.isEmpty && symbol.lastIndexOf('.') > 0 then
-          val lastDot = symbol.lastIndexOf('.')
-          val ownerName = symbol.substring(0, lastDot)
-          val memberName = symbol.substring(lastDot + 1)
-          val dottedOwnerFiles = filterSymbols(ctx.idx.findDefinition(ownerName), ctx)
-            .filter(s => typeKinds.contains(s.kind))
-            .map(_.file).distinct
-          val dottedBlocks = dottedOwnerFiles.flatMap { f =>
-            extractBody(f, memberName, Some(ownerName)).map(b => (file = f, body = b))
-          }
-          if dottedBlocks.nonEmpty then (displayName = memberName, effectiveBlocks = dottedBlocks)
-          else (displayName = symbol, effectiveBlocks = blocks)
-        else (displayName = symbol, effectiveBlocks = blocks)
+        splitOwnerMember(symbol) match {
+          case Some((ownerName, memberName)) if blocks.isEmpty && ctx.inOwner.isEmpty =>
+            val dottedOwnerFiles = filterSymbols(ctx.idx.findDefinition(ownerName), ctx)
+              .filter(s => typeKinds.contains(s.kind))
+              .map(_.file).distinct
+            val dottedBlocks = dottedOwnerFiles.flatMap { f =>
+              extractBody(f, memberName, Some(ownerName)).map(b => (file = f, body = b))
+            }
+            if dottedBlocks.nonEmpty then (displayName = memberName, effectiveBlocks = dottedBlocks)
+            else (displayName = symbol, effectiveBlocks = blocks)
+          case _ => (displayName = symbol, effectiveBlocks = blocks)
+        }
 
       if effectiveBlocks.isEmpty then
         val msg = ctx.inOwner match

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -28,15 +28,10 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
 
 /** Resolve Owner.member syntax: if Owner is a type, extract its members and filter to the member name */
 private def resolveDottedMember(symbol: String, ctx: CommandContext): Option[List[SymbolInfo]] = {
-  val lastDot = symbol.lastIndexOf('.')
-  if lastDot <= 0 then None
-  else {
-    val ownerName = symbol.substring(0, lastDot)
-    val memberName = symbol.substring(lastDot + 1)
+  splitOwnerMember(symbol).flatMap { (ownerName, memberName) =>
     val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
     val memberResults = ownerDefs.flatMap { owner =>
-      val simpleName = if ownerName.contains(".") then ownerName.substring(ownerName.lastIndexOf('.') + 1) else ownerName
-      val members = extractMembers(owner.file, simpleName)
+      val members = extractMembers(owner.file, simpleNameOf(ownerName))
       members.filter(_.name.equalsIgnoreCase(memberName)).map { m =>
         SymbolInfo(
           name = m.name,

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -59,7 +59,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
               s"${otherSym.name} --path ${rel}/"
           }
         // For qualified lookups, use the simple name for member/impl queries
-        val simpleName = if symbol.contains(".") then symbol.substring(symbol.lastIndexOf('.') + 1) else symbol
+        val simpleName = simpleNameOf(symbol)
         // Scaladoc
         val doc = if ctx.noDoc then None else extractDoc(sym.file, sym.line)
         // Extract raw members once — reused for members, related, and brief
@@ -71,10 +71,8 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
           else (inherited = Nil: List[(parentName: String, parentFile: Option[java.nio.file.Path], parentPackage: String, members: List[MemberInfo])], parentMemberKeys = Set.empty[(name: String, kind: SymbolKind)])
         val inherited = inheritResult.inherited
         val parentKeys = inheritResult.parentMemberKeys
-        val members = rawMembers.map { m =>
-          val m2 = if ctx.inherited && parentKeys.contains((name = m.name, kind = m.kind)) then m.copy(isOverride = true) else m
-          if ctx.withBody then enrichMemberWithBody(m2, sym.file, simpleName, ctx.maxBodyLines) else m2
-        }.sortBy(memberKindRank).take(ctx.membersLimit)
+        val members = decorateMembers(rawMembers, parentKeys, sym.file, simpleName, ctx)
+          .sortBy(memberKindRank).take(ctx.membersLimit)
         // Companion lookup
         val companion = findCompanion(sym, simpleName, defs)
           .map((s, ms) => (sym = s, members = ms.sortBy(memberKindRank).take(ctx.membersLimit)))

--- a/src/commands/grep.scala
+++ b/src/commands/grep.scala
@@ -30,7 +30,7 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
             val fileCount = scopedResults.map(_.file).distinct.size
             CmdResult.GrepCount(scopedResults.size, fileCount, scopedTimedOut, hint, stderrHint)
           else
-            val suffix = if scopedTimedOut then " (timed out — partial results)" else ""
+            val suffix = timedOutSuffix(scopedTimedOut)
             val inStr = s""" in $owner"""
             CmdResult.RefList(
               header = s"""Matches for "$displayPattern"$inStr — ${scopedResults.size} found:$suffix""",
@@ -45,7 +45,7 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
             val fileCount = results.map(_.file).distinct.size
             CmdResult.GrepCount(results.size, fileCount, grepTimedOut, hint, stderrHint)
           else
-            val suffix = if grepTimedOut then " (timed out — partial results)" else ""
+            val suffix = timedOutSuffix(grepTimedOut)
             CmdResult.RefList(
               header = s"""Matches for "$displayPattern" — ${results.size} found:$suffix""",
               refs = results,
@@ -54,19 +54,40 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
               emptyMessage = s"""No matches for "$displayPattern"$suffix""",
               stderrHint = stderrHint)
 
+/** Find a symbol's definitions for scoped grep, falling back to an exact-name
+  * scan over type symbols when the indexed lookup misses. */
+private def findOwnerDefs(name: String, ctx: CommandContext, typesOnly: Boolean): List[SymbolInfo] = {
+  val primary = filterSymbols(ctx.idx.findDefinition(name), ctx.copy(kindFilter = None))
+  val defs = if typesOnly then primary.filter(s => typeKinds.contains(s.kind)) else primary
+  if defs.nonEmpty then defs
+  else filterSymbols(ctx.idx.symbols.filter(s => s.name == name && typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
+}
+
+/** Grep a 1-indexed inclusive line span, returning matched lines. */
+private def grepSpan(lines: collection.Seq[String], startLine: Int, endLine: Int,
+                     regex: java.util.regex.Pattern): List[(lineNum: Int, text: String)] = {
+  val matched = scala.collection.mutable.ListBuffer.empty[(lineNum: Int, text: String)]
+  var lineIdx = startLine - 1 // 0-indexed
+  val endIdx = math.min(endLine, lines.size) // 1-indexed inclusive -> exclusive in 0-indexed
+  while lineIdx < endIdx do {
+    if regex.matcher(lines(lineIdx)).find() then
+      matched += ((lineNum = lineIdx + 1, text = lines(lineIdx).trim))
+    lineIdx += 1
+  }
+  matched.toList
+}
+
 private def grepInSymbol(pattern: String, owner: String, ctx: CommandContext): (results: List[Reference], timedOut: Boolean) = boundary {
   val regex = java.util.regex.Pattern.compile(pattern) // pattern is pre-validated by fixPosixRegex
 
   // Split Owner.member if present
-  val (ownerName, memberName) = if owner.contains(".") then
-    val lastDot = owner.lastIndexOf('.')
-    (owner.substring(0, lastDot), Some(owner.substring(lastDot + 1)))
-  else (owner, None)
+  val (ownerName, memberName) = splitOwnerMember(owner) match {
+    case Some((o, m)) => (o, Some(m))
+    case None => (owner, None)
+  }
 
   // Find the owner's files
-  var ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx.copy(kindFilter = None))
-  if ownerDefs.isEmpty then
-    ownerDefs = filterSymbols(ctx.idx.symbols.filter(s => s.name == ownerName && typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
+  val ownerDefs = findOwnerDefs(ownerName, ctx, typesOnly = false)
   if ownerDefs.isEmpty then break((Nil, false))
 
   val results = scala.collection.mutable.ListBuffer.empty[Reference]
@@ -79,14 +100,9 @@ private def grepInSymbol(pattern: String, owner: String, ctx: CommandContext): (
     bodies.foreach { b =>
       val lines = try java.nio.file.Files.readAllLines(sym.file).asScala catch
         case _: java.io.IOException => break((Nil, false))
-      // Grep within the body span
-      var lineIdx = b.startLine - 1 // 0-indexed
-      val endIdx = math.min(b.endLine, lines.size) // 1-indexed inclusive -> exclusive in 0-indexed
-      while lineIdx < endIdx do
-        val line = lines(lineIdx)
-        if regex.matcher(line).find() then
-          results += Reference(sym.file, lineIdx + 1, line.trim)
-        lineIdx += 1
+      grepSpan(lines, b.startLine, b.endLine, regex).foreach { m =>
+        results += Reference(sym.file, m.lineNum, m.text)
+      }
     }
   }
   (results.toList, false)
@@ -98,10 +114,7 @@ private def grepEachMethod(pattern: String, displayPattern: String, owner: Strin
   val regex = java.util.regex.Pattern.compile(pattern) // pattern is pre-validated by fixPosixRegex
 
   // Find the owner type
-  var ownerDefs = filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
-    .filter(s => typeKinds.contains(s.kind))
-  if ownerDefs.isEmpty then
-    ownerDefs = filterSymbols(ctx.idx.symbols.filter(s => s.name == owner && typeKinds.contains(s.kind)), ctx.copy(kindFilter = None))
+  val ownerDefs = findOwnerDefs(owner, ctx, typesOnly = true)
   if ownerDefs.isEmpty then
     break(CmdResult.NotFound(s"Type not found: $owner", mkNotFoundWithSuggestions(owner, ctx, "grep")))
 
@@ -120,15 +133,9 @@ private def grepEachMethod(pattern: String, displayPattern: String, owner: Strin
       if lines.nonEmpty then
         membersWithSpans.foreach { ms =>
           if System.nanoTime() < deadline then
-            val matchedLines = scala.collection.mutable.ListBuffer.empty[(lineNum: Int, text: String)]
-            var lineIdx = ms.startLine - 1
-            val endIdx = math.min(ms.endLine, lines.size)
-            while lineIdx < endIdx do
-              if regex.matcher(lines(lineIdx)).find() then
-                matchedLines += ((lineNum = lineIdx + 1, text = lines(lineIdx).trim))
-              lineIdx += 1
+            val matchedLines = grepSpan(lines, ms.startLine, ms.endLine, regex)
             if matchedLines.nonEmpty then
-              matches += MethodGrepMatch(ms.member, sym.file, matchedLines.size, matchedLines.toList)
+              matches += MethodGrepMatch(ms.member, sym.file, matchedLines.size, matchedLines)
           else timedOut = true
         }
   }

--- a/src/commands/imports.scala
+++ b/src/commands/imports.scala
@@ -9,7 +9,7 @@ def cmdImports(args: List[String], ctx: CommandContext): CmdResult =
           s"""No imports of "$symbol" found""",
           mkNotFoundWithSuggestions(symbol, ctx, "imports").copy(timedOut = timedOut))
       else
-        val suffix = if timedOut then " (timed out — partial results)" else ""
+        val suffix = timedOutSuffix(timedOut)
         CmdResult.RefList(
           header = s"""Imports of "$symbol" — ${results.size} found:$suffix""",
           refs = results,

--- a/src/commands/index-cmd.scala
+++ b/src/commands/index-cmd.scala
@@ -1,5 +1,5 @@
 def cmdIndex(args: List[String], ctx: CommandContext): CmdResult =
-  val byKind = ctx.idx.symbols.groupBy(_.kind).toList.sortBy(-_._2.size).map((k, v) => (kind = k, count = v.size))
+  val byKind = countByKind(ctx.idx.symbols)
   CmdResult.IndexStats(
     fileCount = ctx.idx.fileCount,
     symbolCount = ctx.idx.symbols.size,

--- a/src/commands/members.scala
+++ b/src/commands/members.scala
@@ -2,8 +2,9 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex members <Symbol>")
     case Some(symbol) =>
-      val simpleName = if symbol.contains(".") then symbol.substring(symbol.lastIndexOf('.') + 1) else symbol
-      val defs = filterSymbols(ctx.idx.findDefinition(symbol).filter(s => typeKinds.contains(s.kind)), ctx)
+      val simpleName = simpleNameOf(symbol)
+      val typeDefs = ctx.idx.findDefinition(symbol).filter(s => typeKinds.contains(s.kind))
+      val defs = filterSymbols(typeDefs, ctx)
 
       if defs.isEmpty then
         CmdResult.NotFound(
@@ -14,12 +15,9 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
           val inheritResult = collectInheritedMembers(s, ctx)
           val inherited = inheritResult.inherited
           val parentKeys = inheritResult.parentMemberKeys
-          val members = extractMembers(s.file, simpleName, Some(s.kind)).map { m =>
-            val m2 = if ctx.inherited && parentKeys.contains((name = m.name, kind = m.kind)) then m.copy(isOverride = true) else m
-            if ctx.withBody then enrichMemberWithBody(m2, s.file, simpleName, ctx.maxBodyLines) else m2
-          }
-          // Companion lookup
-          val companion = findCompanion(s, simpleName, ctx.idx.findDefinition(symbol).filter(d => typeKinds.contains(d.kind)))
+          val members = decorateMembers(extractMembers(s.file, simpleName, Some(s.kind)), parentKeys, s.file, simpleName, ctx)
+          // Companion lookup (against unfiltered defs so --kind doesn't hide the companion)
+          val companion = findCompanion(s, simpleName, typeDefs)
           MemberSectionData(
             file = s.file,
             ownerKind = s.kind,

--- a/src/commands/overrides.scala
+++ b/src/commands/overrides.scala
@@ -5,11 +5,9 @@ def cmdOverrides(args: List[String], ctx: CommandContext): CmdResult =
       var results = findOverrides(ctx.idx, methodName, ctx.ofTrait, ctx.limit)
       if ctx.withBody then
         results = results.map { o =>
-          val bodies = extractBody(o.file, methodName, Some(o.enclosingClass))
-          bodies.headOption match
-            case Some(b) if ctx.maxBodyLines <= 0 || (b.endLine - b.startLine + 1) <= ctx.maxBodyLines =>
-              o.copy(body = Some(b))
-            case _ => o
+          bodyWithinLimit(o.file, methodName, Some(o.enclosingClass), ctx.maxBodyLines) match
+            case Some(b) => o.copy(body = Some(b))
+            case None => o
         }
       if results.isEmpty then
         val ofStr = ctx.ofTrait.map(t => s" of $t").getOrElse("")

--- a/src/commands/overview.scala
+++ b/src/commands/overview.scala
@@ -22,11 +22,7 @@ private def isStdlibParent(name: String): Boolean =
 private def isStdlibPackageOnly(lowerName: String, symbolsByName: Map[String, List[SymbolInfo]]): Boolean =
   symbolsByName.get(lowerName) match
     case None => false
-    case Some(syms) => syms.forall { s =>
-      val pkg = s.packageName.toLowerCase
-      pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg.startsWith("scala.") ||
-        pkg == "java" || pkg == "javax" || pkg == "scala"
-    }
+    case Some(syms) => syms.forall(s => isStdlibPackage(s.packageName.toLowerCase))
 
 private def recoverName(lower: String, symbolsByName: Map[String, List[SymbolInfo]]): String =
   symbolsByName.get(lower).flatMap(_.headOption).map(_.name).getOrElse(lower)
@@ -37,11 +33,12 @@ private def recoverSignature(lower: String, symbolsByName: Map[String, List[Symb
 def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
   var allSymbols = filterSymbols(ctx.idx.symbols, ctx)
 
-  val symbolsByKind = allSymbols.groupBy(_.kind).toList.sortBy(-_._2.size)
+  val symbolsByKind = countByKind(allSymbols)
   val topPackages: List[(pkg: String, syms: List[SymbolInfo])] = allSymbols.groupBy(_.packageName)
     .filter(_._1.nonEmpty).toList.sortBy(-_._2.size).take(ctx.limit)
     .map((p, s) => (pkg = p, syms = s))
 
+  // Most-extended non-stdlib parents, ranked — feeds both mostExtended and hubTypes
   val mostExtended = ctx.idx.parentIndex.toList
     .filter((name, _) => ctx.idx.symbolsByName.contains(name) && !isStdlibParent(name) && !isStdlibPackageOnly(name, ctx.idx.symbolsByName))
     .filter((name, _) => recoverName(name, ctx.idx.symbolsByName).length > 1) // exclude single-char names
@@ -92,32 +89,20 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
         .map((pkg, deps) => pkg -> deps.filter(relevant.contains))
     case None => archPkgDeps
 
-  // Architecture: hub types (most-referenced + most-extended)
+  // Architecture: hub types — same ranking as mostExtended, different projection
   val hubTypes: List[(name: String, score: Int, signature: String)] = if effectiveArch then {
-    val refCounts = mutable.HashMap.empty[String, (count: Int, distinctPkgs: Int)]
-    ctx.idx.parentIndex.foreach { (name, impls) =>
-      if ctx.idx.symbolsByName.contains(name) && !isStdlibParent(name) &&
-         !isStdlibPackageOnly(name, ctx.idx.symbolsByName) &&
-         recoverName(name, ctx.idx.symbolsByName).length > 1 then
-        val filtered = filterSymbols(impls, ctx)
-        if filtered.nonEmpty then
-          refCounts(name) = (count = filtered.size, distinctPkgs = filtered.map(_.packageName).distinct.size)
-    }
-    refCounts.toList
-      .sortBy((_, data) => (-data.distinctPkgs, -data.count))
-      .take(ctx.limit)
-      .map((name, data) => (
-        name = recoverName(name, ctx.idx.symbolsByName),
-        score = data.count,
-        signature = recoverSignature(name, ctx.idx.symbolsByName)
-      ))
+    mostExtended.map(t => (
+      name = recoverName(t.name, ctx.idx.symbolsByName),
+      score = t.impls.size,
+      signature = recoverSignature(t.name, ctx.idx.symbolsByName)
+    ))
   } else Nil
 
   CmdResult.Overview(OverviewData(
     fileCount = allSymbols.map(_.file).distinct.size,
     symbolCount = allSymbols.size,
     packageCount = allSymbols.map(_.packageName).filter(_.nonEmpty).distinct.size,
-    symbolsByKind = symbolsByKind.map((k, syms) => (kind = k, count = syms.size)),
+    symbolsByKind = symbolsByKind,
     topPackages = topPackages.map((p, syms) => (pkg = p, count = syms.size)),
     mostExtended = mostExtended.map(t => (
       name = recoverName(t.name, ctx.idx.symbolsByName),

--- a/src/commands/package-cmd.scala
+++ b/src/commands/package-cmd.scala
@@ -6,24 +6,20 @@ def cmdPackage(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex package <pkg>")
     case Some(pkg) =>
-      resolvePackage(pkg, ctx) match
-        case None =>
-          CmdResult.NotFound(
-            s"""Package "$pkg" not found""",
-            mkPackageNotFound(pkg, ctx, "package"))
-        case Some(resolvedPkg) =>
-          var symbols = filterSymbols(ctx.idx.symbols.filter(_.packageName == resolvedPkg), ctx)
-          if ctx.explainMode then
-            val allTypes = symbols.filter(s => typeKinds.contains(s.kind))
-              .sortBy(s => (kindRank = kindRankMap(s.kind), name = s.name))
-            val types = allTypes.take(ctx.limit)
-            val entries = types.map { s =>
-              val members = extractMembers(s.file, s.name, Some(s.kind)).sortBy(memberKindRank).take(3)
-              val implCount = filterSymbols(ctx.idx.findImplementations(s.name), ctx).size
-              PackageExplainedEntry(s, members, implCount)
-            }
-            CmdResult.PackageExplained(resolvedPkg, entries, symbols.size, allTypes.size)
-          else
-            if ctx.definitionsOnly then
-              symbols = symbols.filter(s => typeKinds.contains(s.kind))
-            CmdResult.PackageSymbols(resolvedPkg, symbols)
+      withResolvedPackage(pkg, ctx, "package") { resolvedPkg =>
+        var symbols = filterSymbols(ctx.idx.symbols.filter(_.packageName == resolvedPkg), ctx)
+        if ctx.explainMode then
+          val allTypes = symbols.filter(s => typeKinds.contains(s.kind))
+            .sortBy(s => (kindRank = kindRankMap(s.kind), name = s.name))
+          val types = allTypes.take(ctx.limit)
+          val entries = types.map { s =>
+            val members = extractMembers(s.file, s.name, Some(s.kind)).sortBy(memberKindRank).take(3)
+            val implCount = filterSymbols(ctx.idx.findImplementations(s.name), ctx).size
+            PackageExplainedEntry(s, members, implCount)
+          }
+          CmdResult.PackageExplained(resolvedPkg, entries, symbols.size, allTypes.size)
+        else
+          if ctx.definitionsOnly then
+            symbols = symbols.filter(s => typeKinds.contains(s.kind))
+          CmdResult.PackageSymbols(resolvedPkg, symbols)
+      }

--- a/src/commands/summary.scala
+++ b/src/commands/summary.scala
@@ -2,22 +2,18 @@ def cmdSummary(args: List[String], ctx: CommandContext): CmdResult =
   args.headOption match
     case None => CmdResult.UsageError("Usage: scalex summary <package>")
     case Some(pkg) =>
-      resolvePackage(pkg, ctx) match
-        case None =>
-          CmdResult.NotFound(
-            s"""Package "$pkg" not found""",
-            mkPackageNotFound(pkg, ctx, "summary"))
-        case Some(resolvedPkg) =>
-          val prefix = resolvedPkg + "."
-          // Collect all packages that start with resolvedPkg (including itself)
-          var allSymbols = filterSymbols(symbolsInPackage(resolvedPkg, ctx.idx.symbols), ctx)
+      withResolvedPackage(pkg, ctx, "summary") { resolvedPkg =>
+        val prefix = resolvedPkg + "."
+        // Collect all packages that start with resolvedPkg (including itself)
+        val allSymbols = filterSymbols(symbolsInPackage(resolvedPkg, ctx.idx.symbols), ctx)
 
-          // Group by sub-package relative to resolvedPkg
-          val grouped = allSymbols.groupBy { s =>
-            if s.packageName == resolvedPkg then "(root)"
-            else s.packageName.stripPrefix(prefix)
-          }
-          val subPackages = grouped.toList
-            .map((sub, syms) => (subPkg = sub, count = syms.size))
-            .sortBy(-_.count)
-          CmdResult.PackageSummary(resolvedPkg, subPackages, allSymbols.size)
+        // Group by sub-package relative to resolvedPkg
+        val grouped = allSymbols.groupBy { s =>
+          if s.packageName == resolvedPkg then "(root)"
+          else s.packageName.stripPrefix(prefix)
+        }
+        val subPackages = grouped.toList
+          .map((sub, syms) => (subPkg = sub, count = syms.size))
+          .sortBy(-_.count)
+        CmdResult.PackageSummary(resolvedPkg, subPackages, allSymbols.size)
+      }

--- a/src/commands/symbols.scala
+++ b/src/commands/symbols.scala
@@ -4,14 +4,14 @@ def cmdSymbols(args: List[String], ctx: CommandContext): CmdResult =
     case Some(file) =>
       val results = ctx.idx.fileSymbols(file)
       if ctx.summaryMode then
-        val grouped = results.groupBy(_.kind).toList.sortBy(-_._2.size)
+        val grouped = countByKind(results)
         if ctx.jsonOutput then
-          val byKind = grouped.map((k, syms) => s""""${k.toString.toLowerCase}":${syms.size}""").mkString(",")
+          val byKind = grouped.map((k, count) => s""""${k.toString.toLowerCase}":$count""").mkString(",")
           // Consistent with overview/index-stats symbolsByKind format
           println(s"""{"file":"${jsonEscape(file)}","symbolsByKind":{$byKind},"total":${results.size}}""")
           CmdResult.StringList(header = "", items = Nil, total = 0) // already printed
         else
-          val counts = grouped.map((k, syms) => s"${syms.size} ${k.toString.toLowerCase}${if syms.size > 1 then "s" else ""}").mkString(", ")
+          val counts = grouped.map((k, count) => s"$count ${k.toString.toLowerCase}${if count > 1 then "s" else ""}").mkString(", ")
           val summary = if counts.nonEmpty then s"$file: $counts (${results.size} total)" else s"$file: no symbols"
           CmdResult.StringList(header = "", items = Nil, total = 0, emptyMessage = summary)
       else

--- a/src/format.scala
+++ b/src/format.scala
@@ -189,7 +189,7 @@ private def renderCategorizedRefs(r: CmdResult.CategorizedRefs, ctx: CommandCont
     println(s"""{"categories":{$entries},"timedOut":${r.timedOut}}""")
   } else {
     val total = r.grouped.values.map(_.size).sum
-    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — $total found:$suffix""")
     val confidenceOrder = List(Confidence.High, Confidence.Medium, Confidence.Low)
     confidenceOrder.foreach { conf =>
@@ -224,7 +224,7 @@ private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
     val arr = r.refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
     println(s"""{"results":$arr,"timedOut":${r.timedOut}}""")
   } else {
-    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — ${r.refs.size} found:$suffix""")
     val annotated = r.refs.map(ref => (ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
     val sorted = annotated.sortBy { case (ref, c) => (confidence = c.ordinal, path = ctx.workspace.relativize(ref.file).toString, line = ref.line) }
@@ -1038,14 +1038,14 @@ private def renderGrepCount(r: CmdResult.GrepCount, ctx: CommandContext): Unit =
     val hintStr = r.hint.getOrElse("")
     println(s"""{"matches":${r.matches},"files":${r.files},"timedOut":${r.timedOut}$hintStr}""")
   } else {
-    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    val suffix = timedOutSuffix(r.timedOut)
     println(s"${r.matches} matches across ${r.files} files$suffix")
   }
 }
 
 private def renderGrepByMethod(r: CmdResult.GrepByMethod, ctx: CommandContext): Unit = {
   r.stderrHint.foreach(System.err.println)
-  val suffix = if r.timedOut then " (timed out — partial results)" else ""
+  val suffix = timedOutSuffix(r.timedOut)
   if ctx.jsonOutput then {
     val shown = r.methods.take(ctx.limit)
     val items = shown.map { m =>
@@ -1210,7 +1210,7 @@ private def renderApiSurface(r: CmdResult.ApiSurface, ctx: CommandContext): Unit
 }
 
 private def renderRefsTop(r: CmdResult.RefsTop, ctx: CommandContext): Unit = {
-  val timedOutSuffix = if r.timedOut then " (timed out — results may be incomplete)" else ""
+  val suffix = timedOutSuffix(r.timedOut)
   if ctx.jsonOutput then {
     val filesJson = r.fileRanking.map { (file, count) =>
       val rel = jsonEscape(ctx.workspace.relativize(file).toString)
@@ -1219,7 +1219,7 @@ private def renderRefsTop(r: CmdResult.RefsTop, ctx: CommandContext): Unit = {
     println(s"""{"symbol":"${jsonEscape(r.symbol)}","files":$filesJson,"total":${r.total},"timedOut":${r.timedOut}}""")
   } else {
     val fileCount = r.fileRanking.size
-    println(s"Top $fileCount files referencing '${r.symbol}' (${r.total} total references)$timedOutSuffix:")
+    println(s"Top $fileCount files referencing '${r.symbol}' (${r.total} total references)$suffix:")
     r.fileRanking.foreach { (file, count) =>
       val rel = ctx.workspace.relativize(file)
       println(f"  $count%4d  $rel")
@@ -1232,7 +1232,7 @@ private def renderRefsSummary(r: CmdResult.RefsSummary, ctx: CommandContext): Un
     val counts = r.categoryCounts.map((cat, count) => s""""${cat.toString}":$count""").mkString("{", ",", "}")
     println(s"""{"symbol":"${jsonEscape(r.symbol)}","counts":$counts,"total":${r.total},"timedOut":${r.timedOut}}""")
   } else {
-    val suffix = if r.timedOut then " (timed out — partial results)" else ""
+    val suffix = timedOutSuffix(r.timedOut)
     val parts = r.categoryCounts.map { (cat, count) =>
       val label = cat match {
         case RefCategory.Definition => "definitions"

--- a/src/index.scala
+++ b/src/index.scala
@@ -527,12 +527,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
         case SymbolKind.Def | SymbolKind.Val | SymbolKind.Type => 2
         case _ => 3
       val testRank = if isTestFile(s.file, workspace) then 1 else 0
-      // Deprioritize java.*/javax.*/scala.* standard library packages
-      val pkg = s.packageName.toLowerCase
-      val stdlibRank =
-        if pkg.startsWith("java.") || pkg.startsWith("javax.") || pkg == "java" || pkg == "javax" then 2
-        else if pkg.startsWith("scala.") || pkg == "scala" then 1
-        else 0
+      val stdlibRank = stdlibPkgRank(s.packageName.toLowerCase)
       // Symbols in heavily-imported types rank higher (lower importRank = better)
       val importRank = -symbolImportRank.getOrElse(s.name.toLowerCase, 0)
       val pathLen = s.file.toString.length


### PR DESCRIPTION
## Summary

Review of all 29 command handlers found nine pockets of repeated logic; this PR extracts them into shared helpers in `command-helpers.scala` and removes the duplication at every call site. Net −189 lines of duplicated logic, +202 mostly helper definitions and doc comments.

### New shared helpers

- `simpleNameOf` / `splitOwnerMember` — dotted-name splitting, replacing 7 hand-rolled `lastIndexOf('.')` sites in `definition`, `body`, `members`, `explain`, `grep`
- `decorateMembers` — the identical isOverride-marking + body-enrichment pipeline from `explain` and `members`
- `bodyWithinLimit` — the body-size gate, now backing both `enrichMemberWithBody` and the inline copy in `overrides`
- `withResolvedPackage` — the resolve-or-not-found block copy-pasted across `api`, `package`, `summary`
- `isStdlibPackage` / `stdlibPkgRank` — the stdlib-package predicate that existed in 4 flavors (command-helpers, overview, `rankSymbols`, `searchRank` in index.scala)
- `timedOutSuffix` — replaces 9 hardcoded copies of the suffix string across format.scala, grep, imports
- `countByKind` — the groupBy-kind-sort-count chain from `index`, `overview`, `symbols`

### Local cleanups

- `grep` gains private `findOwnerDefs` (with a `typesOnly` flag — its two call sites intentionally differed) and `grepSpan`, collapsing duplicated owner-lookup and line-scan loops
- `overview` computes its parent ranking once; `hubTypes` is now a projection of `mostExtended` instead of a full recomputation of the same filter/sort chain
- `members` no longer calls `findDefinition` twice; the companion lookup still uses unfiltered defs so `--kind` can't hide a companion (now commented)

### Behavior changes (intentional, changelogged)

1. `refs --top` timed-out suffix unified to `(timed out — partial results)` (was `results may be incomplete`); no test pinned the old string
2. `overview` hub-type tie-ordering is now deterministic and matches most-extended (was HashMap iteration order)

## Test plan

- `./mill __.compile` — clean, zero warnings, zero deprecations
- `./mill test` — 416 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)