### PR TITLE
refactor: extract shared helpers across src/, fix grep --json escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,31 @@
 ### Changed
 - When both `-w` and `--workspace` are passed, the last occurrence now wins (previously `--workspace` always took precedence regardless of position)
 - `refs --top` now uses the same timed-out suffix as every other command (`(timed out — partial results)` instead of `(timed out — results may be incomplete)`)
+- `overview --architecture/--concise/--focus-package` reads imports recorded in the index instead of re-parsing every source file — on the scala3 corpus (17.7k files) this drops `overview --concise` from ~3.7s to ~0.75s (4.9×)
+- Native-image note: bloom-loading commands (`refs`/`imports`/`coverage`) run 7–15% slower in this build (~50–90ms on the scala3 corpus) while most other commands got 10–18% faster. The slowdown is entirely in the untouched index-deserialization phase and does not reproduce on the JVM (parity there) — it traces to GraalVM GC pacing/codegen shifts from the binary growing, not to any changed code path. Pinning the heap (`-Xms1g`) recovers most of it on both old and new binaries
+- Line-number gutters are now uniformly left-aligned: `refs -C` previously right-aligned line numbers while `body` left-aligned them
+- `refs`/`imports` now report `timedOut: true` when the deadline expires mid-file on the last scanned file (previously the partial result could be reported as complete)
 
 ### Fixed
+- `grep --json` no longer emits invalid JSON when the auto-corrected pattern contains backslashes or quotes (e.g. `grep 'foo\|\d+' --json` produced an unescaped `"corrected":"foo|\d+"` hint)
+- `graph` no longer corrupts its edge-list args when a value-taking global flag (e.g. `--limit 5`) is passed — the flag strip-list is now derived from the flag registry instead of a hardcoded subset
 - `--expand` without a numeric value no longer consumes a following flag (e.g. `explain Foo --expand --no-doc` now applies `--no-doc`; bare `--expand` still means depth 1)
 - A positional argument that equals a flag's value elsewhere in the arg list (e.g. `scalex def --kind class class`) is no longer dropped — flag parsing is now a single position-aware pass
 - Corrupted or truncated index caches now report the failure cause on stderr (`index load failed (EOFException: …) — rebuilding`) instead of a generic message
 - Git subprocess readers are closed after use; a missing `git` binary now produces a clear error instead of a stack trace
 
 ### Changed (internal)
+- JSON emission helpers (`jStr`/`jArr`/`jStrArr`/`jOpt`, `jsonMemberFields`, `jsonBodyFields`) replace ~50 hand-rolled `jsonEscape` interpolation fragments across all renderers — every string value is escaped exactly once by construction
+- One `DeadlineScan` chassis (deadline, result queue, unreadable-file counter, parallel per-file/per-line scanning) behind `grepFiles`, `findReferences`, and `findImports`
+- Shared `pathPredicate` for the `--no-tests`/`--path`/`--exclude-path` filter chain (previously copied in `filterSymbols`, `filterRefs`, `grepFiles`, `astPatternSearch`, `tests`)
+- One `nameMatchTier` classifier (exact/prefix/contains/reverse-contains/camelCase) behind symbol search, file search, and owner-scoped suggestions
+- `requireArg` helper replaces the 21 identical `args.headOption match … UsageError` command preambles
+- `buildMultiIndex` builds the inverted lazy indexes (`parentIndex`, `typeParamParentIndex`, `annotationIndex`); `distinctSymbols` uses `distinctBy`
+- Java extraction shares `javaParams`/`javaMethodSig`/`javaFieldInfo`/`javaLine` between file-symbol and member extraction (signatures can no longer drift apart), and Java body extraction uses one `addBody` slice helper
+- `findTypeDefs` names the repeated "definitions that are types" lookup; `SymbolKind.label`, `Confidence.label/explanation`, `refCategoryOrder`, `wildcardImportPkg`, `pkgSuffix`, `numberedLine`, `renderShown` (the `... and N more` footer), and a single recursive hierarchy printer replace their scattered copies
+- `renderSourceBlocks` reads each file at most once for context windows (previously twice per block in text mode); context slicing shares one `contextWindow` helper and `readSourceLines`
+- `coverage` computes its not-found hint in the command instead of inside the renderer; `bench.scala` is `return`-free
+- New tests: a structural JSON validator sweeps every `--json` command output; locks on search ranking, overview package-dependency edges, Java signature consistency, truncation footers, and context-line rendering
 - New `clibase` Mill module — app-agnostic CLI plumbing usable as a base for other CLIs: declarative flag registry (each flag declared once: spellings, value shape, default, help text), single-pass lenient parser (unknown `--long` flags ignored), typed `Flags` bag, generated `Options:` help, `Timings`, `OutputBudget` (line-boundary truncation), `BatchLoop` (stdin REPL)
 - The self-contained `asciiGraph` package moved from `src/graph/` to its own `graph` Mill module
 - Deleted `ParsedFlags` (45 parallel fields), the hand-written parser match, and the hand-written options help — flag spellings, defaults, and help text now live in one declaration per flag in `src/flags.scala`, and `CommandContext` is built in a single place (`flagsToContext`)

--- a/clibase/src/flags.scala
+++ b/clibase/src/flags.scala
@@ -77,7 +77,8 @@ object Flag {
 
 /** An application's full flag set, in help-display order. */
 final class FlagRegistry(val flags: List[Flag[?]]) {
-  private[clibase] val byName: Map[String, Flag[?]] =
+  /** Lookup of every accepted spelling to its flag declaration. */
+  val byName: Map[String, Flag[?]] =
     flags.iterator.flatMap(f => f.names.map(_ -> f)).toMap
 
   /** Generated `Options:` section body — one line per flag, declaration order. */

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,25 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Dedup refactor: extract reusable units across src/ (no behavior change except noted)
+
+- [x] JSON emission helpers (`jStr`/`jArr`/`jStrArr`/`jOpt`/`jsonMemberFields`/`jsonBodyFields`) replacing ~50 hand-rolled `jsonEscape` interpolation fragments in `format.scala`
+- [x] Bug fix: `grep --json` emits invalid JSON when the auto-corrected pattern contains `\` or `"` (unescaped `"corrected"` hint in `cmdGrep`)
+- [x] `overview --architecture/--concise` reads imports from the index (`WorkspaceIndex.fileImports`) instead of re-parsing every file from disk; reuses `parseImportTarget` instead of the hand-rolled lastDot package split (~3.7s → warm-query latency on scala3)
+- [x] Deadline-scan chassis (`DeadlineScan`): one shared parallel file-scan (deadline + result queue + unreadable counter + stderr report) behind `grepFiles`, `findReferences`, `findImports`; behavior fix: per-line deadline expiry now sets `timedOut` in all three
+- [x] Shared path/test filter predicate (`pathPredicate`) behind `filterSymbols`, `filterRefs`, `grepFiles`, `astPatternSearch`, `cmdTests`
+- [x] `requireArg` helper for the 21 identical `args.headOption match … UsageError` command preambles
+- [x] `buildMultiIndex` helper for the inverted lazy indexes (`parentIndex`, `typeParamParentIndex`, `annotationIndex`); `distinctBy` for `distinctSymbols`
+- [x] Shared name-match tier classifier (`nameMatchTier`) behind `search`, `searchFiles`, `mkOwnerScopedSuggestions`
+- [x] Context-window slicing helper + `readSourceLines` reuse in `format.scala` (fixes `renderSourceBlocks` reading the same file twice)
+- [x] Numbered source-line printer + member-line formatters; behavior change: line numbers uniformly left-aligned (refs `-C` previously right-aligned)
+- [x] `renderShown` truncation-footer helper across the render sites
+- [x] Java extraction helpers (`javaParams`, `javaMethodSig`, `javaFieldInfo`, `javaLine`, `addBody`) deduplicating symbol vs member vs body extraction
+- [x] `findTypeDefs` shared type-definition lookup across `members`/`body`/`def`/inherited-member collection
+- [x] Shared constants: `refCategoryOrder`, `Confidence.label/explanation`, `wildcardImportPkg`, `SymbolKind.label`; one recursive hierarchy printer for both directions
+- [x] Policy/layering: removed `return` from `bench.scala`; graph-command flag strip-list derived from `scalexFlags` registry (fixes `graph --render … --limit 5` corrupting the edge list); not-found hint computed in `cmdCoverage` instead of the renderer
+- [x] Guard tests: structural JSON validator sweep over every `--json` command; locks on search ranking, overview package deps, Java signature consistency, truncation footers, context rendering
+
 ### clibase: reusable CLI base module + graph module extraction
 
 - [x] New `clibase` Mill module — app-agnostic CLI plumbing: declarative flag registry (declare a flag once: names, value shape, default, help), single-pass lenient parser (unknown `--long` flags ignored), typed `Flags` bag, generated options help, `Timings`, `OutputBudget` (line-boundary truncation), `BatchLoop` (stdin REPL)

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -199,10 +199,8 @@ def astPatternSearch(idx: WorkspaceIndex, workspace: Path,
                      bodyContains: Option[String], noTests: Boolean,
                      pathFilter: Option[String], excludePath: Option[String] = None,
                      limit: Int): List[AstPatternMatch] = {
-  var candidates = idx.symbols.filter(s => typeKinds.contains(s.kind))
-  if noTests then candidates = candidates.filter(s => !isTestFile(s.file, workspace))
-  pathFilter.foreach { p => candidates = candidates.filter(s => matchesPath(s.file, p, workspace)) }
-  excludePath.foreach { p => candidates = candidates.filter(s => !matchesPath(s.file, p, workspace)) }
+  val keep = pathPredicate(noTests, pathFilter, excludePath, workspace)
+  var candidates = idx.symbols.filter(s => typeKinds.contains(s.kind) && keep(s.file))
 
   // Filter by extends
   extendsTrait.foreach { traitName =>

--- a/src/bench.scala
+++ b/src/bench.scala
@@ -147,8 +147,9 @@ def benchIndexBuild(workspace: Path, warmup: Int, iters: Int): BenchResult =
       |  --warmup N         Warmup iterations (default: 5)
       |  --iterations N     Measured iterations (default: 20)
       |""".stripMargin)
-    return
+  else runBenchCli(argList)
 
+private def runBenchCli(argList: List[String]): Unit =
   val warmup = argList.indexOf("--warmup") match
     case -1 => 5
     case i => argList.lift(i + 1).flatMap(_.toIntOption).getOrElse(5)
@@ -176,26 +177,28 @@ def benchIndexBuild(workspace: Path, warmup: Int, iters: Int): BenchResult =
 
   def run(name: String): Unit =
     println(s"[$name]")
-    val result = name match
-      case "extract-single" => benchExtractSingle(workspace, warmup, iterations)
+    val result: Option[BenchResult] = name match
+      case "extract-single" => Some(benchExtractSingle(workspace, warmup, iterations))
       case "extract-batch" =>
         val r1 = benchExtractBatch(workspace, warmup, iterations)
         printResult(r1)
-        benchExtractBatchParallel(workspace, warmup, iterations)
-      case "bloom-build" => benchBloomBuild(workspace, warmup, iterations)
-      case "persistence-save" => benchPersistenceSave(workspace, warmup, iterations)
+        Some(benchExtractBatchParallel(workspace, warmup, iterations))
+      case "bloom-build" => Some(benchBloomBuild(workspace, warmup, iterations))
+      case "persistence-save" => Some(benchPersistenceSave(workspace, warmup, iterations))
       case "persistence-load" =>
         val r1 = benchPersistenceLoad(workspace, warmup, iterations)
         printResult(r1)
-        benchPersistenceLoadNoBlooms(workspace, warmup, iterations)
-      case "search" => benchSearch(workspace, warmup, iterations)
-      case "refs" => benchRefs(workspace, warmup, iterations)
-      case "index-cold" => benchIndexBuild(workspace, warmup, math.min(iterations, 5))
+        Some(benchPersistenceLoadNoBlooms(workspace, warmup, iterations))
+      case "search" => Some(benchSearch(workspace, warmup, iterations))
+      case "refs" => Some(benchRefs(workspace, warmup, iterations))
+      case "index-cold" => Some(benchIndexBuild(workspace, warmup, math.min(iterations, 5)))
       case _ =>
         println(s"  Unknown benchmark: $name")
-        return
-    printResult(result)
-    println()
+        None
+    result.foreach { r =>
+      printResult(r)
+      println()
+    }
 
   if benchName == "all" then
     val allBenches = List("extract-single", "extract-batch", "bloom-build",

--- a/src/cli.scala
+++ b/src/cli.scala
@@ -1,5 +1,5 @@
 import java.nio.file.{Files, Path}
-import clibase.{BatchLoop, Flags, Timings}
+import clibase.{BatchLoop, Flag, Flags, Timings}
 
 // ── CLI entry point ─────────────────────────────────────────────────────────
 
@@ -79,16 +79,22 @@ private def runCli(f: Flags, args: List[String]): Unit =
       }
 
     case "graph" :: _ =>
-      // graph command doesn't need workspace index — extract raw args after "graph", strip global flags
+      // graph command doesn't need workspace index — extract raw args after "graph",
+      // stripping every registry flag (derived from scalexFlags, so a newly added
+      // global flag can never leak into the edge-list args). Graph-local flags
+      // like --render/--unicode are not in the registry and pass through; --json
+      // is stripped here but already reflected in ctx.jsonOutput.
       val afterGraph = args.dropWhile(_ != "graph").drop(1)
       val graphArgs = {
         val buf = scala.collection.mutable.ListBuffer[String]()
         var i = 0
         while i < afterGraph.size do
-          afterGraph(i) match
-            case "-w" | "--workspace" | "--max-output" | "--in-package" => i += 1 // skip flag + value
-            case "--timings" | "--json" | "--each-method" => () // skip standalone flags already parsed
-            case other => buf += other
+          scalexFlags.byName.get(afterGraph(i)) match
+            case Some(_: Flag.BooleanFlag) => () // skip standalone flag
+            case Some(_: Flag.OptionalIntFlag) =>
+              if i + 1 < afterGraph.size && afterGraph(i + 1).toIntOption.isDefined then i += 1
+            case Some(_) => i += 1 // value-taking flag: skip its value too
+            case None => buf += afterGraph(i)
           i += 1
         buf.toList
       }

--- a/src/command-helpers.scala
+++ b/src/command-helpers.scala
@@ -3,6 +3,14 @@ import scala.collection.mutable
 
 // ── Command helpers ─────────────────────────────────────────────────────────
 
+/** Standard command preamble: the first positional arg is required; without it
+  * the command answers with its usage line. */
+def requireArg(args: List[String], usage: String)(f: String => CmdResult): CmdResult =
+  args.headOption match {
+    case None => CmdResult.UsageError(usage)
+    case Some(arg) => f(arg)
+  }
+
 def hasRegexHint(pattern: String): Boolean =
   pattern.contains("\\|")
 
@@ -52,8 +60,7 @@ def mkNotFoundWithSuggestions(symbol: String, ctx: CommandContext, cmd: String):
 
 /** Build owner-scoped suggestions ranked by similarity to `symbol`. */
 def mkOwnerScopedSuggestions(symbol: String, owner: String, ctx: CommandContext): List[String] =
-  val ownerDefs = filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
-    .filter(s => typeKinds.contains(s.kind))
+  val ownerDefs = filterSymbols(findTypeDefs(owner, ctx), ctx.copy(kindFilter = None))
   val members = ownerDefs.headOption.toList.flatMap(s => extractMembers(s.file, s.name, Some(s.kind)))
   // Rank by similarity: exact > prefix > contains > rest
   val lower = symbol.toLowerCase
@@ -62,14 +69,15 @@ def mkOwnerScopedSuggestions(symbol: String, owner: String, ctx: CommandContext)
   val contains = mutable.ListBuffer.empty[MemberInfo]
   val rest = mutable.ListBuffer.empty[MemberInfo]
   members.foreach { m =>
-    val n = m.name.toLowerCase
-    if n == lower then exact += m
-    else if n.startsWith(lower) then prefix += m
-    else if n.contains(lower) then contains += m
-    else rest += m
+    nameMatchTier(lower, m.name) match {
+      case Some(MatchTier.Exact)    => exact += m
+      case Some(MatchTier.Prefix)   => prefix += m
+      case Some(MatchTier.Contains) => contains += m
+      case _                        => rest += m
+    }
   }
   (exact.toList ++ prefix.toList ++ contains.toList ++ rest.toList).take(5).map { m =>
-    s"${m.kind.toString.toLowerCase} ${m.name} in $owner"
+    s"${m.kind.label} ${m.name} in $owner"
   }
 
 // ── Package resolution (shared by package, api, summary) ────────────────────
@@ -107,26 +115,26 @@ def withResolvedPackage(pkg: String, ctx: CommandContext, cmd: String)(f: String
 
 // ── Shared filters ──────────────────────────────────────────────────────────
 
+/** The --no-tests / --path / --exclude-path predicate for `ctx`, or None when
+  * no file-level filters are active (callers skip the pass entirely). */
+private def ctxPathPredicate(ctx: CommandContext): Option[Path => Boolean] =
+  if ctx.noTests || ctx.pathFilter.isDefined || ctx.excludePath.isDefined then
+    Some(pathPredicate(ctx.noTests, ctx.pathFilter, ctx.excludePath, ctx.workspace))
+  else None
+
 def filterSymbols(symbols: List[SymbolInfo], ctx: CommandContext): List[SymbolInfo] =
   var r = symbols
   ctx.kindFilter.foreach { k =>
     val kk = k.toLowerCase
-    r = r.filter(_.kind.toString.toLowerCase == kk)
+    r = r.filter(_.kind.label == kk)
   }
-  if ctx.noTests then r = r.filter(s => !isTestFile(s.file, ctx.workspace))
-  ctx.pathFilter.foreach { p => r = r.filter(s => matchesPath(s.file, p, ctx.workspace)) }
-  ctx.excludePath.foreach { p => r = r.filter(s => !matchesPath(s.file, p, ctx.workspace)) }
-  ctx.inPackageFilter.foreach { pkg =>
-    val prefix = pkg + "."
-    r = r.filter(s => s.packageName == pkg || s.packageName.startsWith(prefix))
-  }
+  ctxPathPredicate(ctx).foreach { keep => r = r.filter(s => keep(s.file)) }
+  ctx.inPackageFilter.foreach { pkg => r = symbolsInPackage(pkg, r) }
   r
 
 def filterRefs(refs: List[Reference], ctx: CommandContext): List[Reference] =
   var r = refs
-  if ctx.noTests then r = r.filter(ref => !isTestFile(ref.file, ctx.workspace))
-  ctx.pathFilter.foreach { p => r = r.filter(ref => matchesPath(ref.file, p, ctx.workspace)) }
-  ctx.excludePath.foreach { p => r = r.filter(ref => !matchesPath(ref.file, p, ctx.workspace)) }
+  ctxPathPredicate(ctx).foreach { keep => r = r.filter(ref => keep(ref.file)) }
   ctx.inPackageFilter.foreach { pkg =>
     val prefix = pkg + "."
     r = r.filter { ref =>
@@ -141,6 +149,10 @@ def filterRefs(refs: List[Reference], ctx: CommandContext): List[Reference] =
 // ── Shared constants ─────────────────────────────────────────────────────────
 
 val typeKinds: Set[SymbolKind] = Set(SymbolKind.Class, SymbolKind.Trait, SymbolKind.Object, SymbolKind.Enum)
+
+/** Definitions of `name` that are types (class/trait/object/enum). */
+def findTypeDefs(name: String, ctx: CommandContext): List[SymbolInfo] =
+  ctx.idx.findDefinition(name).filter(s => typeKinds.contains(s.kind))
 
 // ── Stdlib package detection ─────────────────────────────────────────────────
 
@@ -190,7 +202,7 @@ private def collectInheritedMembersImpl(sym: SymbolInfo, ctx: CommandContext): (
     parentNames.foreach { pName =>
       if !visited.contains(pName.toLowerCase) then {
         visited += pName.toLowerCase
-        val parentDefs = ctx.idx.findDefinition(pName).filter(s => typeKinds.contains(s.kind))
+        val parentDefs = findTypeDefs(pName, ctx)
         parentDefs.headOption.foreach { pd =>
           val parentMembers = extractMembers(pd.file, pd.name, Some(pd.kind))
           parentMembers.foreach(m => allParentKeys += ((name = m.name, kind = m.kind)))

--- a/src/commands/annotated.scala
+++ b/src/commands/annotated.scala
@@ -1,7 +1,5 @@
 def cmdAnnotated(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex annotated <annotation>")
-    case Some(query) =>
+  requireArg(args, "Usage: scalex annotated <annotation>") { query =>
       val annot = query.stripPrefix("@")
       val results = filterSymbols(ctx.idx.findAnnotated(annot), ctx)
       CmdResult.SymbolList(
@@ -9,3 +7,4 @@ def cmdAnnotated(args: List[String], ctx: CommandContext): CmdResult =
         symbols = results,
         total = results.size,
         emptyMessage = s"No symbols with @$annot annotation found")
+  }

--- a/src/commands/api.scala
+++ b/src/commands/api.scala
@@ -1,7 +1,5 @@
 def cmdApi(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex api <package>")
-    case Some(pkg) =>
+  requireArg(args, "Usage: scalex api <package>") { pkg =>
       withResolvedPackage(pkg, ctx, "api") { resolvedPkg =>
         val surface = ctx.idx.findApiSurface(resolvedPkg, ctx.usedByFilter)
         // Apply kind/test/path filters to the symbols
@@ -17,3 +15,4 @@ def cmdApi(args: List[String], ctx: CommandContext): CmdResult =
           internalOnly = internal.map(_.symbol.name).sorted
         )
       }
+  }

--- a/src/commands/body.scala
+++ b/src/commands/body.scala
@@ -1,13 +1,10 @@
 def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex body <symbol> [--in <owner>]")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex body <symbol> [--in <owner>]") { symbol =>
       // Find files containing the symbol
       val defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
       val ownerFiles = ctx.inOwner match
         case Some(owner) =>
-          filterSymbols(ctx.idx.findDefinition(owner), ctx.copy(kindFilter = None))
-            .filter(s => typeKinds.contains(s.kind)).map(_.file).distinct
+          filterSymbols(findTypeDefs(owner, ctx), ctx.copy(kindFilter = None)).map(_.file).distinct
         case None => Nil
       val filesToSearch = if defs.nonEmpty then {
         // When --in is specified, also include the owner's files — the symbol may
@@ -30,8 +27,7 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
       val (displayName, effectiveBlocks) =
         splitOwnerMember(symbol) match {
           case Some((ownerName, memberName)) if blocks.isEmpty && ctx.inOwner.isEmpty =>
-            val dottedOwnerFiles = filterSymbols(ctx.idx.findDefinition(ownerName), ctx)
-              .filter(s => typeKinds.contains(s.kind))
+            val dottedOwnerFiles = filterSymbols(findTypeDefs(ownerName, ctx), ctx)
               .map(_.file).distinct
             val dottedBlocks = dottedOwnerFiles.flatMap { f =>
               extractBody(f, memberName, Some(ownerName)).map(b => (file = f, body = b))
@@ -55,3 +51,4 @@ def cmdBody(args: List[String], ctx: CommandContext): CmdResult =
         CmdResult.NotFound(msg, scopedHint)
       else
         CmdResult.SourceBlocks(displayName, effectiveBlocks, ctx.contextLines, ctx.showImports)
+  }

--- a/src/commands/context-cmd.scala
+++ b/src/commands/context-cmd.scala
@@ -1,9 +1,7 @@
 import java.nio.file.Path
 
 def cmdContext(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex context <file:line>")
-    case Some(arg) =>
+  requireArg(args, "Usage: scalex context <file:line>") { arg =>
       val parts = arg.split(":")
       if parts.length < 2 then
         CmdResult.UsageError("Usage: scalex context <file:line> (e.g. src/Main.scala:42)")
@@ -16,3 +14,4 @@ def cmdContext(args: List[String], ctx: CommandContext): CmdResult =
             val resolved = if Path.of(filePath).isAbsolute then Path.of(filePath) else ctx.workspace.resolve(filePath)
             val scopes = extractScopes(resolved, line)
             CmdResult.Scopes(resolved, line, scopes)
+  }

--- a/src/commands/coverage.scala
+++ b/src/commands/coverage.scala
@@ -1,8 +1,9 @@
 def cmdCoverage(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex coverage <symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex coverage <symbol>") { symbol =>
       val refs = ctx.idx.findReferences(symbol).results
       val testRefs = refs.filter(r => isTestFile(r.file, ctx.workspace))
       val testFiles = testRefs.map(r => ctx.workspace.relativize(r.file).toString).distinct
-      CmdResult.CoverageReport(symbol, refs.size, testRefs, testFiles)
+      // Hint computed here so the renderer stays a pure formatter
+      val hint = if refs.isEmpty then Some(mkNotFoundWithSuggestions(symbol, ctx, "coverage")) else None
+      CmdResult.CoverageReport(symbol, refs.size, testRefs, testFiles, hint)
+  }

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -1,7 +1,5 @@
 def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex def <symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex def <symbol>") { symbol =>
       var results = filterSymbols(ctx.idx.findDefinition(symbol), ctx)
       results = rankSymbols(results, ctx.workspace)
       // If no results and symbol contains ".", try Owner.member resolution
@@ -25,11 +23,12 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
           header = s"""Definition of "$symbol":""",
           symbols = results,
           total = results.size)
+  }
 
 /** Resolve Owner.member syntax: if Owner is a type, extract its members and filter to the member name */
 private def resolveDottedMember(symbol: String, ctx: CommandContext): Option[List[SymbolInfo]] = {
   splitOwnerMember(symbol).flatMap { (ownerName, memberName) =>
-    val ownerDefs = filterSymbols(ctx.idx.findDefinition(ownerName), ctx).filter(s => typeKinds.contains(s.kind))
+    val ownerDefs = filterSymbols(findTypeDefs(ownerName, ctx), ctx)
     val memberResults = ownerDefs.flatMap { owner =>
       val members = extractMembers(owner.file, simpleNameOf(ownerName))
       members.filter(_.name.equalsIgnoreCase(memberName)).map { m =>

--- a/src/commands/deps.scala
+++ b/src/commands/deps.scala
@@ -1,7 +1,5 @@
 def cmdDeps(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex deps <symbol> [--depth N]")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex deps <symbol> [--depth N]") { symbol =>
       val depth = (if ctx.maxDepth < 0 then 1 else ctx.maxDepth).max(1).min(5)
       val (importDeps, bodyDeps) = extractDeps(ctx.idx, symbol, ctx.workspace, maxDepth = depth)
       if importDeps.isEmpty && bodyDeps.isEmpty then
@@ -10,3 +8,4 @@ def cmdDeps(args: List[String], ctx: CommandContext): CmdResult =
           mkNotFoundWithSuggestions(symbol, ctx, "deps"))
       else
         CmdResult.Dependencies(symbol, importDeps, bodyDeps)
+  }

--- a/src/commands/diff.scala
+++ b/src/commands/diff.scala
@@ -2,9 +2,7 @@ import scala.collection.mutable
 import java.nio.file.Files
 
 def cmdDiff(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex diff <git-ref> (e.g. scalex diff HEAD~1)")
-    case Some(ref) =>
+  requireArg(args, "Usage: scalex diff <git-ref> (e.g. scalex diff HEAD~1)") { ref =>
       val changedFiles = runGitDiff(ctx.workspace, ref)
       val added = mutable.ListBuffer.empty[DiffSymbol]
       val removed = mutable.ListBuffer.empty[DiffSymbol]
@@ -39,3 +37,4 @@ def cmdDiff(args: List[String], ctx: CommandContext): CmdResult =
       }
 
       CmdResult.SymbolDiff(ref, changedFiles.size, added.toList, removed.toList, modified.toList)
+  }

--- a/src/commands/doc.scala
+++ b/src/commands/doc.scala
@@ -1,7 +1,5 @@
 def cmdDoc(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex doc <Symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex doc <Symbol>") { symbol =>
       val defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx)
       if defs.isEmpty then
         CmdResult.NotFound(
@@ -12,3 +10,4 @@ def cmdDoc(args: List[String], ctx: CommandContext): CmdResult =
           DocEntryData(s, extractDoc(s.file, s.line))
         }
         CmdResult.DocEntries(symbol, entries)
+  }

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -1,9 +1,7 @@
 import scala.util.boundary, boundary.break
 
 def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex explain <symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex explain <symbol>") { symbol =>
       var defs = filterSymbols(ctx.idx.findDefinition(symbol), ctx.copy(kindFilter = None))
       defs = rankSymbols(defs, ctx.workspace)
       // If no results and symbol contains ".", try Owner.member resolution
@@ -104,6 +102,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
           CmdResult.Explanation(sym, doc, members, impls, importRefs, companion, expandedImpls,
             otherMatches = otherMatches, totalImpls = totalImpls, inherited = inherited,
             relatedTypes = relatedTypes)
+  }
 }
 
 private def expandImpls(impls: List[SymbolInfo], ctx: CommandContext,

--- a/src/commands/file.scala
+++ b/src/commands/file.scala
@@ -1,10 +1,9 @@
 def cmdFile(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex file <query>")
-    case Some(query) =>
+  requireArg(args, "Usage: scalex file <query>") { query =>
       val results = ctx.idx.searchFiles(query)
       CmdResult.StringList(
         header = s"""Found ${results.size} files matching "$query":""",
         items = results,
         total = results.size,
         emptyMessage = s"""Found 0 files matching "$query"\n  Hint: scalex indexes ${ctx.idx.fileCount} git-tracked .scala files.""")
+  }

--- a/src/commands/grep.scala
+++ b/src/commands/grep.scala
@@ -18,7 +18,7 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
         if isLiteralQuoted then Some(s"""  Note: invalid regex, treating as literal search: "$rawPattern"""")
         else if wasFixed then Some(s"""  Note: auto-corrected POSIX regex to Java regex: "$rawPattern" → "$pattern"""")
         else None
-      val hint = if wasFixed && !isLiteralQuoted then Some(s""","corrected":"$pattern"""") else None
+      val hint = if wasFixed && !isLiteralQuoted then Some(s""","corrected":${jStr(pattern)}""") else None
       ctx.inOwner match
         case Some(owner) if ctx.eachMethod =>
           // Per-method grep: iterate members, grep each body, report which methods matched

--- a/src/commands/hierarchy.scala
+++ b/src/commands/hierarchy.scala
@@ -1,7 +1,5 @@
 def cmdHierarchy(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex hierarchy <symbol> [--up] [--down] [--depth N]")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex hierarchy <symbol> [--up] [--down] [--depth N]") { symbol =>
       val depth = if ctx.maxDepth < 0 then 5 else ctx.maxDepth.max(1)
       buildHierarchy(ctx.idx, symbol, ctx.goUp, ctx.goDown, depth, ctx.workspace) match
         case None =>
@@ -10,3 +8,4 @@ def cmdHierarchy(args: List[String], ctx: CommandContext): CmdResult =
             mkNotFoundWithSuggestions(symbol, ctx, "hierarchy"))
         case Some(tree) =>
           CmdResult.HierarchyResult(symbol, tree)
+  }

--- a/src/commands/impl.scala
+++ b/src/commands/impl.scala
@@ -1,7 +1,5 @@
 def cmdImpl(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex impl <trait>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex impl <trait>") { symbol =>
       val results = filterSymbols(ctx.idx.findImplementations(symbol), ctx)
       if results.isEmpty then
         CmdResult.NotFound(
@@ -12,3 +10,4 @@ def cmdImpl(args: List[String], ctx: CommandContext): CmdResult =
           header = s"""Implementations of "$symbol" — ${results.size} found:""",
           symbols = results,
           total = results.size)
+  }

--- a/src/commands/imports.scala
+++ b/src/commands/imports.scala
@@ -1,7 +1,5 @@
 def cmdImports(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex imports <symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex imports <symbol>") { symbol =>
       val (rawResults, timedOut) = ctx.idx.findImports(symbol, strict = ctx.strict)
       val results = filterRefs(rawResults, ctx)
       if results.isEmpty then
@@ -15,3 +13,4 @@ def cmdImports(args: List[String], ctx: CommandContext): CmdResult =
           refs = results,
           timedOut = timedOut,
           useContext = false)
+  }

--- a/src/commands/members.scala
+++ b/src/commands/members.scala
@@ -1,9 +1,7 @@
 def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex members <Symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex members <Symbol>") { symbol =>
       val simpleName = simpleNameOf(symbol)
-      val typeDefs = ctx.idx.findDefinition(symbol).filter(s => typeKinds.contains(s.kind))
+      val typeDefs = findTypeDefs(symbol, ctx)
       val defs = filterSymbols(typeDefs, ctx)
 
       if defs.isEmpty then
@@ -29,3 +27,4 @@ def cmdMembers(args: List[String], ctx: CommandContext): CmdResult =
           )
         }
         CmdResult.MemberSections(symbol, sections)
+  }

--- a/src/commands/overrides.scala
+++ b/src/commands/overrides.scala
@@ -1,7 +1,5 @@
 def cmdOverrides(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex overrides <method> [--of <trait>]")
-    case Some(methodName) =>
+  requireArg(args, "Usage: scalex overrides <method> [--of <trait>]") { methodName =>
       var results = findOverrides(ctx.idx, methodName, ctx.ofTrait, ctx.limit)
       if ctx.withBody then
         results = results.map { o =>
@@ -19,3 +17,4 @@ def cmdOverrides(args: List[String], ctx: CommandContext): CmdResult =
         CmdResult.OverrideList(
           header = s"Overrides of $methodName$ofStr — ${results.size} found:",
           results = results)
+  }

--- a/src/commands/overview.scala
+++ b/src/commands/overview.scala
@@ -24,11 +24,15 @@ private def isStdlibPackageOnly(lowerName: String, symbolsByName: Map[String, Li
     case None => false
     case Some(syms) => syms.forall(s => isStdlibPackage(s.packageName.toLowerCase))
 
+/** The indexed symbol behind a lowercased parentIndex key, if any. */
+private def recoverSymbol(lower: String, symbolsByName: Map[String, List[SymbolInfo]]): Option[SymbolInfo] =
+  symbolsByName.get(lower).flatMap(_.headOption)
+
 private def recoverName(lower: String, symbolsByName: Map[String, List[SymbolInfo]]): String =
-  symbolsByName.get(lower).flatMap(_.headOption).map(_.name).getOrElse(lower)
+  recoverSymbol(lower, symbolsByName).map(_.name).getOrElse(lower)
 
 private def recoverSignature(lower: String, symbolsByName: Map[String, List[SymbolInfo]]): String =
-  symbolsByName.get(lower).flatMap(_.headOption).map(_.signature).getOrElse("")
+  recoverSymbol(lower, symbolsByName).map(_.signature).getOrElse("")
 
 def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
   var allSymbols = filterSymbols(ctx.idx.symbols, ctx)
@@ -53,24 +57,18 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
 
   val effectiveArch = ctx.architecture || ctx.focusPackage.isDefined || ctx.concise
 
-  // Architecture: compute package dependency graph from imports
+  // Architecture: compute package dependency graph from imports recorded at
+  // index time (no source reparse needed)
   val archPkgDeps: Map[String, Set[String]] = if effectiveArch then {
     val deps = mutable.HashMap.empty[String, mutable.HashSet[String]]
     allSymbols.groupBy(_.file).foreach { (file, syms) =>
       val filePkg = syms.headOption.map(_.packageName).getOrElse("")
       if filePkg.nonEmpty && !isJavaFile(file) then {
-        parseFile(file).foreach { tree =>
-          val (imports, _) = extractImports(tree)
-          imports.foreach { imp =>
-            val trimmed = imp.trim.stripPrefix("import ")
-            // Extract package from import: "com.example.Foo" → "com.example"
-            val lastDot = trimmed.lastIndexOf('.')
-            if lastDot > 0 then {
-              val importPkg = trimmed.substring(0, lastDot)
-              // Only track cross-package dependencies
-              if importPkg != filePkg && ctx.idx.packages.contains(importPkg) then {
-                deps.getOrElseUpdate(filePkg, mutable.HashSet.empty) += importPkg
-              }
+        ctx.idx.fileImports(file).foreach { imp =>
+          parseImportTarget(imp).foreach { (importPkg, _, _) =>
+            // Only track cross-package dependencies
+            if importPkg != filePkg && ctx.idx.packages.contains(importPkg) then {
+              deps.getOrElseUpdate(filePkg, mutable.HashSet.empty) += importPkg
             }
           }
         }

--- a/src/commands/package-cmd.scala
+++ b/src/commands/package-cmd.scala
@@ -3,9 +3,7 @@ private val kindRankMap: Map[SymbolKind, Int] = Map(
 ).withDefaultValue(4)
 
 def cmdPackage(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex package <pkg>")
-    case Some(pkg) =>
+  requireArg(args, "Usage: scalex package <pkg>") { pkg =>
       withResolvedPackage(pkg, ctx, "package") { resolvedPkg =>
         var symbols = filterSymbols(ctx.idx.symbols.filter(_.packageName == resolvedPkg), ctx)
         if ctx.explainMode then
@@ -23,3 +21,4 @@ def cmdPackage(args: List[String], ctx: CommandContext): CmdResult =
             symbols = symbols.filter(s => typeKinds.contains(s.kind))
           CmdResult.PackageSymbols(resolvedPkg, symbols)
       }
+  }

--- a/src/commands/refs.scala
+++ b/src/commands/refs.scala
@@ -1,7 +1,5 @@
 def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex refs <symbol>")
-    case Some(symbol) =>
+  requireArg(args, "Usage: scalex refs <symbol>") { symbol =>
       val targetPkgs = ctx.idx.symbolsByName.getOrElse(symbol.toLowerCase, Nil).map(_.packageName).toSet
       def filterByCategory(grouped: Map[RefCategory, List[Reference]]): (filtered: Map[RefCategory, List[Reference]], stderrHint: Option[String]) =
         ctx.categoryFilter match
@@ -24,11 +22,7 @@ def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
         val (categorized, timedOut) = ctx.idx.categorizeReferences(symbol, strict = ctx.strict)
         val rawGrouped = categorized.map((cat, refs) => (cat, filterRefs(refs, ctx)))
         val counts = rawGrouped.toList.map((cat, refs) => (category = cat, count = refs.size)).filter(_.count > 0)
-          .sortBy { entry =>
-            val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
-                             RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
-            order.indexOf(entry.category)
-          }
+          .sortBy(entry => refCategoryOrder.indexOf(entry.category))
         val total = counts.map(_.count).sum
         CmdResult.RefsSummary(symbol, counts, total, timedOut)
       else if ctx.categorize then
@@ -40,3 +34,4 @@ def cmdRefs(args: List[String], ctx: CommandContext): CmdResult =
         val (rawRefs, timedOut) = ctx.idx.findReferences(symbol, strict = ctx.strict)
         val results = filterRefs(rawRefs, ctx)
         CmdResult.FlatRefs(symbol, results, targetPkgs, timedOut)
+  }

--- a/src/commands/search.scala
+++ b/src/commands/search.scala
@@ -1,7 +1,5 @@
 def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex search <query>")
-    case Some(query) =>
+  requireArg(args, "Usage: scalex search <query>") { query =>
       var results = ctx.idx.search(query)
       ctx.searchMode.foreach {
         case "exact" =>
@@ -47,3 +45,4 @@ def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
           header = s"""Found ${results.size} symbols matching "$query":""",
           symbols = results,
           total = results.size)
+  }

--- a/src/commands/summary.scala
+++ b/src/commands/summary.scala
@@ -1,7 +1,5 @@
 def cmdSummary(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex summary <package>")
-    case Some(pkg) =>
+  requireArg(args, "Usage: scalex summary <package>") { pkg =>
       withResolvedPackage(pkg, ctx, "summary") { resolvedPkg =>
         val prefix = resolvedPkg + "."
         // Collect all packages that start with resolvedPkg (including itself)
@@ -17,3 +15,4 @@ def cmdSummary(args: List[String], ctx: CommandContext): CmdResult =
           .sortBy(-_.count)
         CmdResult.PackageSummary(resolvedPkg, subPackages, allSymbols.size)
       }
+  }

--- a/src/commands/symbols.scala
+++ b/src/commands/symbols.scala
@@ -1,17 +1,15 @@
 def cmdSymbols(args: List[String], ctx: CommandContext): CmdResult =
-  args.headOption match
-    case None => CmdResult.UsageError("Usage: scalex symbols <file>")
-    case Some(file) =>
+  requireArg(args, "Usage: scalex symbols <file>") { file =>
       val results = ctx.idx.fileSymbols(file)
       if ctx.summaryMode then
         val grouped = countByKind(results)
         if ctx.jsonOutput then
-          val byKind = grouped.map((k, count) => s""""${k.toString.toLowerCase}":$count""").mkString(",")
+          val byKind = grouped.map((k, count) => s""""${k.label}":$count""").mkString(",")
           // Consistent with overview/index-stats symbolsByKind format
-          println(s"""{"file":"${jsonEscape(file)}","symbolsByKind":{$byKind},"total":${results.size}}""")
+          println(s"""{"file":${jStr(file)},"symbolsByKind":{$byKind},"total":${results.size}}""")
           CmdResult.StringList(header = "", items = Nil, total = 0) // already printed
         else
-          val counts = grouped.map((k, count) => s"$count ${k.toString.toLowerCase}${if count > 1 then "s" else ""}").mkString(", ")
+          val counts = grouped.map((k, count) => s"$count ${k.label}${if count > 1 then "s" else ""}").mkString(", ")
           val summary = if counts.nonEmpty then s"$file: $counts (${results.size} total)" else s"$file: no symbols"
           CmdResult.StringList(header = "", items = Nil, total = 0, emptyMessage = summary)
       else
@@ -21,3 +19,4 @@ def cmdSymbols(args: List[String], ctx: CommandContext): CmdResult =
           total = results.size,
           emptyMessage = s"No symbols found in $file",
           truncate = false)
+  }

--- a/src/commands/tests.scala
+++ b/src/commands/tests.scala
@@ -1,8 +1,7 @@
 def cmdTests(args: List[String], ctx: CommandContext): CmdResult =
   val nameFilter = args.headOption
-  var filesToScan = ctx.idx.gitFiles.map(_.path).filter(f => isTestFile(f, ctx.workspace))
-  ctx.pathFilter.foreach { p => filesToScan = filesToScan.filter(f => matchesPath(f, p, ctx.workspace)) }
-  ctx.excludePath.foreach { p => filesToScan = filesToScan.filter(f => !matchesPath(f, p, ctx.workspace)) }
+  val keep = pathPredicate(noTests = false, ctx.pathFilter, ctx.excludePath, ctx.workspace)
+  val filesToScan = ctx.idx.gitFiles.map(_.path).filter(f => isTestFile(f, ctx.workspace) && keep(f))
   val extractedSuites = filesToScan.flatMap(extractTests).map { suite =>
     nameFilter match
       case Some(pattern) =>

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Path}
 import com.google.common.hash.{BloomFilter, Funnels}
 import scala.jdk.CollectionConverters.*
 import com.github.javaparser.{JavaParser as JP, ParserConfiguration}
-import com.github.javaparser.ast.{CompilationUnit as JavaCU}
+import com.github.javaparser.ast.{CompilationUnit as JavaCU, Node as JavaNode, NodeList}
 import com.github.javaparser.ast.body.*
 
 // ── Source reading & parsing helpers ─────────────────────────────────────────
@@ -595,6 +595,27 @@ private def parseJavaFile(path: Path): Option[JavaCU] =
 private def javaTypeToString(tpe: com.github.javaparser.ast.`type`.Type): String =
   tpe.asString()
 
+/** 1-based start line of a JavaParser node (0 when unknown). */
+private def javaLine(node: JavaNode): Int =
+  node.getBegin.map(_.line).orElse(0)
+
+/** "name: Type, name: Type" rendering of a Java parameter list. */
+private def javaParams(params: NodeList[Parameter]): String =
+  val buf = mutable.ListBuffer.empty[String]
+  params.forEach(p => buf += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
+  buf.mkString(", ")
+
+/** Scala-style `def` signature for a Java method — the one shape used by both
+  * file-symbol extraction and member extraction. */
+private def javaMethodSig(m: MethodDeclaration): String =
+  s"def ${m.getNameAsString}(${javaParams(m.getParameters)}): ${javaTypeToString(m.getType)}"
+
+/** Kind + Scala-style signature for one declarator of a Java field. */
+private def javaFieldInfo(f: FieldDeclaration, v: VariableDeclarator): (kind: SymbolKind, sig: String) =
+  val prefix = if f.isFinal then "val" else "var"
+  val kind = if f.isFinal then SymbolKind.Val else SymbolKind.Var
+  (kind = kind, sig = s"$prefix ${v.getNameAsString}: ${javaTypeToString(f.getCommonType)}")
+
 private def javaParentsFromType(td: TypeDeclaration[?]): List[String] =
   val buf = mutable.ListBuffer.empty[String]
   td match
@@ -614,16 +635,12 @@ private def javaAnnotations(decl: com.github.javaparser.ast.nodeTypes.NodeWithAn
   buf.toList
 
 private def javaTypeParams(td: TypeDeclaration[?]): List[String] =
+  val buf = mutable.ListBuffer.empty[String]
   td match
-    case cd: ClassOrInterfaceDeclaration =>
-      val buf = mutable.ListBuffer.empty[String]
-      cd.getTypeParameters.forEach(tp => buf += tp.getNameAsString)
-      buf.toList
-    case rd: RecordDeclaration =>
-      val buf = mutable.ListBuffer.empty[String]
-      rd.getTypeParameters.forEach(tp => buf += tp.getNameAsString)
-      buf.toList
-    case _ => Nil
+    case cd: ClassOrInterfaceDeclaration => cd.getTypeParameters.forEach(tp => buf += tp.getNameAsString)
+    case rd: RecordDeclaration => rd.getTypeParameters.forEach(tp => buf += tp.getNameAsString)
+    case _ => ()
+  buf.toList
 
 private def javaKindAndSig(td: TypeDeclaration[?]): (kind: SymbolKind, sig: String) =
   val name = td.getNameAsString
@@ -637,9 +654,7 @@ private def javaKindAndSig(td: TypeDeclaration[?]): (kind: SymbolKind, sig: Stri
     case cd: ClassOrInterfaceDeclaration if cd.isInterface =>
       (SymbolKind.Trait, s"interface $name$tps$ext")
     case rd: RecordDeclaration =>
-      val params = mutable.ListBuffer.empty[String]
-      rd.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
-      (SymbolKind.Class, s"record $name(${params.mkString(", ")})$ext")
+      (SymbolKind.Class, s"record $name(${javaParams(rd.getParameters)})$ext")
     case _ =>
       (SymbolKind.Class, s"class $name$tps$ext")
 
@@ -674,33 +689,18 @@ private def javaSymbolsFromCu(cu: JavaCU, file: Path): (symbols: List[SymbolInfo
     val parents = javaParentsFromType(td)
     val annots = javaAnnotations(td)
     val (kind, sig) = javaKindAndSig(td)
-    val line = td.getBegin.map(_.line).orElse(0)
-    buf += SymbolInfo(name, kind, file, line, pkg, parents, Nil, sig, annots)
+    buf += SymbolInfo(name, kind, file, javaLine(td), pkg, parents, Nil, sig, annots)
 
     // Extract methods
     td.getMethods.forEach { m =>
-      val mName = m.getNameAsString
-      val params = mutable.ListBuffer.empty[String]
-      m.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
-      val ret = javaTypeToString(m.getType)
-      val mSig = s"def $mName(${params.mkString(", ")}): $ret"
-      val mAnnots = javaAnnotations(m)
-      val mLine = m.getBegin.map(_.line).orElse(0)
-      buf += SymbolInfo(mName, SymbolKind.Def, file, mLine, pkg, Nil, Nil, mSig, mAnnots)
+      buf += SymbolInfo(m.getNameAsString, SymbolKind.Def, file, javaLine(m), pkg, Nil, Nil, javaMethodSig(m), javaAnnotations(m))
     }
 
     // Extract fields
     td.getFields.forEach { f =>
       f.getVariables.forEach { v =>
-        val vName = v.getNameAsString
-        val vType = javaTypeToString(f.getCommonType)
-        val isFinal = f.isFinal
-        val fKind = if isFinal then SymbolKind.Val else SymbolKind.Var
-        val prefix = if isFinal then "val" else "var"
-        val fSig = s"$prefix $vName: $vType"
-        val fAnnots = javaAnnotations(f)
-        val fLine = f.getBegin.map(_.line).orElse(0)
-        buf += SymbolInfo(vName, fKind, file, fLine, pkg, Nil, Nil, fSig, fAnnots)
+        val (fKind, fSig) = javaFieldInfo(f, v)
+        buf += SymbolInfo(v.getNameAsString, fKind, file, javaLine(f), pkg, Nil, Nil, fSig, javaAnnotations(f))
       }
     }
 
@@ -727,48 +727,30 @@ private def extractJavaMembers(file: Path, symbolName: String): List[MemberInfo]
         if td.getNameAsString == symbolName then
           // Methods
           td.getMethods.forEach { m =>
-            val params = mutable.ListBuffer.empty[String]
-            m.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
-            val ret = javaTypeToString(m.getType)
-            val sig = s"def ${m.getNameAsString}(${params.mkString(", ")}): $ret"
             val annots = javaAnnotations(m)
             val isOverride = annots.contains("Override")
-            val line = m.getBegin.map(_.line).orElse(0)
-            buf += MemberInfo(m.getNameAsString, SymbolKind.Def, line, sig, annots, isOverride)
+            buf += MemberInfo(m.getNameAsString, SymbolKind.Def, javaLine(m), javaMethodSig(m), annots, isOverride)
           }
 
           // Fields
           td.getFields.forEach { f =>
             f.getVariables.forEach { v =>
-              val vName = v.getNameAsString
-              val vType = javaTypeToString(f.getCommonType)
-              val isFinal = f.isFinal
-              val fKind = if isFinal then SymbolKind.Val else SymbolKind.Var
-              val prefix = if isFinal then "val" else "var"
-              val sig = s"$prefix $vName: $vType"
-              val annots = javaAnnotations(f)
-              val line = f.getBegin.map(_.line).orElse(0)
-              buf += MemberInfo(vName, fKind, line, sig, annots)
+              val (fKind, sig) = javaFieldInfo(f, v)
+              buf += MemberInfo(v.getNameAsString, fKind, javaLine(f), sig, javaAnnotations(f))
             }
           }
 
           // Constructors
           td.getConstructors.forEach { c =>
-            val params = mutable.ListBuffer.empty[String]
-            c.getParameters.forEach(p => params += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
-            val sig = s"def <init>(${params.mkString(", ")})"
-            val annots = javaAnnotations(c)
-            val line = c.getBegin.map(_.line).orElse(0)
-            buf += MemberInfo("<init>", SymbolKind.Def, line, sig, annots)
+            val sig = s"def <init>(${javaParams(c.getParameters)})"
+            buf += MemberInfo("<init>", SymbolKind.Def, javaLine(c), sig, javaAnnotations(c))
           }
 
           // Nested types
           td.getMembers.forEach {
             case nested: TypeDeclaration[?] =>
               val (kind, sig) = javaKindAndSig(nested)
-              val annots = javaAnnotations(nested)
-              val line = nested.getBegin.map(_.line).orElse(0)
-              buf += MemberInfo(nested.getNameAsString, kind, line, sig, annots)
+              buf += MemberInfo(nested.getNameAsString, kind, javaLine(nested), sig, javaAnnotations(nested))
             case _ =>
           }
 
@@ -776,8 +758,7 @@ private def extractJavaMembers(file: Path, symbolName: String): List[MemberInfo]
           td match
             case ed: EnumDeclaration =>
               ed.getEntries.forEach { entry =>
-                val line = entry.getBegin.map(_.line).orElse(0)
-                buf += MemberInfo(entry.getNameAsString, SymbolKind.Val, line, s"val ${entry.getNameAsString}")
+                buf += MemberInfo(entry.getNameAsString, SymbolKind.Val, javaLine(entry), s"val ${entry.getNameAsString}")
               }
             case _ =>
         else
@@ -798,34 +779,21 @@ private def extractJavaBody(file: Path, symbolName: String, ownerName: Option[St
     case (Some(sourceLines), Some(cu)) =>
       val buf = mutable.ListBuffer.empty[BodyInfo]
 
+      // Slice the node's source span if it defines `symbolName` under an accepted owner
+      def addBody(node: JavaNode, owner: String, name: String): Unit =
+        if name == symbolName && (ownerName.isEmpty || ownerName.contains(owner)) then
+          val sl = node.getBegin.map(_.line).orElse(1)
+          val el = node.getEnd.map(_.line).orElse(sl)
+          val body = ((sl - 1) until el).filter(_ < sourceLines.length).map(sourceLines(_)).mkString("\n")
+          buf += BodyInfo(owner, name, body, sl, el)
+
       def extractFromType(td: TypeDeclaration[?], currentOwner: String): Unit =
         val typeName = td.getNameAsString
 
-        // Check if the type itself matches
-        if symbolName == typeName && (ownerName.isEmpty || ownerName.contains(currentOwner)) then
-          val sl = td.getBegin.map(_.line).orElse(1)
-          val el = td.getEnd.map(_.line).orElse(sl)
-          val body = ((sl - 1) until el).filter(_ < sourceLines.length).map(sourceLines(_)).mkString("\n")
-          buf += BodyInfo(currentOwner, typeName, body, sl, el)
-
-        // Methods
-        td.getMethods.forEach { m =>
-          if m.getNameAsString == symbolName && (ownerName.isEmpty || ownerName.contains(typeName)) then
-            val sl = m.getBegin.map(_.line).orElse(1)
-            val el = m.getEnd.map(_.line).orElse(sl)
-            val body = ((sl - 1) until el).filter(_ < sourceLines.length).map(sourceLines(_)).mkString("\n")
-            buf += BodyInfo(typeName, m.getNameAsString, body, sl, el)
-        }
-
-        // Fields
+        addBody(td, currentOwner, typeName)
+        td.getMethods.forEach(m => addBody(m, typeName, m.getNameAsString))
         td.getFields.forEach { f =>
-          f.getVariables.forEach { v =>
-            if v.getNameAsString == symbolName && (ownerName.isEmpty || ownerName.contains(typeName)) then
-              val sl = f.getBegin.map(_.line).orElse(1)
-              val el = f.getEnd.map(_.line).orElse(sl)
-              val body = ((sl - 1) until el).filter(_ < sourceLines.length).map(sourceLines(_)).mkString("\n")
-              buf += BodyInfo(typeName, v.getNameAsString, body, sl, el)
-          }
+          f.getVariables.forEach(v => addBody(f, typeName, v.getNameAsString))
         }
 
         // Nested types — recurse

--- a/src/format.scala
+++ b/src/format.scala
@@ -1,5 +1,4 @@
 import java.nio.file.Path
-import scala.jdk.CollectionConverters.*
 
 // ── Formatting ──────────────────────────────────────────────────────────────
 
@@ -18,41 +17,63 @@ def jsonEscape(s: String): String =
     i += 1
   sb.toString
 
+// JSON emission helpers — every string value goes through jsonEscape exactly once.
+
+/** Quoted, escaped JSON string value. */
+def jStr(s: String): String = s"\"${jsonEscape(s)}\""
+
+/** JSON array from already-rendered element strings. */
+def jArr(items: Iterable[String]): String = items.mkString("[", ",", "]")
+
+/** JSON array of escaped strings. */
+def jStrArr(items: Iterable[String]): String = jArr(items.map(jStr))
+
+/** Escaped string value or null. */
+def jOpt(o: Option[String]): String = o.map(jStr).getOrElse("null")
+
 def jsonSymbol(s: SymbolInfo, workspace: Path): String =
-  val rel = jsonEscape(workspace.relativize(s.file).toString)
-  val parents = s.parents.map(p => s""""${jsonEscape(p)}"""").mkString("[", ",", "]")
-  val tpParents = s.typeParamParents.map(p => s""""${jsonEscape(p)}"""").mkString("[", ",", "]")
-  val annots = s.annotations.map(a => s""""${jsonEscape(a)}"""").mkString("[", ",", "]")
-  s"""{"name":"${jsonEscape(s.name)}","kind":"${s.kind.toString.toLowerCase}","file":"$rel","line":${s.line},"package":"${jsonEscape(s.packageName)}","parents":$parents,"typeParamParents":$tpParents,"signature":"${jsonEscape(s.signature)}","annotations":$annots}"""
+  val rel = workspace.relativize(s.file).toString
+  s"""{"name":${jStr(s.name)},"kind":${jStr(s.kind.label)},"file":${jStr(rel)},"line":${s.line},"package":${jStr(s.packageName)},"parents":${jStrArr(s.parents)},"typeParamParents":${jStrArr(s.typeParamParents)},"signature":${jStr(s.signature)},"annotations":${jStrArr(s.annotations)}}"""
 
 def jsonRef(r: Reference, workspace: Path): String =
-  val rel = jsonEscape(workspace.relativize(r.file).toString)
-  val alias = r.aliasInfo.map(a => s""""${jsonEscape(a)}"""").getOrElse("null")
-  s"""{"file":"$rel","line":${r.line},"context":"${jsonEscape(r.contextLine)}","alias":$alias}"""
+  val rel = workspace.relativize(r.file).toString
+  s"""{"file":${jStr(rel)},"line":${r.line},"context":${jStr(r.contextLine)},"alias":${jOpt(r.aliasInfo)}}"""
 
 def jsonRefWithContext(r: Reference, workspace: Path, contextN: Int): String =
-  val rel = jsonEscape(workspace.relativize(r.file).toString)
-  val alias = r.aliasInfo.map(a => s""""${jsonEscape(a)}"""").getOrElse("null")
-  val lines = try java.nio.file.Files.readAllLines(r.file).asScala catch
-    case _: Exception => Seq.empty
-  val total = lines.size
+  val rel = workspace.relativize(r.file).toString
+  val lines = readSourceLines(r.file).getOrElse(Array.empty[String])
+  val total = lines.length
   val startLine = math.max(1, r.line - contextN)
   val endLine = math.min(total, r.line + contextN)
-  val ctxLines = (startLine to endLine).map { i =>
-    s"""{"line":$i,"content":"${jsonEscape(lines(i - 1))}","match":${i == r.line}}"""
-  }.mkString("[", ",", "]")
-  s"""{"file":"$rel","line":${r.line},"context":"${jsonEscape(r.contextLine)}","alias":$alias,"contextLines":$ctxLines}"""
+  val ctxLines = jArr((startLine to endLine).map { i =>
+    s"""{"line":$i,"content":${jStr(lines(i - 1))},"match":${i == r.line}}"""
+  })
+  s"""{"file":${jStr(rel)},"line":${r.line},"context":${jStr(r.contextLine)},"alias":${jOpt(r.aliasInfo)},"contextLines":$ctxLines}"""
+
+// Text formatting helpers
+
+/** " (pkg)" suffix, or empty when the package is unknown. */
+def pkgSuffix(packageName: String): String =
+  if packageName.nonEmpty then s" ($packageName)" else ""
+
+/** One source line with a left-aligned number gutter: "42   | text". */
+private def numberedLine(lineNum: Int, content: String): String =
+  s"${lineNum.toString.padTo(4, ' ')} | $content"
+
+/** Print up to `limit` items, then a "... and N more" footer at `indent`. */
+private def renderShown[A](items: List[A], limit: Int, indent: String, footerSuffix: String = "")(printOne: A => Unit): Unit = {
+  items.take(limit).foreach(printOne)
+  if items.size > limit then println(s"$indent... and ${items.size - limit} more$footerSuffix")
+}
 
 def formatSymbol(s: SymbolInfo, workspace: Path): String =
   val rel = workspace.relativize(s.file)
-  val pkg = if s.packageName.nonEmpty then s" (${s.packageName})" else ""
-  s"  ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name}$pkg — $rel:${s.line}"
+  s"  ${s.kind.label.padTo(9, ' ')} ${s.name}${pkgSuffix(s.packageName)} — $rel:${s.line}"
 
 def formatSymbolVerbose(s: SymbolInfo, workspace: Path): String =
   val rel = workspace.relativize(s.file)
-  val pkg = if s.packageName.nonEmpty then s" (${s.packageName})" else ""
   val sig = if s.signature.nonEmpty then s"\n             ${s.signature}" else ""
-  s"  ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name}$pkg — $rel:${s.line}$sig"
+  s"  ${s.kind.label.padTo(9, ' ')} ${s.name}${pkgSuffix(s.packageName)} — $rel:${s.line}$sig"
 
 def formatRef(r: Reference, workspace: Path): String =
   val rel = workspace.relativize(r.file)
@@ -63,21 +84,17 @@ def formatRefWithContext(r: Reference, workspace: Path, contextN: Int): String =
   val rel = workspace.relativize(r.file)
   val alias = r.aliasInfo.map(a => s" [$a]").getOrElse("")
   val header = s"  $rel:${r.line}$alias"
-  val readLines = try Some(java.nio.file.Files.readAllLines(r.file).asScala) catch
-    case _: Exception => None
-  readLines match
+  readSourceLines(r.file) match
     case None => s"$header\n    > ${r.contextLine}"
     case Some(lines) =>
-      val total = lines.size
+      val total = lines.length
       val startLine = math.max(1, r.line - contextN)
       val endLine = math.min(total, r.line + contextN)
       val buf = new StringBuilder(header)
       var i = startLine
       while i <= endLine do
-        val lineContent = lines(i - 1)
         val marker = if i == r.line then ">" else " "
-        val lineNum = i.toString.reverse.padTo(4, ' ').reverse
-        buf.append(s"\n    $marker $lineNum | $lineContent")
+        buf.append(s"\n    $marker ${numberedLine(i, lines(i - 1))}")
         i += 1
       buf.toString
 
@@ -146,16 +163,14 @@ private def renderHint(h: NotFoundHint): Unit = {
 private def renderSymbolList(r: CmdResult.SymbolList, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val items = if r.truncate then r.symbols.take(ctx.limit) else r.symbols
-    val arr = items.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-    println(arr)
+    println(jArr(items.map(s => jsonSymbol(s, ctx.workspace))))
   } else {
     if r.symbols.isEmpty then {
       if r.emptyMessage.nonEmpty then println(r.emptyMessage)
     } else {
       println(r.header)
-      val items = if r.truncate then r.symbols.take(ctx.limit) else r.symbols
-      items.foreach(s => println(ctx.fmt(s, ctx.workspace)))
-      if r.truncate && r.total > ctx.limit then println(s"  ... and ${r.total - ctx.limit} more")
+      if r.truncate then renderShown(r.symbols, ctx.limit, "  ")(s => println(ctx.fmt(s, ctx.workspace)))
+      else r.symbols.foreach(s => println(ctx.fmt(s, ctx.workspace)))
     }
   }
 }
@@ -164,7 +179,7 @@ private def renderRefList(r: CmdResult.RefList, ctx: CommandContext): Unit = {
   r.stderrHint.foreach(System.err.println)
   if ctx.jsonOutput then {
     val jFn: Reference => String = if r.useContext then ctx.jRef else ref => jsonRef(ref, ctx.workspace)
-    val arr = r.refs.take(ctx.limit).map(jFn).mkString("[", ",", "]")
+    val arr = jArr(r.refs.take(ctx.limit).map(jFn))
     val hintStr = r.hint.getOrElse("")
     println(s"""{"results":$arr,"timedOut":${r.timedOut}$hintStr}""")
   } else {
@@ -173,8 +188,7 @@ private def renderRefList(r: CmdResult.RefList, ctx: CommandContext): Unit = {
     } else {
       println(r.header)
       val fFn: Reference => String = if r.useContext then ctx.fmtRef else ref => formatRef(ref, ctx.workspace)
-      r.refs.take(ctx.limit).foreach(ref => println(fFn(ref)))
-      if r.refs.size > ctx.limit then println(s"  ... and ${r.refs.size - ctx.limit} more")
+      renderShown(r.refs, ctx.limit, "  ")(ref => println(fFn(ref)))
     }
   }
 }
@@ -183,35 +197,25 @@ private def renderCategorizedRefs(r: CmdResult.CategorizedRefs, ctx: CommandCont
   r.stderrHint.foreach(System.err.println)
   if ctx.jsonOutput then {
     val entries = r.grouped.map { (cat, refs) =>
-      val arr = refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-      s""""${cat.toString}":$arr"""
+      s""""${cat.toString}":${jArr(refs.take(ctx.limit).map(ctx.jRef))}"""
     }.mkString(",")
     println(s"""{"categories":{$entries},"timedOut":${r.timedOut}}""")
   } else {
     val total = r.grouped.values.map(_.size).sum
     val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — $total found:$suffix""")
-    val confidenceOrder = List(Confidence.High, Confidence.Medium, Confidence.Low)
-    confidenceOrder.foreach { conf =>
+    Confidence.values.foreach { conf =>
       val catRefs = r.grouped.flatMap { (cat, refs) =>
         refs.map(ref => (cat, ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
       }.filter(_._3 == conf).toList
       if catRefs.nonEmpty then {
-        val label = conf match {
-          case Confidence.High   => "High confidence (import-matched)"
-          case Confidence.Medium => "Medium confidence (wildcard import)"
-          case Confidence.Low    => "Low confidence (no matching import)"
-        }
-        println(s"\n  $label:")
+        println(s"\n  ${conf.label} (${conf.explanation}):")
         val byCat = catRefs.groupBy(_._1)
-        val order = List(RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
-                         RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
-        order.foreach { cat =>
+        refCategoryOrder.foreach { cat =>
           byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
             val sorted = entries.sortBy((_, ref, _) => (path = ctx.workspace.relativize(ref.file).toString, line = ref.line))
             println(s"\n    ${cat.toString}:")
-            sorted.take(ctx.limit).foreach((_, ref, _) => println(s"    ${ctx.fmtRef(ref)}"))
-            if sorted.size > ctx.limit then println(s"      ... and ${sorted.size - ctx.limit} more")
+            renderShown(sorted, ctx.limit, "      ")((_, ref, _) => println(s"    ${ctx.fmtRef(ref)}"))
           }
         }
       }
@@ -221,8 +225,7 @@ private def renderCategorizedRefs(r: CmdResult.CategorizedRefs, ctx: CommandCont
 
 private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val arr = r.refs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-    println(s"""{"results":$arr,"timedOut":${r.timedOut}}""")
+    println(s"""{"results":${jArr(r.refs.take(ctx.limit).map(ctx.jRef))},"timedOut":${r.timedOut}}""")
   } else {
     val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — ${r.refs.size} found:$suffix""")
@@ -233,12 +236,7 @@ private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
     sorted.foreach { case (ref, conf) =>
       if shown < ctx.limit then {
         if !lastConf.contains(conf) then {
-          val label = conf match {
-            case Confidence.High   => "High confidence"
-            case Confidence.Medium => "Medium confidence"
-            case Confidence.Low    => "Low confidence"
-          }
-          println(s"\n  [$label]")
+          println(s"\n  [${conf.label}]")
           lastConf = Some(conf)
         }
         println(ctx.fmtRef(ref))
@@ -253,22 +251,20 @@ private def renderStringList(r: CmdResult.StringList, ctx: CommandContext): Unit
   if ctx.jsonOutput then {
     // Skip only when output was already printed (empty items + empty header + empty emptyMessage)
     if r.items.nonEmpty || r.header.nonEmpty || r.emptyMessage.nonEmpty then
-      val arr = r.items.take(ctx.limit).map(f => s""""${jsonEscape(f)}"""").mkString("[", ",", "]")
-      println(arr)
+      println(jStrArr(r.items.take(ctx.limit)))
   } else {
     if r.items.isEmpty then {
       if r.emptyMessage.nonEmpty then println(r.emptyMessage)
     } else {
       println(r.header)
-      r.items.take(ctx.limit).foreach(f => println(s"  $f"))
-      if r.total > ctx.limit then println(s"  ... and ${r.total - ctx.limit} more")
+      renderShown(r.items, ctx.limit, "  ")(f => println(s"  $f"))
     }
   }
 }
 
 private def renderIndexStats(r: CmdResult.IndexStats, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val byKind = r.symbolsByKind.map((k, c) => s""""${k.toString.toLowerCase}":$c""").mkString(",")
+    val byKind = r.symbolsByKind.map((k, c) => s""""${k.label}":$c""").mkString(",")
     println(s"""{"fileCount":${r.fileCount},"symbolCount":${r.symbolCount},"packageCount":${r.packageCount},"symbolsByKind":{$byKind},"indexTimeMs":${r.indexTimeMs},"cachedLoad":${r.cachedLoad},"parsedCount":${r.parsedCount},"skippedCount":${r.skippedCount},"parseFailures":${r.parseFailures}}""")
   } else {
     if r.cachedLoad then
@@ -295,12 +291,26 @@ private def renderInlineBody(body: Option[BodyInfo], indent: String): Unit =
   body.foreach { b =>
     val bodyLines = b.sourceText.split("\n")
     bodyLines.zipWithIndex.foreach { case (line, i) =>
-      println(s"$indent${(b.startLine + i).toString.padTo(4, ' ')} | $line")
+      println(s"$indent${numberedLine(b.startLine + i, line)}")
     }
   }
 
-private def jsonMemberBody(m: MemberInfo): String =
-  m.body.map(b => s""","body":"${jsonEscape(b.sourceText)}","bodyStartLine":${b.startLine},"bodyEndLine":${b.endLine}""").getOrElse("")
+/** `,"body":…,"bodyStartLine":…,"bodyEndLine":…` fields, or empty when there is no body. */
+private def jsonBodyFields(body: Option[BodyInfo]): String =
+  body.map(b => s""","body":${jStr(b.sourceText)},"bodyStartLine":${b.startLine},"bodyEndLine":${b.endLine}""").getOrElse("")
+
+/** The shared member-object core: `"name":…,"kind":…,"line":…,"signature":…` (no braces). */
+private def jsonMemberFields(m: MemberInfo): String =
+  s""""name":${jStr(m.name)},"kind":${jStr(m.kind.label)},"line":${m.line},"signature":${jStr(m.signature)}"""
+
+/** Member line in `members` text output: kind + signature (or name with --brief). */
+private def memberLine(m: MemberInfo, brief: Boolean): String =
+  if brief then s"${m.kind.label.padTo(5, ' ')} ${m.name.padTo(30, ' ')}"
+  else s"${m.kind.label.padTo(5, ' ')} ${m.signature.padTo(50, ' ')}"
+
+/** Member line in `explain` text output: kind + name (or signature with --verbose). */
+private def explainMemberLine(m: MemberInfo, verbose: Boolean): String =
+  s"${m.kind.label.padTo(5, ' ')} ${if verbose then m.signature else m.name}"
 
 private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContext): Unit = {
   // Slice a section's items using global running counters (skipLeft, showLeft).
@@ -315,27 +325,25 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
   if ctx.jsonOutput then {
     val allMembers = r.sections.flatMap { sec =>
       val ownMembers = sec.ownMembers.map { m =>
-        val rel = jsonEscape(ctx.workspace.relativize(sec.file).toString)
+        val rel = ctx.workspace.relativize(sec.file).toString
         val overrideJson = if m.isOverride then ""","isOverride":true""" else ""
-        val bodyJson = m.body.map(b => s""","body":"${jsonEscape(b.sourceText)}","bodyStartLine":${b.startLine},"bodyEndLine":${b.endLine}""").getOrElse("")
-        s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(r.symbol)}","ownerKind":"${sec.ownerKind.toString.toLowerCase}","package":"${jsonEscape(sec.packageName)}","inherited":false$overrideJson$bodyJson}"""
+        s"""{${jsonMemberFields(m)},"file":${jStr(rel)},"owner":${jStr(r.symbol)},"ownerKind":${jStr(sec.ownerKind.label)},"package":${jStr(sec.packageName)},"inherited":false$overrideJson${jsonBodyFields(m.body)}}"""
       }
       val inheritedMembers = sec.inherited.flatMap { (parentName, parentFile, parentPackage, members) =>
         members.map { m =>
-          val rel = parentFile.map(f => jsonEscape(ctx.workspace.relativize(f).toString)).getOrElse("")
-          s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(parentName)}","ownerKind":"inherited","package":"${jsonEscape(parentPackage)}","inherited":true}"""
+          val rel = parentFile.map(f => ctx.workspace.relativize(f).toString).getOrElse("")
+          s"""{${jsonMemberFields(m)},"file":${jStr(rel)},"owner":${jStr(parentName)},"ownerKind":"inherited","package":${jStr(parentPackage)},"inherited":true}"""
         }
       }
       val companionMembers = sec.companion.toList.flatMap { (compSym, compMembers) =>
-        val rel = jsonEscape(ctx.workspace.relativize(compSym.file).toString)
+        val rel = ctx.workspace.relativize(compSym.file).toString
         compMembers.map { m =>
-          s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}","file":"$rel","owner":"${jsonEscape(compSym.name)}","ownerKind":"companion","package":"${jsonEscape(compSym.packageName)}","inherited":false}"""
+          s"""{${jsonMemberFields(m)},"file":${jStr(rel)},"owner":${jStr(compSym.name)},"ownerKind":"companion","package":${jStr(compSym.packageName)},"inherited":false}"""
         }
       }
       ownMembers ++ inheritedMembers ++ companionMembers
     }
-    val paged = allMembers.drop(ctx.offset).take(ctx.limit)
-    println(paged.mkString("[", ",", "]"))
+    println(jArr(allMembers.drop(ctx.offset).take(ctx.limit)))
   } else {
     if r.sections.isEmpty then {
       println(s"""No class/trait/object/enum "${r.symbol}" found""")
@@ -345,8 +353,7 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
       var showLeft = ctx.limit
       r.sections.foreach { sec =>
         val rel = ctx.workspace.relativize(sec.file)
-        val pkg = if sec.packageName.nonEmpty then s" (${sec.packageName})" else ""
-        println(s"Members of ${sec.ownerKind.toString.toLowerCase} ${r.symbol}$pkg — $rel:${sec.line}:")
+        println(s"Members of ${sec.ownerKind.label} ${r.symbol}${pkgSuffix(sec.packageName)} — $rel:${sec.line}:")
         if sec.ownMembers.isEmpty then println("  (no members)")
         else {
           val (shown, omitted, newSkip, newShow) = sliceSection(sec.ownMembers, skipLeft, showLeft)
@@ -354,10 +361,7 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
           if shown.nonEmpty || omitted > 0 then println(s"  Defined in ${r.symbol}:")
           shown.foreach { m =>
             val overrideMarker = if m.isOverride then "  [override]" else ""
-            if !ctx.brief then
-              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}$overrideMarker")
-            else
-              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}$overrideMarker")
+            println(s"    ${memberLine(m, ctx.brief)} :${m.line}$overrideMarker")
             renderInlineBody(m.body, "      ")
           }
           if omitted > 0 then println(s"    ... and $omitted more")
@@ -366,30 +370,20 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
           val (shown, omitted, newSkip, newShow) = sliceSection(pMembers, skipLeft, showLeft)
           skipLeft = newSkip; showLeft = newShow
           if shown.nonEmpty || omitted > 0 then println(s"  Inherited from $parentName:")
-          shown.foreach { m =>
-            if !ctx.brief then
-              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
-            else
-              println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
-          }
+          shown.foreach(m => println(s"    ${memberLine(m, ctx.brief)} :${m.line}"))
           if omitted > 0 then println(s"    ... and $omitted more")
         }
         sec.companion.foreach { (compSym, compMembers) =>
           val compRel = ctx.workspace.relativize(compSym.file)
           if compMembers.isEmpty then {
-            println(s"\n  Companion ${compSym.kind.toString.toLowerCase} ${compSym.name} — $compRel:${compSym.line}:")
+            println(s"\n  Companion ${compSym.kind.label} ${compSym.name} — $compRel:${compSym.line}:")
             println("    (no members)")
           } else {
             val (shown, omitted, newSkip, newShow) = sliceSection(compMembers, skipLeft, showLeft)
             skipLeft = newSkip; showLeft = newShow
             if shown.nonEmpty || omitted > 0 then
-              println(s"\n  Companion ${compSym.kind.toString.toLowerCase} ${compSym.name} — $compRel:${compSym.line}:")
-            shown.foreach { m =>
-              if !ctx.brief then
-                println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.signature.padTo(50, ' ')} :${m.line}")
-              else
-                println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name.padTo(30, ' ')} :${m.line}")
-            }
+              println(s"\n  Companion ${compSym.kind.label} ${compSym.name} — $compRel:${compSym.line}:")
+            shown.foreach(m => println(s"    ${memberLine(m, ctx.brief)} :${m.line}"))
             if omitted > 0 then println(s"    ... and $omitted more")
           }
         }
@@ -401,16 +395,14 @@ private def renderMemberSections(r: CmdResult.MemberSections, ctx: CommandContex
 private def renderDocEntries(r: CmdResult.DocEntries, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val entries = r.entries.take(ctx.limit).map { e =>
-      val rel = jsonEscape(ctx.workspace.relativize(e.sym.file).toString)
-      val doc = e.doc.map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
-      s"""{"name":"${jsonEscape(e.sym.name)}","kind":"${e.sym.kind.toString.toLowerCase}","file":"$rel","line":${e.sym.line},"package":"${jsonEscape(e.sym.packageName)}","doc":$doc}"""
+      val rel = ctx.workspace.relativize(e.sym.file).toString
+      s"""{"name":${jStr(e.sym.name)},"kind":${jStr(e.sym.kind.label)},"file":${jStr(rel)},"line":${e.sym.line},"package":${jStr(e.sym.packageName)},"doc":${jOpt(e.doc)}}"""
     }
-    println(entries.mkString("[", ",", "]"))
+    println(jArr(entries))
   } else {
     r.entries.take(ctx.limit).foreach { e =>
       val rel = ctx.workspace.relativize(e.sym.file)
-      val pkg = if e.sym.packageName.nonEmpty then s" (${e.sym.packageName})" else ""
-      println(s"${e.sym.kind.toString.toLowerCase} ${r.symbol}$pkg — $rel:${e.sym.line}:")
+      println(s"${e.sym.kind.label} ${r.symbol}${pkgSuffix(e.sym.packageName)} — $rel:${e.sym.line}:")
       e.doc match {
         case Some(doc) => println(doc)
         case None => println("  (no scaladoc)")
@@ -423,31 +415,29 @@ private def renderDocEntries(r: CmdResult.DocEntries, ctx: CommandContext): Unit
 private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
   val d = r.data
   if ctx.jsonOutput then {
-    val kindJson = d.symbolsByKind.map((k, c) => s""""${k.toString.toLowerCase}":$c""").mkString("{", ",", "}")
-    val pkgJson = d.topPackages.map((p, c) => s"""{"package":"${jsonEscape(p)}","count":$c}""").mkString("[", ",", "]")
+    val kindJson = d.symbolsByKind.map((k, c) => s""""${k.label}":$c""").mkString("{", ",", "}")
+    val pkgJson = jArr(d.topPackages.map((p, c) => s"""{"package":${jStr(p)},"count":$c}"""))
     if d.hasArchitecture then {
       val depsJson = if ctx.concise then {
         // Concise JSON: top 10 most-connected packages only
         val topConnected = d.pkgDeps.toList.sortBy(-_._2.size).take(10)
         topConnected.map { (pkg, deps) =>
-          val dArr = deps.toList.sorted.take(10).map(dep => s""""${jsonEscape(dep)}"""").mkString("[", ",", "]")
-          s""""${jsonEscape(pkg)}":$dArr"""
+          s"""${jStr(pkg)}:${jStrArr(deps.toList.sorted.take(10))}"""
         }.mkString("{", ",", "}")
       } else {
         d.pkgDeps.map { (pkg, deps) =>
-          val dArr = deps.map(dep => s""""${jsonEscape(dep)}"""").mkString("[", ",", "]")
-          s""""${jsonEscape(pkg)}":$dArr"""
+          s"""${jStr(pkg)}:${jStrArr(deps)}"""
         }.mkString("{", ",", "}")
       }
-      val hubJson = d.hubTypes.map((n, c, sig) => s"""{"name":"${jsonEscape(n)}","score":$c,"signature":"${jsonEscape(sig)}"}""").mkString("[", ",", "]")
-      val focusPkgJson = d.focusPackage.map(p => s""","focusPackage":"${jsonEscape(p)}"""").getOrElse("")
+      val hubJson = jArr(d.hubTypes.map((n, c, sig) => s"""{"name":${jStr(n)},"score":$c,"signature":${jStr(sig)}}"""))
+      val focusPkgJson = d.focusPackage.map(p => s""","focusPackage":${jStr(p)}""").getOrElse("")
       val conciseJson = if ctx.concise then {
         val totalEdges = d.pkgDeps.values.map(_.size).sum
         s""","concise":true,"totalPackagesWithDeps":${d.pkgDeps.size},"totalEdges":$totalEdges"""
       } else ""
       println(s"""{"fileCount":${d.fileCount},"symbolCount":${d.symbolCount},"packageCount":${d.packageCount},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"packageDependencies":$depsJson,"hubTypes":$hubJson$focusPkgJson$conciseJson}""")
     } else {
-      val extJson = d.mostExtended.map((n, c, sig) => s"""{"name":"${jsonEscape(n)}","implementations":$c,"signature":"${jsonEscape(sig)}"}""").mkString("[", ",", "]")
+      val extJson = jArr(d.mostExtended.map((n, c, sig) => s"""{"name":${jStr(n)},"implementations":$c,"signature":${jStr(sig)}}"""))
       println(s"""{"fileCount":${d.fileCount},"symbolCount":${d.symbolCount},"packageCount":${d.packageCount},"symbolsByKind":$kindJson,"topPackages":$pkgJson,"mostExtended":$extJson}""")
     }
   } else if ctx.concise then {
@@ -457,7 +447,7 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
     println(s"Project: ${d.fileCount} files, ${d.symbolCount} symbols, ${d.packageCount} packages$focusNote\n")
 
     // Symbols by kind — single compact line
-    val kindLine = d.symbolsByKind.map((k, c) => s"${c} ${k.toString.toLowerCase}").mkString(", ")
+    val kindLine = d.symbolsByKind.map((k, c) => s"${c} ${k.label}").mkString(", ")
     println(s"Symbols: $kindLine\n")
 
     // Top packages — capped at conciseLimit
@@ -539,28 +529,38 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
   }
 }
 
+/** Context lines around a [startLine, endLine] body span, clamped to the file. */
+private def contextWindow(lines: Array[String], startLine: Int, endLine: Int, n: Int): (
+  before: Seq[(lineNum: Int, text: String)], after: Seq[(lineNum: Int, text: String)]
+) = {
+  val total = lines.length
+  val ctxStart = math.max(1, startLine - n)
+  val ctxEnd = math.min(total, endLine + n)
+  val before = (ctxStart until startLine).filter(i => i >= 1 && i <= total).map(i => (lineNum = i, text = lines(i - 1)))
+  val after = ((endLine + 1) to ctxEnd).filter(i => i >= 1 && i <= total).map(i => (lineNum = i, text = lines(i - 1)))
+  (before = before, after = after)
+}
+
 private def renderSourceBlocks(r: CmdResult.SourceBlocks, ctx: CommandContext): Unit = {
+  def windowFor(file: Path, b: BodyInfo): (before: Seq[(lineNum: Int, text: String)], after: Seq[(lineNum: Int, text: String)]) =
+    if r.contextLines > 0 then
+      contextWindow(readSourceLines(file).getOrElse(Array.empty[String]), b.startLine, b.endLine, r.contextLines)
+    else (before = Seq.empty, after = Seq.empty)
+
   if ctx.jsonOutput then {
     val arr = r.blocks.take(ctx.limit).map { (file, b) =>
-      val rel = jsonEscape(ctx.workspace.relativize(file).toString)
+      val rel = ctx.workspace.relativize(file).toString
       val importsJson = if r.showImports then
-        extractImportLines(file).map(imp => s""","imports":"${jsonEscape(imp)}"""").getOrElse("")
+        extractImportLines(file).map(imp => s""","imports":${jStr(imp)}""").getOrElse("")
       else ""
       val contextJson = if r.contextLines > 0 then
-        val lines = try java.nio.file.Files.readAllLines(file).asScala catch { case _: Exception => Seq.empty }
-        val total = lines.size
-        val ctxStart = math.max(1, b.startLine - r.contextLines)
-        val ctxEnd = math.min(total, b.endLine + r.contextLines)
-        val before = (ctxStart until b.startLine).filter(i => i >= 1 && i <= total).map(i => jsonEscape(lines(i - 1)))
-        val after = ((b.endLine + 1) to ctxEnd).filter(i => i >= 1 && i <= total).map(i => jsonEscape(lines(i - 1)))
-        val beforeJson = before.map(l => s""""$l"""").mkString("[", ",", "]")
-        val afterJson = after.map(l => s""""$l"""").mkString("[", ",", "]")
-        s""","contextBefore":$beforeJson,"contextAfter":$afterJson"""
+        val (before, after) = windowFor(file, b)
+        s""","contextBefore":${jStrArr(before.map(_.text))},"contextAfter":${jStrArr(after.map(_.text))}"""
       else ""
       val abstractJson = if b.isAbstract then ""","isAbstract":true""" else ""
-      s"""{"name":"${jsonEscape(b.symbolName)}","owner":"${jsonEscape(b.ownerName)}","file":"$rel","startLine":${b.startLine},"endLine":${b.endLine},"body":"${jsonEscape(b.sourceText)}"$abstractJson$importsJson$contextJson}"""
-    }.mkString("[", ",", "]")
-    println(arr)
+      s"""{"name":${jStr(b.symbolName)},"owner":${jStr(b.ownerName)},"file":${jStr(rel)},"startLine":${b.startLine},"endLine":${b.endLine},"body":${jStr(b.sourceText)}$abstractJson$importsJson$contextJson}"""
+    }
+    println(jArr(arr))
   } else {
     r.blocks.take(ctx.limit).foreach { (file, b) =>
       val ownerStr = if b.ownerName.nonEmpty then s" — ${b.ownerName}" else ""
@@ -575,30 +575,15 @@ private def renderSourceBlocks(r: CmdResult.SourceBlocks, ctx: CommandContext): 
       val label = if b.isAbstract then "Signature" else "Body"
       val abstractNote = if b.isAbstract then " (abstract, no body)" else ""
       println(s"$label of ${b.symbolName}$ownerStr — $rel:${b.startLine}$abstractNote:")
-      // Context lines before
-      if r.contextLines > 0 then
-        val lines = try java.nio.file.Files.readAllLines(file).asScala catch { case _: Exception => Seq.empty }
-        val total = lines.size
-        val ctxStart = math.max(1, b.startLine - r.contextLines)
-        (ctxStart until b.startLine).foreach { i =>
-          if i >= 1 && i <= total then
-            println(s"  ${i.toString.padTo(4, ' ')} | ${lines(i - 1)}")
-        }
-        if ctxStart < b.startLine then println("  ---")
+      val (before, after) = windowFor(file, b)
+      before.foreach((i, text) => println(s"  ${numberedLine(i, text)}"))
+      if before.nonEmpty then println("  ---")
       val bodyLines = b.sourceText.split("\n")
       bodyLines.zipWithIndex.foreach { case (line, i) =>
-        println(s"  ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
+        println(s"  ${numberedLine(b.startLine + i, line)}")
       }
-      // Context lines after
-      if r.contextLines > 0 then
-        val lines = try java.nio.file.Files.readAllLines(file).asScala catch { case _: Exception => Seq.empty }
-        val total = lines.size
-        val ctxEnd = math.min(total, b.endLine + r.contextLines)
-        if ctxEnd > b.endLine then println("  ---")
-        ((b.endLine + 1) to ctxEnd).foreach { i =>
-          if i >= 1 && i <= total then
-            println(s"  ${i.toString.padTo(4, ' ')} | ${lines(i - 1)}")
-        }
+      if after.nonEmpty then println("  ---")
+      after.foreach((i, text) => println(s"  ${numberedLine(i, text)}"))
       println()
     }
   }
@@ -607,16 +592,16 @@ private def renderSourceBlocks(r: CmdResult.SourceBlocks, ctx: CommandContext): 
 private def renderTestSuites(r: CmdResult.TestSuites, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val arr = r.suites.take(ctx.limit).map { suite =>
-      val rel = jsonEscape(ctx.workspace.relativize(suite.file).toString)
-      val testsJson = suite.tests.map { tc =>
+      val rel = ctx.workspace.relativize(suite.file).toString
+      val testsJson = jArr(suite.tests.map { tc =>
         val bodyField = if r.showBody then {
-          tc.body.map(b => s""","body":"${jsonEscape(b.sourceText)}"""").getOrElse("")
+          tc.body.map(b => s""","body":${jStr(b.sourceText)}""").getOrElse("")
         } else ""
-        s"""{"name":"${jsonEscape(tc.name)}","line":${tc.line}$bodyField}"""
-      }.mkString("[", ",", "]")
-      s"""{"suite":"${jsonEscape(suite.name)}","file":"$rel","line":${suite.line},"tests":$testsJson}"""
-    }.mkString("[", ",", "]")
-    println(arr)
+        s"""{"name":${jStr(tc.name)},"line":${tc.line}$bodyField}"""
+      })
+      s"""{"suite":${jStr(suite.name)},"file":${jStr(rel)},"line":${suite.line},"tests":$testsJson}"""
+    }
+    println(jArr(arr))
   } else {
     if r.suites.isEmpty then {
       println(r.emptyMessage)
@@ -628,10 +613,7 @@ private def renderTestSuites(r: CmdResult.TestSuites, ctx: CommandContext): Unit
           println(s"""  test  "${tc.name}"  :${tc.line}""")
           if r.showBody || ctx.verbose then {
             tc.body.foreach { b =>
-              val bodyLines = b.sourceText.split("\n")
-              bodyLines.zipWithIndex.foreach { case (line, i) =>
-                println(s"    ${(b.startLine + i).toString.padTo(4, ' ')} | $line")
-              }
+              renderInlineBody(Some(b), "    ")
               println()
             }
           }
@@ -655,13 +637,13 @@ private def renderTestCount(r: CmdResult.TestCount, ctx: CommandContext): Unit =
 
 private def renderCoverageReport(r: CmdResult.CoverageReport, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val refsJson = r.testRefs.take(ctx.limit).map(ctx.jRef).mkString("[", ",", "]")
-    println(s"""{"symbol":"${jsonEscape(r.symbol)}","testFileCount":${r.testFiles.size},"referenceCount":${r.testRefs.size},"references":$refsJson}""")
+    val refsJson = jArr(r.testRefs.take(ctx.limit).map(ctx.jRef))
+    println(s"""{"symbol":${jStr(r.symbol)},"testFileCount":${r.testFiles.size},"referenceCount":${r.testRefs.size},"references":$refsJson}""")
   } else {
     if r.testRefs.isEmpty then {
       if r.totalRefs == 0 then {
         println(s"""Coverage of "${r.symbol}" — no references found""")
-        renderHint(mkNotFoundWithSuggestions(r.symbol, ctx, "coverage"))
+        r.hint.foreach(renderHint)
       } else {
         println(s"""Coverage of "${r.symbol}" — ${r.totalRefs} refs but 0 in test files""")
       }
@@ -681,63 +663,50 @@ private def renderCoverageReport(r: CmdResult.CoverageReport, ctx: CommandContex
 private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandContext): Unit = {
   val tree = r.tree
   def nodeJson(n: HierarchyNode): String = {
-    val file = n.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
-    val kind = n.kind.map(k => s""""${k.toString.toLowerCase}"""").getOrElse("null")
+    val file = jOpt(n.file.map(f => ctx.workspace.relativize(f).toString))
+    val kind = jOpt(n.kind.map(_.label))
     val line = n.line.map(_.toString).getOrElse("null")
-    s"""{"name":"${jsonEscape(n.name)}","kind":$kind,"file":$file,"line":$line,"package":"${jsonEscape(n.packageName)}","isExternal":${n.isExternal}}"""
+    s"""{"name":${jStr(n.name)},"kind":$kind,"file":$file,"line":$line,"package":${jStr(n.packageName)},"isExternal":${n.isExternal}}"""
   }
   def treeJson(t: HierarchyTree): String = {
-    val ps = t.parents.map(treeJson).mkString("[", ",", "]")
-    val cs = t.children.map(treeJson).mkString("[", ",", "]")
+    val ps = jArr(t.parents.map(treeJson))
+    val cs = jArr(t.children.map(treeJson))
     val trunc = if t.truncatedChildren > 0 then s""","truncatedChildren":${t.truncatedChildren}""" else ""
     s"""{"node":${nodeJson(t.root)},"parents":$ps,"children":$cs$trunc}"""
+  }
+  // One recursive printer for both directions: `down` walks children (with
+  // truncation notes), parents-mode marks external nodes instead.
+  def printLevel(nodes: List[HierarchyTree], indent: String, down: Boolean): Unit = {
+    nodes.zipWithIndex.foreach { case (t, i) =>
+      val isLast = i == nodes.size - 1
+      val prefix = if isLast then s"$indent└── " else s"$indent├── "
+      val nextIndent = if isLast then s"$indent    " else s"$indent│   "
+      val n = t.root
+      val nkind = n.kind.map(_.label + " ").getOrElse("")
+      val nloc = if !down && n.isExternal then " [external]"
+                 else n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
+      println(s"$prefix$nkind${n.name}${pkgSuffix(n.packageName)}$nloc")
+      printLevel(if down then t.children else t.parents, nextIndent, down)
+      if down && t.truncatedChildren > 0 then
+        println(s"$nextIndent... and ${t.truncatedChildren} more children")
+    }
   }
   if ctx.jsonOutput then {
     println(treeJson(tree))
   } else {
     val rootNode = tree.root
-    val pkg = if rootNode.packageName.nonEmpty then s" (${rootNode.packageName})" else ""
-    val kind = rootNode.kind.map(_.toString.toLowerCase).getOrElse("unknown")
+    val kind = rootNode.kind.map(_.label).getOrElse("unknown")
     val loc = rootNode.file.map(f => s" — ${ctx.workspace.relativize(f)}:${rootNode.line.getOrElse(0)}").getOrElse("")
-    println(s"Hierarchy of $kind ${rootNode.name}$pkg$loc:")
+    println(s"Hierarchy of $kind ${rootNode.name}${pkgSuffix(rootNode.packageName)}$loc:")
     if ctx.goUp then {
       println("  Parents:")
-      def printParents(parents: List[HierarchyTree], indent: String): Unit = {
-        parents.zipWithIndex.foreach { case (pt, i) =>
-          val isLast = i == parents.size - 1
-          val prefix = if isLast then s"$indent└── " else s"$indent├── "
-          val nextIndent = if isLast then s"$indent    " else s"$indent│   "
-          val n = pt.root
-          val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
-          val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
-          val nloc = if n.isExternal then " [external]"
-                     else n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
-          println(s"$prefix$nkind${n.name}$npkg$nloc")
-          printParents(pt.parents, nextIndent)
-        }
-      }
       if tree.parents.isEmpty then println("    (none)")
-      else printParents(tree.parents, "    ")
+      else printLevel(tree.parents, "    ", down = false)
     }
     if ctx.goDown then {
       println("  Children:")
-      def printChildren(children: List[HierarchyTree], indent: String): Unit = {
-        children.zipWithIndex.foreach { case (ct, i) =>
-          val isLast = i == children.size - 1
-          val prefix = if isLast then s"$indent└── " else s"$indent├── "
-          val nextIndent = if isLast then s"$indent    " else s"$indent│   "
-          val n = ct.root
-          val npkg = if n.packageName.nonEmpty then s" (${n.packageName})" else ""
-          val nkind = n.kind.map(_.toString.toLowerCase + " ").getOrElse("")
-          val nloc = n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
-          println(s"$prefix$nkind${n.name}$npkg$nloc")
-          printChildren(ct.children, nextIndent)
-          if ct.truncatedChildren > 0 then
-            println(s"$nextIndent... and ${ct.truncatedChildren} more children")
-        }
-      }
       if tree.children.isEmpty then println("    (none)")
-      else printChildren(tree.children, "    ")
+      else printLevel(tree.children, "    ", down = true)
     }
   }
 }
@@ -745,17 +714,15 @@ private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandCont
 private def renderOverrideList(r: CmdResult.OverrideList, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val arr = r.results.map { o =>
-      val rel = jsonEscape(ctx.workspace.relativize(o.file).toString)
-      val bodyJson = o.body.map(b => s""","body":"${jsonEscape(b.sourceText)}","bodyStartLine":${b.startLine},"bodyEndLine":${b.endLine}""").getOrElse("")
-      s"""{"enclosingClass":"${jsonEscape(o.enclosingClass)}","enclosingKind":"${o.enclosingKind.toString.toLowerCase}","file":"$rel","line":${o.line},"signature":"${jsonEscape(o.signature)}","package":"${jsonEscape(o.packageName)}"$bodyJson}"""
-    }.mkString("[", ",", "]")
-    println(arr)
+      val rel = ctx.workspace.relativize(o.file).toString
+      s"""{"enclosingClass":${jStr(o.enclosingClass)},"enclosingKind":${jStr(o.enclosingKind.label)},"file":${jStr(rel)},"line":${o.line},"signature":${jStr(o.signature)},"package":${jStr(o.packageName)}${jsonBodyFields(o.body)}}"""
+    }
+    println(jArr(arr))
   } else {
     println(r.header)
     r.results.foreach { o =>
       val rel = ctx.workspace.relativize(o.file)
-      val pkg = if o.packageName.nonEmpty then s" (${o.packageName})" else ""
-      println(s"  ${o.enclosingClass}$pkg — $rel:${o.line}")
+      println(s"  ${o.enclosingClass}${pkgSuffix(o.packageName)} — $rel:${o.line}")
       println(s"    ${o.signature}")
       renderInlineBody(o.body, "    ")
     }
@@ -765,58 +732,46 @@ private def renderOverrideList(r: CmdResult.OverrideList, ctx: CommandContext): 
 private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Unit = {
   val sym = r.sym
   val rel = ctx.workspace.relativize(sym.file)
-  val pkg = if sym.packageName.nonEmpty then s" (${sym.packageName})" else ""
   if ctx.jsonOutput then {
-    val docJson = r.doc.map(d => s""""${jsonEscape(d)}"""").getOrElse("null")
-    val membersJson = r.members.map { m =>
+    val membersJson = jArr(r.members.map { m =>
       val overrideJson = if m.isOverride then ""","isOverride":true""" else ""
-      val bodyJson = jsonMemberBody(m)
-      s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"$overrideJson$bodyJson}"""
-    }.mkString("[", ",", "]")
-    val implsJson = r.impls.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
+      s"""{${jsonMemberFields(m)}$overrideJson${jsonBodyFields(m.body)}}"""
+    })
+    val implsJson = jArr(r.impls.map(s => jsonSymbol(s, ctx.workspace)))
     val primaryKeys = r.members.map(m => (name = m.name, kind = m.kind)).toSet
     val companionJson = r.companion.map { (compSym, compMembers) =>
       val uniqueCompMembers = compMembers.filter(m => !primaryKeys.contains((name = m.name, kind = m.kind)))
-      val cMembers = uniqueCompMembers.map { m =>
-        s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
-      }.mkString("[", ",", "]")
+      val cMembers = jArr(uniqueCompMembers.map(m => s"{${jsonMemberFields(m)}}"))
       s"""{"definition":${jsonSymbol(compSym, ctx.workspace)},"members":$cMembers}"""
     }.getOrElse("null")
     def explainedImplJson(ei: ExplainedImpl): String = {
-      val mJson = ei.members.map { m =>
-        s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
-      }.mkString("[", ",", "]")
-      val subJson = ei.subImpls.map(explainedImplJson).mkString("[", ",", "]")
+      val mJson = jArr(ei.members.map(m => s"{${jsonMemberFields(m)}}"))
+      val subJson = jArr(ei.subImpls.map(explainedImplJson))
       s"""{"definition":${jsonSymbol(ei.sym, ctx.workspace)},"members":$mJson,"subImplementations":$subJson}"""
     }
-    val expandedJson = r.expandedImpls.map(explainedImplJson).mkString("[", ",", "]")
+    val expandedJson = jArr(r.expandedImpls.map(explainedImplJson))
     val importCount = r.importRefs.size
     val importRefsJson = if importCount <= 10 then
-      val arr = r.importRefs.map(ref => jsonRef(ref, ctx.workspace)).mkString("[", ",", "]")
-      s""","importFiles":$arr"""
+      s""","importFiles":${jArr(r.importRefs.map(ref => jsonRef(ref, ctx.workspace)))}"""
     else ""
     val otherJson = if r.otherMatches.nonEmpty then
-      val arr = r.otherMatches.map(s => s""""${jsonEscape(s)}"""").mkString("[", ",", "]")
-      s""","otherMatches":$arr"""
+      s""","otherMatches":${jStrArr(r.otherMatches)}"""
     else ""
     val totalImplJson = if r.totalImpls > r.impls.size then s""","totalImplementations":${r.totalImpls}""" else ""
     val inheritedJson = if r.inherited.nonEmpty then
-      val groups = r.inherited.map { (parentName, parentFile, parentPackage, members) =>
-        val pRel = parentFile.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
-        val mJson = members.map { m =>
-          s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
-        }.mkString("[", ",", "]")
-        s"""{"parent":"${jsonEscape(parentName)}","parentFile":$pRel,"parentPackage":"${jsonEscape(parentPackage)}","members":$mJson}"""
-      }.mkString("[", ",", "]")
+      val groups = jArr(r.inherited.map { (parentName, parentFile, parentPackage, members) =>
+        val pRel = jOpt(parentFile.map(f => ctx.workspace.relativize(f).toString))
+        val mJson = jArr(members.map(m => s"{${jsonMemberFields(m)}}"))
+        s"""{"parent":${jStr(parentName)},"parentFile":$pRel,"parentPackage":${jStr(parentPackage)},"members":$mJson}"""
+      })
       s""","inherited":$groups"""
     else ""
     val relatedJson = if r.relatedTypes.nonEmpty then
-      val arr = r.relatedTypes.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
-      s""","relatedTypes":$arr"""
+      s""","relatedTypes":${jArr(r.relatedTypes.map(s => jsonSymbol(s, ctx.workspace)))}"""
     else ""
-    println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":$docJson,"members":$membersJson,"implementations":$implsJson,"importCount":$importCount$importRefsJson,"companion":$companionJson,"expandedImplementations":$expandedJson$otherJson$totalImplJson$inheritedJson$relatedJson}""")
+    println(s"""{"definition":${jsonSymbol(sym, ctx.workspace)},"doc":${jOpt(r.doc)},"members":$membersJson,"implementations":$implsJson,"importCount":$importCount$importRefsJson,"companion":$companionJson,"expandedImplementations":$expandedJson$otherJson$totalImplJson$inheritedJson$relatedJson}""")
   } else {
-    println(s"Explanation of ${sym.kind.toString.toLowerCase} ${sym.name}$pkg:\n")
+    println(s"Explanation of ${sym.kind.label} ${sym.name}${pkgSuffix(sym.packageName)}:\n")
     println(s"  Definition: $rel:${sym.line}")
     println(s"  Signature: ${sym.signature}")
     if sym.parents.nonEmpty then println(s"  Extends: ${sym.parents.mkString(", ")}")
@@ -832,37 +787,29 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
     if r.members.nonEmpty then {
       println(s"  Members (top ${r.members.size}):")
       r.members.foreach { m =>
-        val label = if ctx.verbose then m.signature else m.name
         val overrideMarker = if m.isOverride then "  [override]" else ""
-        println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label$overrideMarker")
+        println(s"    ${explainMemberLine(m, ctx.verbose)}$overrideMarker")
         renderInlineBody(m.body, "      ")
       }
       println()
     }
     r.inherited.foreach { (parentName, _, _, pMembers) =>
       println(s"  Inherited from $parentName:")
-      pMembers.take(ctx.membersLimit).foreach { m =>
-        val label = if ctx.verbose then m.signature else m.name
-        println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
-      }
-      if pMembers.size > ctx.membersLimit then println(s"    ... and ${pMembers.size - ctx.membersLimit} more")
+      renderShown(pMembers, ctx.membersLimit, "    ")(m => println(s"    ${explainMemberLine(m, ctx.verbose)}"))
       println()
     }
     r.companion.foreach { (compSym, compMembers) =>
       val compRel = ctx.workspace.relativize(compSym.file)
-      println(s"  Companion ${compSym.kind.toString.toLowerCase} ${compSym.name} — $compRel:${compSym.line}")
+      println(s"  Companion ${compSym.kind.label} ${compSym.name} — $compRel:${compSym.line}")
       if compMembers.nonEmpty then
         // Deduplicate: skip companion members that are identical to primary members
         val primaryKeys = r.members.map(m => (name = m.name, kind = m.kind)).toSet
         val uniqueCompMembers = compMembers.filter(m => !primaryKeys.contains((name = m.name, kind = m.kind)))
         val dupeCount = compMembers.size - uniqueCompMembers.size
         if uniqueCompMembers.nonEmpty then
-          uniqueCompMembers.foreach { m =>
-            val label = if ctx.verbose then m.signature else m.name
-            println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
-          }
+          uniqueCompMembers.foreach(m => println(s"    ${explainMemberLine(m, ctx.verbose)}"))
         if dupeCount > 0 then
-          println(s"    ($dupeCount members shared with ${sym.kind.toString.toLowerCase}, shown above)")
+          println(s"    ($dupeCount members shared with ${sym.kind.label}, shown above)")
       println()
     }
     if r.impls.nonEmpty then {
@@ -878,11 +825,8 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       println("  Expanded implementations:")
       def printExpanded(impls: List[ExplainedImpl], indent: String): Unit = {
         impls.foreach { ei =>
-          println(s"$indent${ei.sym.kind.toString.toLowerCase} ${ei.sym.name} — ${ctx.workspace.relativize(ei.sym.file)}:${ei.sym.line}")
-          ei.members.foreach { m =>
-            val label = if ctx.verbose then m.signature else m.name
-            println(s"$indent  ${m.kind.toString.toLowerCase.padTo(5, ' ')} $label")
-          }
+          println(s"$indent${ei.sym.kind.label} ${ei.sym.name} — ${ctx.workspace.relativize(ei.sym.file)}:${ei.sym.line}")
+          ei.members.foreach(m => println(s"$indent  ${explainMemberLine(m, ctx.verbose)}"))
           if ei.subImpls.nonEmpty then printExpanded(ei.subImpls, indent + "  ")
         }
       }
@@ -893,8 +837,7 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       println(s"  Related types (${r.relatedTypes.size}):")
       r.relatedTypes.foreach { s =>
         val relFile = ctx.workspace.relativize(s.file)
-        val pkg = if s.packageName.nonEmpty then s" (${s.packageName})" else ""
-        println(s"    ${s.kind.toString.toLowerCase.padTo(5, ' ')} ${s.name}$pkg — $relFile:${s.line}")
+        println(s"    ${s.kind.label.padTo(5, ' ')} ${s.name}${pkgSuffix(s.packageName)} — $relFile:${s.line}")
       }
       println()
     }
@@ -915,44 +858,36 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
 
 private def renderDependencies(r: CmdResult.Dependencies, ctx: CommandContext): Unit = {
   def depJson(d: DepInfo): String = {
-    val file = d.file.map(f => s""""${jsonEscape(ctx.workspace.relativize(f).toString)}"""").getOrElse("null")
+    val file = jOpt(d.file.map(f => ctx.workspace.relativize(f).toString))
     val line = d.line.map(_.toString).getOrElse("null")
-    s"""{"name":"${jsonEscape(d.name)}","kind":"${jsonEscape(d.kind)}","file":$file,"line":$line,"package":"${jsonEscape(d.packageName)}","depth":${d.depth}}"""
+    s"""{"name":${jStr(d.name)},"kind":${jStr(d.kind)},"file":$file,"line":$line,"package":${jStr(d.packageName)},"depth":${d.depth}}"""
+  }
+  def printDep(d: DepInfo): Unit = {
+    val indent = "  " * d.depth
+    val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
+    println(s"    $indent${d.kind.padTo(9, ' ')} ${d.name}$loc")
   }
   if ctx.jsonOutput then {
-    val iArr = r.importDeps.map(depJson).mkString("[", ",", "]")
-    val bArr = r.bodyDeps.map(depJson).mkString("[", ",", "]")
-    println(s"""{"imports":$iArr,"bodyReferences":$bArr}""")
+    println(s"""{"imports":${jArr(r.importDeps.map(depJson))},"bodyReferences":${jArr(r.bodyDeps.map(depJson))}}""")
   } else {
     println(s"""Dependencies of "${r.symbol}":""")
     if r.importDeps.nonEmpty then {
       println(s"\n  Imports:")
-      r.importDeps.take(ctx.limit).foreach { d =>
-        val indent = "  " * d.depth
-        val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
-        println(s"    $indent${d.kind.padTo(9, ' ')} ${d.name}$loc")
-      }
-      if r.importDeps.size > ctx.limit then println(s"    ... and ${r.importDeps.size - ctx.limit} more")
+      renderShown(r.importDeps, ctx.limit, "    ")(printDep)
     }
     if r.bodyDeps.nonEmpty then {
       println(s"\n  Body references:")
-      r.bodyDeps.take(ctx.limit).foreach { d =>
-        val indent = "  " * d.depth
-        val loc = d.file.map(f => s" — ${ctx.workspace.relativize(f)}:${d.line.getOrElse(0)}").getOrElse("")
-        println(s"    $indent${d.kind.padTo(9, ' ')} ${d.name}$loc")
-      }
-      if r.bodyDeps.size > ctx.limit then println(s"    ... and ${r.bodyDeps.size - ctx.limit} more")
+      renderShown(r.bodyDeps, ctx.limit, "    ")(printDep)
     }
   }
 }
 
 private def renderScopes(r: CmdResult.Scopes, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val arr = r.scopes.map { s =>
-      s"""{"name":"${jsonEscape(s.name)}","kind":"${jsonEscape(s.kind)}","line":${s.line}}"""
-    }.mkString("[", ",", "]")
-    val rel = jsonEscape(ctx.workspace.relativize(r.file).toString)
-    println(s"""{"file":"$rel","line":${r.line},"scopes":$arr}""")
+    val arr = jArr(r.scopes.map { s =>
+      s"""{"name":${jStr(s.name)},"kind":${jStr(s.kind)},"line":${s.line}}"""
+    })
+    println(s"""{"file":${jStr(ctx.workspace.relativize(r.file).toString)},"line":${r.line},"scopes":$arr}""")
   } else {
     val rel = ctx.workspace.relativize(r.file)
     println(s"Context at $rel:${r.line}:")
@@ -971,40 +906,27 @@ private def renderSymbolDiff(r: CmdResult.SymbolDiff, ctx: CommandContext): Unit
       println("""{"added":[],"removed":[],"modified":[]}""")
     } else {
       def diffSymJson(s: DiffSymbol): String =
-        s"""{"name":"${jsonEscape(s.name)}","kind":"${s.kind.toString.toLowerCase}","file":"${jsonEscape(s.file)}","line":${s.line},"package":"${jsonEscape(s.packageName)}","signature":"${jsonEscape(s.signature)}"}"""
-      val addedJson = r.added.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
-      val removedJson = r.removed.take(ctx.limit).map(diffSymJson).mkString("[", ",", "]")
-      val modifiedJson = r.modified.take(ctx.limit).map { (o, n) =>
+        s"""{"name":${jStr(s.name)},"kind":${jStr(s.kind.label)},"file":${jStr(s.file)},"line":${s.line},"package":${jStr(s.packageName)},"signature":${jStr(s.signature)}}"""
+      val addedJson = jArr(r.added.take(ctx.limit).map(diffSymJson))
+      val removedJson = jArr(r.removed.take(ctx.limit).map(diffSymJson))
+      val modifiedJson = jArr(r.modified.take(ctx.limit).map { (o, n) =>
         s"""{"old":${diffSymJson(o)},"new":${diffSymJson(n)}}"""
-      }.mkString("[", ",", "]")
-      println(s"""{"ref":"${jsonEscape(r.ref)}","filesChanged":${r.filesChanged},"added":$addedJson,"removed":$removedJson,"modified":$modifiedJson}""")
+      })
+      println(s"""{"ref":${jStr(r.ref)},"filesChanged":${r.filesChanged},"added":$addedJson,"removed":$removedJson,"modified":$modifiedJson}""")
     }
   } else {
     if r.filesChanged == 0 then {
       println(s"No Scala files changed compared to ${r.ref}")
     } else {
       println(s"Symbol changes compared to ${r.ref} (${r.filesChanged} files changed):")
-      if r.added.nonEmpty then {
-        println(s"\n  Added (${r.added.size}):")
-        r.added.take(ctx.limit).foreach { s =>
-          println(s"    + ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
+      def printGroup(label: String, marker: String, syms: List[DiffSymbol]): Unit =
+        if syms.nonEmpty then {
+          println(s"\n  $label (${syms.size}):")
+          renderShown(syms, ctx.limit, "    ")(s => println(s"    $marker ${s.kind.label.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}"))
         }
-        if r.added.size > ctx.limit then println(s"    ... and ${r.added.size - ctx.limit} more")
-      }
-      if r.removed.nonEmpty then {
-        println(s"\n  Removed (${r.removed.size}):")
-        r.removed.take(ctx.limit).foreach { s =>
-          println(s"    - ${s.kind.toString.toLowerCase.padTo(9, ' ')} ${s.name} — ${s.file}:${s.line}")
-        }
-        if r.removed.size > ctx.limit then println(s"    ... and ${r.removed.size - ctx.limit} more")
-      }
-      if r.modified.nonEmpty then {
-        println(s"\n  Modified (${r.modified.size}):")
-        r.modified.take(ctx.limit).foreach { (_, n) =>
-          println(s"    ~ ${n.kind.toString.toLowerCase.padTo(9, ' ')} ${n.name} — ${n.file}:${n.line}")
-        }
-        if r.modified.size > ctx.limit then println(s"    ... and ${r.modified.size - ctx.limit} more")
-      }
+      printGroup("Added", "+", r.added)
+      printGroup("Removed", "-", r.removed)
+      printGroup("Modified", "~", r.modified.map(_.after))
       if r.added.isEmpty && r.removed.isEmpty && r.modified.isEmpty then
         println("  No symbol-level changes detected")
     }
@@ -1014,10 +936,10 @@ private def renderSymbolDiff(r: CmdResult.SymbolDiff, ctx: CommandContext): Unit
 private def renderAstMatches(r: CmdResult.AstMatches, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val arr = r.results.map { m =>
-      val rel = jsonEscape(ctx.workspace.relativize(m.file).toString)
-      s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","file":"$rel","line":${m.line},"package":"${jsonEscape(m.packageName)}","signature":"${jsonEscape(m.signature)}"}"""
-    }.mkString("[", ",", "]")
-    println(arr)
+      val rel = ctx.workspace.relativize(m.file).toString
+      s"""{"name":${jStr(m.name)},"kind":${jStr(m.kind.label)},"file":${jStr(rel)},"line":${m.line},"package":${jStr(m.packageName)},"signature":${jStr(m.signature)}}"""
+    }
+    println(jArr(arr))
   } else {
     if r.results.isEmpty then
       println(s"No types matching AST pattern (${r.filters})")
@@ -1025,8 +947,7 @@ private def renderAstMatches(r: CmdResult.AstMatches, ctx: CommandContext): Unit
       println(s"Types matching AST pattern (${r.filters}) — ${r.results.size} found:")
       r.results.foreach { m =>
         val rel = ctx.workspace.relativize(m.file)
-        val pkg = if m.packageName.nonEmpty then s" (${m.packageName})" else ""
-        println(s"  ${m.kind.toString.toLowerCase.padTo(9, ' ')} ${m.name}$pkg — $rel:${m.line}")
+        println(s"  ${m.kind.label.padTo(9, ' ')} ${m.name}${pkgSuffix(m.packageName)} — $rel:${m.line}")
       }
     }
   }
@@ -1047,28 +968,25 @@ private def renderGrepByMethod(r: CmdResult.GrepByMethod, ctx: CommandContext): 
   r.stderrHint.foreach(System.err.println)
   val suffix = timedOutSuffix(r.timedOut)
   if ctx.jsonOutput then {
-    val shown = r.methods.take(ctx.limit)
-    val items = shown.map { m =>
-      val file = jsonEscape(ctx.workspace.relativize(m.file).toString)
-      val linesJson = m.matchLines.map(ml => s"""{"line":${ml.lineNum},"text":"${jsonEscape(ml.text)}"}""").mkString("[", ",", "]")
-      s"""{"name":"${jsonEscape(m.member.name)}","kind":"${m.member.kind.toString.toLowerCase}","signature":"${jsonEscape(m.member.signature)}","file":"$file","line":${m.member.line},"matches":${m.matchCount},"matchLines":$linesJson}"""
-    }.mkString("[", ",", "]")
+    val items = jArr(r.methods.take(ctx.limit).map { m =>
+      val file = ctx.workspace.relativize(m.file).toString
+      val linesJson = jArr(m.matchLines.map(ml => s"""{"line":${ml.lineNum},"text":${jStr(ml.text)}}"""))
+      s"""{"name":${jStr(m.member.name)},"kind":${jStr(m.member.kind.label)},"signature":${jStr(m.member.signature)},"file":${jStr(file)},"line":${m.member.line},"matches":${m.matchCount},"matchLines":$linesJson}"""
+    })
     val total = r.methods.map(_.matchCount).sum
     val truncated = if r.methods.size > ctx.limit then s""","truncated":true,"totalMethods":${r.methods.size}""" else ""
     val timedOutStr = if r.timedOut then s""","timedOut":true""" else ""
     val hintStr = r.hint.getOrElse("")
-    println(s"""{"pattern":"${jsonEscape(r.pattern)}","owner":"${jsonEscape(r.owner)}","methods":$items,"totalMatches":$total$truncated$timedOutStr$hintStr}""")
+    println(s"""{"pattern":${jStr(r.pattern)},"owner":${jStr(r.owner)},"methods":$items,"totalMatches":$total$truncated$timedOutStr$hintStr}""")
   } else {
     if r.methods.isEmpty then
       println(s"""No methods in ${r.owner} whose body contains "${r.pattern}"$suffix""")
     else {
       val total = r.methods.map(_.matchCount).sum
       println(s"""Methods in ${r.owner} whose body contains "${r.pattern}" — ${r.methods.size} methods, $total matches:$suffix""")
-      val shown = r.methods.take(ctx.limit)
-      val maxSig = shown.map(_.member.signature.length).maxOption.getOrElse(0)
-      shown.foreach { m =>
-        val relFile = ctx.workspace.relativize(m.file).toString
-        val loc = s"$relFile:${m.member.line}"
+      val maxSig = r.methods.take(ctx.limit).map(_.member.signature.length).maxOption.getOrElse(0)
+      renderShown(r.methods, ctx.limit, "  ", " (use --limit 0 to show all)") { m =>
+        val loc = s"${ctx.workspace.relativize(m.file)}:${m.member.line}"
         val pad = " " * (maxSig - m.member.signature.length)
         val plural = if m.matchCount == 1 then "match" else "matches"
         println(s"  ${m.member.signature}$pad — $loc  (${m.matchCount} $plural)")
@@ -1076,16 +994,13 @@ private def renderGrepByMethod(r: CmdResult.GrepByMethod, ctx: CommandContext): 
           println(s"      ${ml.lineNum} | ${ml.text}")
         }
       }
-      val remaining = r.methods.size - shown.size
-      if remaining > 0 then println(s"  ... and $remaining more (use --limit 0 to show all)")
     }
   }
 }
 
 private def renderPackages(r: CmdResult.Packages, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val arr = r.packages.map(p => s""""${jsonEscape(p)}"""").mkString("[", ",", "]")
-    println(arr)
+    println(jStrArr(r.packages))
   } else {
     println(s"Packages (${r.packages.size}):")
     r.packages.foreach(p => println(s"  $p"))
@@ -1098,10 +1013,9 @@ private def pluralKind(kind: SymbolKind): String = kind match
 
 private def renderPackageSymbols(r: CmdResult.PackageSymbols, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val items = r.symbols.take(ctx.limit)
-    val arr = items.map(s => jsonSymbol(s, ctx.workspace)).mkString("[", ",", "]")
+    val arr = jArr(r.symbols.take(ctx.limit).map(s => jsonSymbol(s, ctx.workspace)))
     val truncated = if r.symbols.size > ctx.limit then ",\"truncated\":true" else ""
-    println(s"""{"package":"${jsonEscape(r.pkg)}","symbolCount":${r.symbols.size},"symbols":$arr$truncated}""")
+    println(s"""{"package":${jStr(r.pkg)},"symbolCount":${r.symbols.size},"symbols":$arr$truncated}""")
   } else {
     if r.symbols.isEmpty then {
       println(s"""Package ${r.pkg}: (no symbols)""")
@@ -1111,14 +1025,12 @@ private def renderPackageSymbols(r: CmdResult.PackageSymbols, ctx: CommandContex
         r.symbols.groupBy(_.kind).toList.sortBy(-_._2.size).map((k, s) => (kind = k, syms = s))
       byKind.foreach { (kind, syms) =>
         println(s"  ${pluralKind(kind)} (${syms.size}):")
-        val items = syms.sortBy(_.name).take(ctx.limit)
-        items.foreach { s =>
+        renderShown(syms.sortBy(_.name), ctx.limit, "    ") { s =>
           if ctx.verbose then
             println(s"    ${s.name.padTo(30, ' ')} ${s.signature.take(60)}  — ${ctx.workspace.relativize(s.file)}:${s.line}")
           else
             println(s"    ${s.name.padTo(30, ' ')} ${ctx.workspace.relativize(s.file)}:${s.line}")
         }
-        if syms.size > ctx.limit then println(s"    ... and ${syms.size - ctx.limit} more")
       }
     }
   }
@@ -1126,14 +1038,12 @@ private def renderPackageSymbols(r: CmdResult.PackageSymbols, ctx: CommandContex
 
 private def renderPackageExplained(r: CmdResult.PackageExplained, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val typesJson = r.entries.map { e =>
-      val mJson = e.members.map { m =>
-        s"""{"name":"${jsonEscape(m.name)}","kind":"${m.kind.toString.toLowerCase}","line":${m.line},"signature":"${jsonEscape(m.signature)}"}"""
-      }.mkString("[", ",", "]")
+    val typesJson = jArr(r.entries.map { e =>
+      val mJson = jArr(e.members.map(m => s"{${jsonMemberFields(m)}}"))
       s"""{"definition":${jsonSymbol(e.sym, ctx.workspace)},"members":$mJson,"implCount":${e.implCount}}"""
-    }.mkString("[", ",", "]")
+    })
     val truncatedJson = if r.totalTypes > r.entries.size then s""","totalTypes":${r.totalTypes},"truncated":true""" else ""
-    println(s"""{"package":"${jsonEscape(r.pkg)}","totalSymbols":${r.totalSymbols},"types":$typesJson$truncatedJson}""")
+    println(s"""{"package":${jStr(r.pkg)},"totalSymbols":${r.totalSymbols},"types":$typesJson$truncatedJson}""")
   } else {
     if r.entries.isEmpty then {
       println(s"""Package ${r.pkg}: (no types)""")
@@ -1146,11 +1056,11 @@ private def renderPackageExplained(r: CmdResult.PackageExplained, ctx: CommandCo
       r.entries.foreach { e =>
         val rel = ctx.workspace.relativize(e.sym.file)
         val implSuffix = if e.implCount > 0 then s" (${e.implCount} impls)" else ""
-        println(s"  ${e.sym.kind.toString.toLowerCase} ${e.sym.name}$implSuffix — $rel:${e.sym.line}")
+        println(s"  ${e.sym.kind.label} ${e.sym.name}$implSuffix — $rel:${e.sym.line}")
         println(s"    ${e.sym.signature}")
         if e.members.nonEmpty then
           e.members.foreach { m =>
-            println(s"    ${m.kind.toString.toLowerCase.padTo(5, ' ')} ${m.name}: ${m.signature.take(60)}")
+            println(s"    ${m.kind.label.padTo(5, ' ')} ${m.name}: ${m.signature.take(60)}")
           }
         println()
       }
@@ -1162,10 +1072,10 @@ private def renderPackageExplained(r: CmdResult.PackageExplained, ctx: CommandCo
 
 private def renderPackageSummary(r: CmdResult.PackageSummary, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val arr = r.subPackages.map { (sub, count) =>
-      s"""{"subPackage":"${jsonEscape(sub)}","symbolCount":$count}"""
-    }.mkString("[", ",", "]")
-    println(s"""{"package":"${jsonEscape(r.pkg)}","totalSymbols":${r.totalSymbols},"subPackages":$arr}""")
+    val arr = jArr(r.subPackages.map { (sub, count) =>
+      s"""{"subPackage":${jStr(sub)},"symbolCount":$count}"""
+    })
+    println(s"""{"package":${jStr(r.pkg)},"totalSymbols":${r.totalSymbols},"subPackages":$arr}""")
   } else {
     if r.subPackages.isEmpty then {
       println(s"""Package ${r.pkg}: no symbols found""")
@@ -1182,24 +1092,22 @@ private def renderPackageSummary(r: CmdResult.PackageSummary, ctx: CommandContex
 
 private def renderApiSurface(r: CmdResult.ApiSurface, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val items = r.symbols.take(ctx.limit).map { (sym, count) =>
-      val rel = jsonEscape(ctx.workspace.relativize(sym.file).toString)
-      s"""{"name":"${jsonEscape(sym.name)}","kind":"${sym.kind.toString.toLowerCase}","file":"$rel","line":${sym.line},"package":"${jsonEscape(sym.packageName)}","importerCount":$count}"""
-    }.mkString("[", ",", "]")
-    val internalJson = r.internalOnly.map(n => s""""${jsonEscape(n)}"""").mkString("[", ",", "]")
-    println(s"""{"package":"${jsonEscape(r.pkg)}","exportedCount":${r.symbols.size},"totalInPackage":${r.totalInPackage},"symbols":$items,"internalOnly":$internalJson}""")
+    val items = jArr(r.symbols.take(ctx.limit).map { (sym, count) =>
+      val rel = ctx.workspace.relativize(sym.file).toString
+      s"""{"name":${jStr(sym.name)},"kind":${jStr(sym.kind.label)},"file":${jStr(rel)},"line":${sym.line},"package":${jStr(sym.packageName)},"importerCount":$count}"""
+    })
+    println(s"""{"package":${jStr(r.pkg)},"exportedCount":${r.symbols.size},"totalInPackage":${r.totalInPackage},"symbols":$items,"internalOnly":${jStrArr(r.internalOnly)}}""")
   } else {
     if r.symbols.isEmpty && r.internalOnly.isEmpty then {
       println(s"""API surface of ${r.pkg}: no symbols found""")
     } else {
       val exportedCount = r.symbols.size
       println(s"API surface of ${r.pkg} ($exportedCount of ${r.totalInPackage} symbols imported externally):\n")
-      r.symbols.take(ctx.limit).foreach { (sym, count) =>
+      renderShown(r.symbols, ctx.limit, "  ") { (sym, count) =>
         val rel = ctx.workspace.relativize(sym.file)
         val importerLabel = if count == 1 then "importer" else "importers"
-        println(s"  ${sym.name.padTo(25, ' ')} ${sym.kind.toString.toLowerCase.padTo(9, ' ')} $count $importerLabel  $rel:${sym.line}")
+        println(s"  ${sym.name.padTo(25, ' ')} ${sym.kind.label.padTo(9, ' ')} $count $importerLabel  $rel:${sym.line}")
       }
-      if r.symbols.size > ctx.limit then println(s"  ... and ${r.symbols.size - ctx.limit} more")
       if r.internalOnly.nonEmpty then {
         val shown = r.internalOnly.take(10)
         val suffix = if r.internalOnly.size > 10 then s", ... and ${r.internalOnly.size - 10} more" else ""
@@ -1212,11 +1120,10 @@ private def renderApiSurface(r: CmdResult.ApiSurface, ctx: CommandContext): Unit
 private def renderRefsTop(r: CmdResult.RefsTop, ctx: CommandContext): Unit = {
   val suffix = timedOutSuffix(r.timedOut)
   if ctx.jsonOutput then {
-    val filesJson = r.fileRanking.map { (file, count) =>
-      val rel = jsonEscape(ctx.workspace.relativize(file).toString)
-      s"""{"file":"$rel","count":$count}"""
-    }.mkString("[", ",", "]")
-    println(s"""{"symbol":"${jsonEscape(r.symbol)}","files":$filesJson,"total":${r.total},"timedOut":${r.timedOut}}""")
+    val filesJson = jArr(r.fileRanking.map { (file, count) =>
+      s"""{"file":${jStr(ctx.workspace.relativize(file).toString)},"count":$count}"""
+    })
+    println(s"""{"symbol":${jStr(r.symbol)},"files":$filesJson,"total":${r.total},"timedOut":${r.timedOut}}""")
   } else {
     val fileCount = r.fileRanking.size
     println(s"Top $fileCount files referencing '${r.symbol}' (${r.total} total references)$suffix:")
@@ -1230,7 +1137,7 @@ private def renderRefsTop(r: CmdResult.RefsTop, ctx: CommandContext): Unit = {
 private def renderRefsSummary(r: CmdResult.RefsSummary, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
     val counts = r.categoryCounts.map((cat, count) => s""""${cat.toString}":$count""").mkString("{", ",", "}")
-    println(s"""{"symbol":"${jsonEscape(r.symbol)}","counts":$counts,"total":${r.total},"timedOut":${r.timedOut}}""")
+    println(s"""{"symbol":${jStr(r.symbol)},"counts":$counts,"total":${r.total},"timedOut":${r.timedOut}}""")
   } else {
     val suffix = timedOutSuffix(r.timedOut)
     val parts = r.categoryCounts.map { (cat, count) =>
@@ -1267,11 +1174,11 @@ private def renderEntrypoints(r: CmdResult.Entrypoints, ctx: CommandContext): Un
   if ctx.jsonOutput then {
     val groups = categoryOrder.map { cat =>
       val entries = byCategory.getOrElse(cat, Nil).take(ctx.limit)
-      val arr = entries.map { e =>
-        val rel = jsonEscape(ctx.workspace.relativize(e.sym.file).toString)
+      val arr = jArr(entries.map { e =>
+        val rel = ctx.workspace.relativize(e.sym.file).toString
         val line = e.memberLine.getOrElse(e.sym.line)
-        s"""{"name":"${jsonEscape(e.sym.name)}","kind":"${e.sym.kind.toString.toLowerCase}","file":"$rel","line":$line,"package":"${jsonEscape(e.sym.packageName)}"}"""
-      }.mkString("[", ",", "]")
+        s"""{"name":${jStr(e.sym.name)},"kind":${jStr(e.sym.kind.label)},"file":${jStr(rel)},"line":$line,"package":${jStr(e.sym.packageName)}}"""
+      })
       s""""${categoryJsonKeys(cat)}":$arr"""
     }.mkString(",")
     println(s"""{"entrypoints":{$groups},"total":${r.total}}""")
@@ -1284,12 +1191,11 @@ private def renderEntrypoints(r: CmdResult.Entrypoints, ctx: CommandContext): Un
         val entries = byCategory.getOrElse(cat, Nil)
         if entries.nonEmpty then {
           println(s"  ${categoryLabels(cat)} (${entries.size}):")
-          entries.take(ctx.limit).foreach { e =>
+          renderShown(entries, ctx.limit, "    ") { e =>
             val rel = ctx.workspace.relativize(e.sym.file)
             val line = e.memberLine.getOrElse(e.sym.line)
-            println(s"    ${e.sym.kind.toString.toLowerCase.padTo(9, ' ')} ${e.sym.name} — $rel:$line")
+            println(s"    ${e.sym.kind.label.padTo(9, ' ')} ${e.sym.name} — $rel:$line")
           }
-          if entries.size > ctx.limit then println(s"    ... and ${entries.size - ctx.limit} more")
           println()
         }
       }
@@ -1298,7 +1204,7 @@ private def renderEntrypoints(r: CmdResult.Entrypoints, ctx: CommandContext): Un
 }
 
 private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
-  val suggestionsJson = r.hint.suggestions.map(s => s""""${jsonEscape(s)}"""").mkString("[", ",", "]")
+  val suggestionsJson = jStrArr(r.hint.suggestions)
   if ctx.jsonOutput then {
     r.hint.cmd match {
       case "hierarchy" =>

--- a/src/index.scala
+++ b/src/index.scala
@@ -226,6 +226,103 @@ object IndexPersistence:
 
         result.toMap
 
+// ── Deadline-bounded file scanning ──────────────────────────────────────────
+
+/** Shared chassis for the deadline-bounded parallel file scans behind
+  * `grepFiles`/`findReferences`/`findImports`: result queue, timeout flag,
+  * unreadable-file counter, and the per-file/per-line deadline checks. */
+private final class DeadlineScan(timeoutMs: Long) {
+  private val deadline: Long = System.nanoTime() + timeoutMs * 1_000_000
+  @volatile var timedOut: Boolean = false
+  private val queue = ConcurrentLinkedQueue[Reference]()
+  private val unreadable = java.util.concurrent.atomic.AtomicInteger(0)
+
+  def inTime: Boolean = System.nanoTime() < deadline
+
+  def emit(r: Reference): Unit = queue.add(r)
+
+  /** A file's lines, counting the file as unreadable (empty result) on IO errors. */
+  def readLines(path: Path): collection.Seq[String] =
+    try Files.readAllLines(path).asScala catch {
+      case _: java.io.IOException =>
+        unreadable.incrementAndGet()
+        Seq.empty
+    }
+
+  /** Visit each candidate in parallel while the deadline holds, handing its
+    * lines to `onFile`; candidates skipped after the deadline mark `timedOut`. */
+  def scanParallel[A](candidates: List[A])(pathOf: A => Path)(onFile: (item: A, path: Path, lines: collection.Seq[String]) => Unit): Unit =
+    candidates.asJava.parallelStream().forEach { item =>
+      if inTime then {
+        val path = pathOf(item)
+        onFile(item, path, readLines(path))
+      } else timedOut = true
+    }
+
+  /** Per-line loop with deadline checks; lines skipped after the deadline mark `timedOut`. */
+  def forEachLine(lines: collection.Seq[String])(f: (line: String, lineNum: Int) => Unit): Unit =
+    lines.zipWithIndex.foreach { case (line, idx) =>
+      if inTime then f(line, idx + 1)
+      else timedOut = true
+    }
+
+  def reportUnreadable(label: String): Unit =
+    if unreadable.get() > 0 then System.err.println(s"scalex: ${unreadable.get()} file(s) unreadable during $label")
+
+  def results: List[Reference] = queue.asScala.toList
+}
+
+// ── Ranked name matching ─────────────────────────────────────────────────────
+
+/** Match-quality tiers for ranked name search, best first. */
+enum MatchTier {
+  case Exact, Prefix, Contains, ReverseContains, CamelCase
+}
+
+private def isSegmentStart(name: String, i: Int): Boolean =
+  i == 0 || name(i).isUpper || (i > 0 && name(i - 1) == '_')
+
+/** True if every char of `query` (lowercase) appears in `name` walking
+  * camelCase/snake_case segment starts, e.g. "usl" matches "UserServiceLive". */
+def camelCaseMatch(query: String, name: String): Boolean =
+  query.length >= 2 && {
+    val qLower = query.toLowerCase
+    val nLower = name.toLowerCase
+    var qi = 0
+    var ni = 0
+    while qi < qLower.length && ni < nLower.length do
+      if qLower(qi) == nLower(ni) then
+        qi += 1
+        ni += 1
+      else
+        ni += 1
+        while ni < nLower.length && !isSegmentStart(name, ni) do ni += 1
+    qi == qLower.length
+  }
+
+/** Classify how `name` matches a query (`lowerQuery` must be pre-lowercased).
+  * One classifier behind symbol search, file search, and suggestion ranking. */
+def nameMatchTier(lowerQuery: String, name: String): Option[MatchTier] = {
+  val n = name.toLowerCase
+  if n == lowerQuery then Some(MatchTier.Exact)
+  else if n.startsWith(lowerQuery) then Some(MatchTier.Prefix)
+  else if n.contains(lowerQuery) then Some(MatchTier.Contains)
+  else if lowerQuery.endsWith(n) && n.length >= 3 && n.length > lowerQuery.length / 2 then Some(MatchTier.ReverseContains)
+  else if camelCaseMatch(lowerQuery, name) then Some(MatchTier.CamelCase)
+  else None
+}
+
+/** Inverted index: group items under each (already-normalized) key produced by `keys`. */
+private def buildMultiIndex[A, K](items: List[A])(keys: A => IterableOnce[K]): Map[K, List[A]] = {
+  val idx = mutable.HashMap.empty[K, mutable.ListBuffer[A]]
+  items.foreach { item =>
+    keys(item).iterator.foreach { k =>
+      idx.getOrElseUpdate(k, mutable.ListBuffer.empty) += item
+    }
+  }
+  idx.map((k, v) => k -> v.toList).toMap
+}
+
 // ── Workspace index ─────────────────────────────────────────────────────────
 
 class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
@@ -262,30 +359,17 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
 
   lazy val parentIndex: Map[String, List[SymbolInfo]] =
     Timings.phase("build-parentIndex") {
-      val pIdx = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      allSymbols.foreach { s =>
-        s.parents.foreach { p =>
-          pIdx.getOrElseUpdate(p.toLowerCase, mutable.ListBuffer.empty) += s
-        }
-      }
-      pIdx.map((k, v) => k -> v.toList).toMap
+      buildMultiIndex(allSymbols)(_.parents.map(_.toLowerCase))
     }
 
   lazy val typeParamParentIndex: Map[String, List[SymbolInfo]] =
     Timings.phase("build-typeParamParentIndex") {
-      val idx = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      allSymbols.foreach { s =>
-        s.typeParamParents.foreach { p =>
-          idx.getOrElseUpdate(p.toLowerCase, mutable.ListBuffer.empty) += s
-        }
-      }
-      idx.map((k, v) => k -> v.toList).toMap
+      buildMultiIndex(allSymbols)(_.typeParamParents.map(_.toLowerCase))
     }
 
   private lazy val distinctSymbols: List[SymbolInfo] =
     Timings.phase("build-distinctSymbols") {
-      val seen = mutable.HashSet.empty[(String, Path, Int)]
-      allSymbols.filter(s => seen.add((s.name, s.file, s.line)))
+      allSymbols.distinctBy(s => (name = s.name, file = s.file, line = s.line))
     }
 
   lazy val packageToSymbols: Map[String, Set[String]] =
@@ -332,13 +416,7 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
 
   private lazy val annotationIndex: Map[String, List[SymbolInfo]] =
     Timings.phase("build-annotationIndex") {
-      val aByAnnot = mutable.HashMap.empty[String, mutable.ListBuffer[SymbolInfo]]
-      allSymbols.foreach { s =>
-        s.annotations.foreach { a =>
-          aByAnnot.getOrElseUpdate(a.toLowerCase, mutable.ListBuffer.empty) += s
-        }
-      }
-      aByAnnot.map((k, v) => k -> v.toList).toMap
+      buildMultiIndex(allSymbols)(_.annotations.map(_.toLowerCase))
     }
 
   var fileCount: Int = 0
@@ -473,29 +551,17 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     compileRegex(pattern) match
       case None => (Nil, false)
       case Some(regex) =>
-        var candidates = gitFiles
-        if noTests then candidates = candidates.filter(gf => !isTestFile(gf.path, workspace))
-        pathFilter.foreach { p => candidates = candidates.filter(gf => matchesPath(gf.path, p, workspace)) }
-        excludePath.foreach { p => candidates = candidates.filter(gf => !matchesPath(gf.path, p, workspace)) }
-        val deadline = System.nanoTime() + timeoutMs * 1_000_000
-        var grepTimedOut = false
-        val results = ConcurrentLinkedQueue[Reference]()
-        val grepUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
-        candidates.asJava.parallelStream().forEach { gf =>
-          if System.nanoTime() < deadline then {
-            try {
-              val lines = Files.readAllLines(gf.path).asScala
-              lines.zipWithIndex.foreach { case (line, idx) =>
-                if System.nanoTime() < deadline then {
-                  if regex.matcher(line).find() then
-                    results.add(Reference(gf.path, idx + 1, line.trim))
-                } else grepTimedOut = true
-              }
-            } catch { case _: java.io.IOException => grepUnreadable.incrementAndGet(); () }
-          } else grepTimedOut = true
+        val keep = pathPredicate(noTests, pathFilter, excludePath, workspace)
+        val candidates = gitFiles.filter(gf => keep(gf.path))
+        val scan = DeadlineScan(timeoutMs)
+        scan.scanParallel(candidates)(_.path) { (_, path, lines) =>
+          scan.forEachLine(lines) { (line, lineNum) =>
+            if regex.matcher(line).find() then
+              scan.emit(Reference(path, lineNum, line.trim))
+          }
         }
-        if grepUnreadable.get() > 0 then System.err.println(s"scalex: ${grepUnreadable.get()} file(s) unreadable during grep")
-        (results.asScala.toList.sortBy(r => (workspace.relativize(r.file).toString, r.line)), grepTimedOut)
+        scan.reportUnreadable("grep")
+        (scan.results.sortBy(r => (path = workspace.relativize(r.file).toString, line = r.line)), scan.timedOut)
 
   private def compileRegex(pattern: String): Option[java.util.regex.Pattern] =
     try Some(java.util.regex.Pattern.compile(pattern))
@@ -513,12 +579,13 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     val fuzzy = mutable.ListBuffer.empty[SymbolInfo]
 
     distinctSymbols.foreach { s =>
-      val n = s.name.toLowerCase
-      if n == lower then exact += s
-      else if n.startsWith(lower) then prefix += s
-      else if n.contains(lower) then contains += s
-      else if lower.endsWith(n) && n.length >= 3 && n.length > lower.length / 2 then reverseContains += s
-      else if camelCaseMatch(lower, s.name) then fuzzy += s
+      nameMatchTier(lower, s.name).foreach {
+        case MatchTier.Exact           => exact += s
+        case MatchTier.Prefix          => prefix += s
+        case MatchTier.Contains        => contains += s
+        case MatchTier.ReverseContains => reverseContains += s
+        case MatchTier.CamelCase       => fuzzy += s
+      }
     }
     def searchRank(s: SymbolInfo): (kindRank: Int, testRank: Int, stdlibRank: Int, importRank: Int, pathLen: Int) =
       val kindRank = s.kind match
@@ -548,11 +615,13 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
 
     indexedFiles.foreach { f =>
       val fileName = f.relativePath.substring(f.relativePath.lastIndexOf('/') + 1).stripSuffix(".scala").stripSuffix(".java")
-      val n = fileName.toLowerCase
-      if n == lower then exact += f.relativePath
-      else if n.startsWith(lower) then prefix += f.relativePath
-      else if n.contains(lower) then contains += f.relativePath
-      else if camelCaseMatch(lower, fileName) then fuzzy += f.relativePath
+      nameMatchTier(lower, fileName).foreach {
+        case MatchTier.Exact     => exact += f.relativePath
+        case MatchTier.Prefix    => prefix += f.relativePath
+        case MatchTier.Contains  => contains += f.relativePath
+        case MatchTier.CamelCase => fuzzy += f.relativePath
+        case MatchTier.ReverseContains => () // not a useful tier for filenames
+      }
     }
     exact.toList ++ prefix.toList ++ contains.toList ++ fuzzy.sortBy(_.length).toList
 
@@ -572,34 +641,24 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       (candidates, allCandidates, fileAliasMap)
     }
 
-    val deadline = System.nanoTime() + timeoutMs * 1_000_000
-    var timedOut = false
-    val results = ConcurrentLinkedQueue[Reference]()
+    val scan = DeadlineScan(timeoutMs)
     val seen = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
-    val refsUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
     Timings.phase("text-search") {
-      allCandidates.asJava.parallelStream().forEach { idxFile =>
-        if System.nanoTime() < deadline then
-          val path = workspace.resolve(idxFile.relativePath)
-          val lines = try Files.readAllLines(path).asScala catch
-            case _: java.io.IOException => refsUnreadable.incrementAndGet(); Seq.empty
-          val aliasName = fileAliasMap.get(idxFile.relativePath)
-          lines.zipWithIndex.foreach {
-            case (line, idx) if System.nanoTime() < deadline =>
-              val key = s"${idxFile.relativePath}:${idx + 1}"
-              if wordMatch(line, name) && seen.add(key) then
-                results.add(Reference(path, idx + 1, line.trim))
-              else aliasName match
-                case Some(alias) if wordMatch(line, alias) && seen.add(key) =>
-                  results.add(Reference(path, idx + 1, line.trim, Some(s"via alias $alias")))
-                case _ =>
+      scan.scanParallel(allCandidates)(f => workspace.resolve(f.relativePath)) { (idxFile, path, lines) =>
+        val aliasName = fileAliasMap.get(idxFile.relativePath)
+        scan.forEachLine(lines) { (line, lineNum) =>
+          val key = s"${idxFile.relativePath}:$lineNum"
+          if wordMatch(line, name) && seen.add(key) then
+            scan.emit(Reference(path, lineNum, line.trim))
+          else aliasName match
+            case Some(alias) if wordMatch(line, alias) && seen.add(key) =>
+              scan.emit(Reference(path, lineNum, line.trim, Some(s"via alias $alias")))
             case _ =>
-          }
-        else timedOut = true
+        }
       }
     }
-    if refsUnreadable.get() > 0 then System.err.println(s"scalex: ${refsUnreadable.get()} file(s) unreadable during refs")
-    (results.asScala.toList, timedOut)
+    scan.reportUnreadable("refs")
+    (scan.results, scan.timedOut)
 
   def categorizeReferences(name: String, strict: Boolean = false): (grouped: Map[RefCategory, List[Reference]], timedOut: Boolean) =
     val (refs, timedOut) = findReferences(name, strict = strict)
@@ -626,54 +685,44 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   def findImports(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): (results: List[Reference], timedOut: Boolean) =
     val wordMatch: (String, String) => Boolean = if strict then containsWordStrict else containsWord
     val candidates = indexedFiles.filter(f => f.identifierBloom.forall(_.mightContain(name)))
-    val deadline = System.nanoTime() + timeoutMs * 1_000_000
-    var timedOut = false
-    val results = ConcurrentLinkedQueue[Reference]()
+    val scan = DeadlineScan(timeoutMs)
     val resultPaths = java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
-    val importsUnreadable = java.util.concurrent.atomic.AtomicInteger(0)
-    candidates.asJava.parallelStream().forEach { idxFile =>
-      if System.nanoTime() < deadline then
-        val path = workspace.resolve(idxFile.relativePath)
-        val lines = try Files.readAllLines(path).asScala catch
-          case _: java.io.IOException => importsUnreadable.incrementAndGet(); Seq.empty
-        lines.zipWithIndex.foreach {
-          case (line, idx) if System.nanoTime() < deadline && line.trim.startsWith("import ") && wordMatch(line, name) =>
-            results.add(Reference(path, idx + 1, line.trim))
-            resultPaths.add(s"${idxFile.relativePath}:${idx + 1}")
-          case _ =>
-        }
-      else timedOut = true
+    scan.scanParallel(candidates)(f => workspace.resolve(f.relativePath)) { (idxFile, path, lines) =>
+      scan.forEachLine(lines) { (line, lineNum) =>
+        if line.trim.startsWith("import ") && wordMatch(line, name) then
+          scan.emit(Reference(path, lineNum, line.trim))
+          resultPaths.add(s"${idxFile.relativePath}:$lineNum")
+      }
     }
 
     // Also find wildcard imports that resolve to a package containing the target symbol
     val targetPkgs = symbolsByName.getOrElse(name.toLowerCase, Nil).map(_.packageName).toSet
     if targetPkgs.nonEmpty then
-      for idxFile <- indexedFiles if System.nanoTime() < deadline do
+      for idxFile <- indexedFiles if scan.inTime do
         for imp <- idxFile.imports do
-          val trimmed = imp.trim.stripPrefix("import ")
-          if (trimmed.endsWith("._") || trimmed.endsWith(".*")) then
-            val pkg = trimmed.dropRight(2)
-            if targetPkgs.contains(pkg) then
-              val path = workspace.resolve(idxFile.relativePath)
-              try {
-                val lines = Files.readAllLines(path).asScala
-                lines.zipWithIndex.foreach { case (line, lineIdx) =>
-                  if line.trim == imp.trim then
-                    val key = s"${idxFile.relativePath}:${lineIdx + 1}"
-                    if !resultPaths.contains(key) then
-                      results.add(Reference(path, lineIdx + 1, line.trim))
-                      resultPaths.add(key)
-                }
-              } catch { case _: java.io.IOException => importsUnreadable.incrementAndGet(); () }
+          if wildcardImportPkg(imp).exists(targetPkgs.contains) then
+            val path = workspace.resolve(idxFile.relativePath)
+            scan.forEachLine(scan.readLines(path)) { (line, lineNum) =>
+              if line.trim == imp.trim then
+                val key = s"${idxFile.relativePath}:$lineNum"
+                if !resultPaths.contains(key) then
+                  scan.emit(Reference(path, lineNum, line.trim))
+                  resultPaths.add(key)
+            }
 
-    if importsUnreadable.get() > 0 then System.err.println(s"scalex: ${importsUnreadable.get()} file(s) unreadable during imports")
-    (results.asScala.toList, timedOut)
+    scan.reportUnreadable("imports")
+    (scan.results, scan.timedOut)
 
   private def filePackage(idxFile: IndexedFile): String =
     idxFile.symbols.headOption.map(_.packageName).getOrElse("")
 
   def filePackageByPath(relPath: String): Option[String] =
     indexedByPath.get(relPath).map(filePackage)
+
+  /** Import lines recorded at index time for the file at `path` (absolute).
+    * Lets callers avoid re-parsing source just to read imports. */
+  def fileImports(path: Path): List[String] =
+    indexedByPath.get(workspace.relativize(path).toString).map(_.imports).getOrElse(Nil)
 
   def resolveConfidence(ref: Reference, targetName: String, targetPackages: Set[String]): Confidence =
     val relPath = workspace.relativize(ref.file).toString
@@ -693,34 +742,9 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
           }
           if hasExplicit || hasAliasMatch then Confidence.High
           else
-            val hasWildcard = imports.exists { imp =>
-              val trimmed = imp.trim.stripPrefix("import ")
-              (trimmed.endsWith("._") || trimmed.endsWith(".*")) && {
-                val pkg = trimmed.dropRight(2)
-                targetPackages.contains(pkg)
-              }
-            }
+            val hasWildcard = imports.exists(imp => wildcardImportPkg(imp).exists(targetPackages.contains))
             if hasWildcard then Confidence.Medium
             else Confidence.Low
-
-  private def isSegmentStart(name: String, i: Int): Boolean =
-    i == 0 || name(i).isUpper || (i > 0 && name(i - 1) == '_')
-
-  private def camelCaseMatch(query: String, name: String): Boolean =
-    query.length >= 2 && {
-      val qLower = query.toLowerCase
-      val nLower = name.toLowerCase
-      var qi = 0
-      var ni = 0
-      while qi < qLower.length && ni < nLower.length do
-        if qLower(qi) == nLower(ni) then
-          qi += 1
-          ni += 1
-        else
-          ni += 1
-          while ni < nLower.length && !isSegmentStart(name, ni) do ni += 1
-      qi == qLower.length
-    }
 
   /** True if `word` occurs in `line` with no word character (per `isWordChar`)
     * directly before or after the occurrence. */
@@ -792,42 +816,51 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       }
     }
 
-  private def parseImportTarget(imp: String): Option[(pkg: String, names: List[String], isWildcard: Boolean)] =
-    val trimmed = imp.trim.stripPrefix("import ")
-    if trimmed.isEmpty then None
-    else {
+// ── Import line parsing ──────────────────────────────────────────────────────
 
-    // Handle brace-enclosed imports: import pkg.{A, B, C as D, _}
-    val braceStart = trimmed.indexOf('{')
-    if braceStart >= 0 then
-      val pkg = trimmed.substring(0, braceStart).stripSuffix(".")
-      val braceEnd = trimmed.indexOf('}', braceStart)
-      val inner = if braceEnd >= 0 then trimmed.substring(braceStart + 1, braceEnd) else trimmed.substring(braceStart + 1)
-      val parts = inner.split(',').map(_.trim).filter(_.nonEmpty)
-      var isWildcard = false
-      val names = mutable.ListBuffer.empty[String]
-      parts.foreach { part =>
-        if part == "_" || part == "*" then isWildcard = true
-        else
-          // Handle "Foo as Bar" or "Foo => Bar" — we want the original name (Foo)
-          val asIdx = part.indexOf(" as ")
-          val arrowIdx = part.indexOf(" => ")
-          val name = if asIdx >= 0 then part.substring(0, asIdx).trim
-                     else if arrowIdx >= 0 then part.substring(0, arrowIdx).trim
-                     else part.trim
-          if name.nonEmpty && name != "_" && name != "*" then names += name
-      }
-      Some((pkg, names.toList, isWildcard))
-    else
-      // Simple import: import pkg.Name or import pkg._ or import pkg.*
-      val lastDot = trimmed.lastIndexOf('.')
-      if lastDot < 0 then None
+/** Parse an import line into its package, imported names, and wildcard flag.
+  * Handles brace imports ("import pkg.{A, B as C, _}") and simple imports. */
+def parseImportTarget(imp: String): Option[(pkg: String, names: List[String], isWildcard: Boolean)] =
+  val trimmed = imp.trim.stripPrefix("import ")
+  if trimmed.isEmpty then None
+  else {
+
+  // Handle brace-enclosed imports: import pkg.{A, B, C as D, _}
+  val braceStart = trimmed.indexOf('{')
+  if braceStart >= 0 then
+    val pkg = trimmed.substring(0, braceStart).stripSuffix(".")
+    val braceEnd = trimmed.indexOf('}', braceStart)
+    val inner = if braceEnd >= 0 then trimmed.substring(braceStart + 1, braceEnd) else trimmed.substring(braceStart + 1)
+    val parts = inner.split(',').map(_.trim).filter(_.nonEmpty)
+    var isWildcard = false
+    val names = mutable.ListBuffer.empty[String]
+    parts.foreach { part =>
+      if part == "_" || part == "*" then isWildcard = true
       else
-        val pkg = trimmed.substring(0, lastDot)
-        val name = trimmed.substring(lastDot + 1)
-        if name == "_" || name == "*" then Some((pkg, Nil, true))
-        else Some((pkg, List(name), false))
+        // Handle "Foo as Bar" or "Foo => Bar" — we want the original name (Foo)
+        val asIdx = part.indexOf(" as ")
+        val arrowIdx = part.indexOf(" => ")
+        val name = if asIdx >= 0 then part.substring(0, asIdx).trim
+                   else if arrowIdx >= 0 then part.substring(0, arrowIdx).trim
+                   else part.trim
+        if name.nonEmpty && name != "_" && name != "*" then names += name
     }
+    Some((pkg, names.toList, isWildcard))
+  else
+    // Simple import: import pkg.Name or import pkg._ or import pkg.*
+    val lastDot = trimmed.lastIndexOf('.')
+    if lastDot < 0 then None
+    else
+      val pkg = trimmed.substring(0, lastDot)
+      val name = trimmed.substring(lastDot + 1)
+      if name == "_" || name == "*" then Some((pkg, Nil, true))
+      else Some((pkg, List(name), false))
+  }
+
+/** Package of a wildcard import line ("import pkg._" / "import pkg.*"), or None. */
+def wildcardImportPkg(imp: String): Option[String] =
+  val trimmed = imp.trim.stripPrefix("import ")
+  if trimmed.endsWith("._") || trimmed.endsWith(".*") then Some(trimmed.dropRight(2)) else None
 
 // ── Filtering helpers ────────────────────────────────────────────────────────
 
@@ -843,3 +876,11 @@ def isTestFile(path: Path, workspace: Path): Boolean =
 def matchesPath(file: Path, prefix: String, workspace: Path): Boolean =
   val rel = workspace.relativize(file).toString
   rel.startsWith(prefix)
+
+/** Predicate combining the --no-tests / --path / --exclude-path file filters,
+  * shared by symbol/ref filtering and the file-scanning commands. */
+def pathPredicate(noTests: Boolean, pathFilter: Option[String], excludePath: Option[String], workspace: Path): Path => Boolean =
+  path =>
+    (!noTests || !isTestFile(path, workspace)) &&
+    pathFilter.forall(p => matchesPath(path, p, workspace)) &&
+    excludePath.forall(p => !matchesPath(path, p, workspace))

--- a/src/model.scala
+++ b/src/model.scala
@@ -18,6 +18,9 @@ enum SymbolKind(val id: Byte):
   case Extension extends SymbolKind(9)
   case Package   extends SymbolKind(10)
 
+  /** Lowercase display name used in all text and JSON output. */
+  def label: String = toString.toLowerCase
+
 object SymbolKind:
   private val byId: Array[SymbolKind] = values.sortBy(_.id)
   def fromId(id: Byte): SymbolKind = byId(id)
@@ -50,10 +53,28 @@ case class IndexedFile(
 enum RefCategory:
   case Definition, ExtendedBy, ImportedBy, UsedAsType, Comment, Usage
 
+/** Display order for reference categories (differs from declaration order). */
+val refCategoryOrder: List[RefCategory] = List(
+  RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
+  RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
+
 case class CategorizedRef(ref: Reference, category: RefCategory)
 
 enum Confidence:
   case High, Medium, Low
+
+  def label: String = this match {
+    case Confidence.High   => "High confidence"
+    case Confidence.Medium => "Medium confidence"
+    case Confidence.Low    => "Low confidence"
+  }
+
+  /** Parenthetical shown next to the label in categorized refs output. */
+  def explanation: String = this match {
+    case Confidence.High   => "import-matched"
+    case Confidence.Medium => "wildcard import"
+    case Confidence.Low    => "no matching import"
+  }
 
 // ── Member / body / hierarchy types ─────────────────────────────────────────
 
@@ -177,7 +198,7 @@ enum CmdResult:
   case SourceBlocks(symbol: String, blocks: List[(file: Path, body: BodyInfo)], contextLines: Int = 0, showImports: Boolean = false)
   case TestSuites(suites: List[TestSuiteResult], showBody: Boolean, emptyMessage: String = "No test suites found")
   case TestCount(suites: Int, tests: Int, dynamicSites: Int)
-  case CoverageReport(symbol: String, totalRefs: Int, testRefs: List[Reference], testFiles: List[String])
+  case CoverageReport(symbol: String, totalRefs: Int, testRefs: List[Reference], testFiles: List[String], hint: Option[NotFoundHint] = None)
   case HierarchyResult(symbol: String, tree: HierarchyTree)
   case OverrideList(header: String, results: List[OverrideInfo])
   case Explanation(sym: SymbolInfo, doc: Option[String], members: List[MemberInfo], impls: List[SymbolInfo], importRefs: List[Reference],

--- a/tests/refactor-guard.test.scala
+++ b/tests/refactor-guard.test.scala
@@ -1,0 +1,354 @@
+import java.nio.file.Path
+
+/** Guards for the dedup refactor: validates that every --json output is
+  * structurally valid JSON, and locks behavior the refactor touches
+  * (search ranking, overview package deps, grep corrected-hint escaping,
+  * Java signature consistency, truncation footers). */
+class RefactorGuardSuite extends ScalexTestBase {
+
+  // ── Minimal JSON validator (no external deps) ─────────────────────────────
+
+  private final class JsonParser(s: String) {
+    var pos: Int = 0
+    private def peek: Char = if pos < s.length then s.charAt(pos) else '\u0000'
+    private def skipWs(): Unit = {
+      while pos < s.length && s.charAt(pos).isWhitespace do pos += 1
+    }
+    private def consume(lit: String): Boolean = {
+      if s.startsWith(lit, pos) then {
+        pos += lit.length
+        true
+      } else false
+    }
+    def parseValue(): Boolean = {
+      skipWs()
+      peek match {
+        case '{' => parseObject()
+        case '[' => parseArray()
+        case '"' => parseString()
+        case 't' => consume("true")
+        case 'f' => consume("false")
+        case 'n' => consume("null")
+        case c if c == '-' || c.isDigit => parseNumber()
+        case _ => false
+      }
+    }
+    private def parseObject(): Boolean = {
+      pos += 1 // consume '{'
+      skipWs()
+      if peek == '}' then {
+        pos += 1
+        true
+      } else {
+        var ok = true
+        var done = false
+        while ok && !done do {
+          skipWs()
+          ok = parseString()
+          if ok then {
+            skipWs()
+            ok = peek == ':'
+            if ok then pos += 1
+          }
+          if ok then ok = parseValue()
+          if ok then {
+            skipWs()
+            if peek == ',' then pos += 1
+            else if peek == '}' then {
+              pos += 1
+              done = true
+            } else ok = false
+          }
+        }
+        ok
+      }
+    }
+    private def parseArray(): Boolean = {
+      pos += 1 // consume '['
+      skipWs()
+      if peek == ']' then {
+        pos += 1
+        true
+      } else {
+        var ok = true
+        var done = false
+        while ok && !done do {
+          ok = parseValue()
+          if ok then {
+            skipWs()
+            if peek == ',' then pos += 1
+            else if peek == ']' then {
+              pos += 1
+              done = true
+            } else ok = false
+          }
+        }
+        ok
+      }
+    }
+    private def isHex(c: Char): Boolean =
+      c.isDigit || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
+    private def parseString(): Boolean = {
+      if peek != '"' then false
+      else {
+        pos += 1
+        var ok = true
+        var closed = false
+        while ok && !closed && pos < s.length do {
+          s.charAt(pos) match {
+            case '"' =>
+              closed = true
+              pos += 1
+            case '\\' =>
+              if pos + 1 >= s.length then ok = false
+              else {
+                s.charAt(pos + 1) match {
+                  case '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' => pos += 2
+                  case 'u' =>
+                    if pos + 5 < s.length && (2 to 5).forall(i => isHex(s.charAt(pos + i))) then pos += 6
+                    else ok = false
+                  case _ => ok = false
+                }
+              }
+            case c if c < 0x20 => ok = false
+            case _ => pos += 1
+          }
+        }
+        ok && closed
+      }
+    }
+    private def parseNumber(): Boolean = {
+      val start = pos
+      if peek == '-' then pos += 1
+      while pos < s.length && s.charAt(pos).isDigit do pos += 1
+      if peek == '.' then {
+        pos += 1
+        while pos < s.length && s.charAt(pos).isDigit do pos += 1
+      }
+      if peek == 'e' || peek == 'E' then {
+        pos += 1
+        if peek == '+' || peek == '-' then pos += 1
+        while pos < s.length && s.charAt(pos).isDigit do pos += 1
+      }
+      pos > start && s.charAt(pos - 1).isDigit
+    }
+  }
+
+  private def assertValidJson(out: String, label: String): Unit = {
+    val trimmed = out.trim
+    assert(trimmed.nonEmpty, s"[$label] produced empty output")
+    val p = JsonParser(trimmed)
+    var ok = p.parseValue()
+    var i = p.pos
+    while i < trimmed.length && trimmed.charAt(i).isWhitespace do i += 1
+    ok = ok && i == trimmed.length
+    assert(ok, s"[$label] invalid JSON near position ${p.pos}: ${trimmed.take(400)}")
+  }
+
+  // ── JSON validity sweep over every command ────────────────────────────────
+
+  test("every --json command output is structurally valid JSON") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    def ctx(mod: CommandContext => CommandContext = identity): CommandContext =
+      mod(CommandContext(idx = idx, workspace = workspace, jsonOutput = true, limit = 50))
+
+    val cases: List[(label: String, cmd: String, args: List[String], ctx: CommandContext)] = List(
+      (label = "search", cmd = "search", args = List("User"), ctx = ctx()),
+      (label = "search-miss", cmd = "search", args = List("NoSuchSymbolXyz"), ctx = ctx()),
+      (label = "def", cmd = "def", args = List("UserService"), ctx = ctx()),
+      (label = "def-dotted", cmd = "def", args = List("Outer.Inner"), ctx = ctx()),
+      (label = "impl", cmd = "impl", args = List("UserService"), ctx = ctx()),
+      (label = "refs-categorized", cmd = "refs", args = List("UserService"), ctx = ctx()),
+      (label = "refs-flat", cmd = "refs", args = List("UserService"), ctx = ctx(_.copy(categorize = false))),
+      (label = "refs-flat-context", cmd = "refs", args = List("UserService"), ctx = ctx(_.copy(categorize = false, contextLines = 2))),
+      (label = "refs-count", cmd = "refs", args = List("UserService"), ctx = ctx(_.copy(countOnly = true))),
+      (label = "refs-top", cmd = "refs", args = List("UserService"), ctx = ctx(_.copy(topN = Some(3)))),
+      (label = "imports", cmd = "imports", args = List("UserService"), ctx = ctx()),
+      (label = "imports-miss", cmd = "imports", args = List("NoSuchSymbolXyz"), ctx = ctx()),
+      (label = "members", cmd = "members", args = List("UserServiceLive"), ctx = ctx()),
+      (label = "members-inherited", cmd = "members", args = List("UserServiceLive"), ctx = ctx(_.copy(inherited = true))),
+      (label = "members-body", cmd = "members", args = List("UserServiceLive"), ctx = ctx(_.copy(withBody = true))),
+      (label = "members-java", cmd = "members", args = List("UserRepository"), ctx = ctx()),
+      (label = "doc", cmd = "doc", args = List("PaymentService"), ctx = ctx()),
+      (label = "overview", cmd = "overview", args = Nil, ctx = ctx()),
+      (label = "overview-arch", cmd = "overview", args = Nil, ctx = ctx(_.copy(architecture = true))),
+      (label = "overview-concise", cmd = "overview", args = Nil, ctx = ctx(_.copy(concise = true))),
+      (label = "overview-focus", cmd = "overview", args = Nil, ctx = ctx(_.copy(focusPackage = Some("com.example")))),
+      (label = "symbols", cmd = "symbols", args = List("src/main/scala/com/example/UserService.scala"), ctx = ctx()),
+      (label = "symbols-summary", cmd = "symbols", args = List("src/main/scala/com/example/UserService.scala"), ctx = ctx(_.copy(summaryMode = true))),
+      (label = "file", cmd = "file", args = List("UserService"), ctx = ctx()),
+      (label = "annotated", cmd = "annotated", args = List("deprecated"), ctx = ctx()),
+      (label = "grep", cmd = "grep", args = List("findUser"), ctx = ctx()),
+      (label = "grep-count", cmd = "grep", args = List("findUser"), ctx = ctx(_.copy(countOnly = true))),
+      (label = "grep-in", cmd = "grep", args = List("db"), ctx = ctx(_.copy(inOwner = Some("UserServiceLive")))),
+      (label = "grep-each-method", cmd = "grep", args = List("db"), ctx = ctx(_.copy(inOwner = Some("UserServiceLive"), eachMethod = true))),
+      (label = "packages", cmd = "packages", args = Nil, ctx = ctx()),
+      (label = "package", cmd = "package", args = List("com.example"), ctx = ctx()),
+      (label = "package-explain", cmd = "package", args = List("com.example"), ctx = ctx(_.copy(explainMode = true))),
+      (label = "index", cmd = "index", args = Nil, ctx = ctx()),
+      (label = "body", cmd = "body", args = List("findUser"), ctx = ctx()),
+      (label = "body-context-imports", cmd = "body", args = List("findUser"), ctx = ctx(_.copy(contextLines = 2, showImports = true))),
+      (label = "tests", cmd = "tests", args = Nil, ctx = ctx()),
+      (label = "tests-count", cmd = "tests", args = Nil, ctx = ctx(_.copy(countOnly = true))),
+      (label = "coverage", cmd = "coverage", args = List("UserService"), ctx = ctx()),
+      (label = "hierarchy", cmd = "hierarchy", args = List("UserServiceLive"), ctx = ctx()),
+      (label = "overrides", cmd = "overrides", args = List("findUser"), ctx = ctx(_.copy(ofTrait = Some("UserService")))),
+      (label = "explain", cmd = "explain", args = List("UserService"), ctx = ctx()),
+      (label = "explain-shallow", cmd = "explain", args = List("UserService"), ctx = ctx(_.copy(shallow = true))),
+      (label = "explain-brief", cmd = "explain", args = List("UserService"), ctx = ctx(_.copy(brief = true))),
+      (label = "explain-inherited", cmd = "explain", args = List("UserServiceLive"), ctx = ctx(_.copy(inherited = true))),
+      (label = "explain-related", cmd = "explain", args = List("UserService"), ctx = ctx(_.copy(related = true))),
+      (label = "explain-expand", cmd = "explain", args = List("UserService"), ctx = ctx(_.copy(expandDepth = 1))),
+      (label = "explain-miss", cmd = "explain", args = List("NoSuchSymbolXyz"), ctx = ctx()),
+      (label = "deps", cmd = "deps", args = List("UserServiceLive"), ctx = ctx()),
+      (label = "context", cmd = "context", args = List("src/main/scala/com/example/UserService.scala:8"), ctx = ctx()),
+      (label = "diff", cmd = "diff", args = List("HEAD"), ctx = ctx()),
+      (label = "ast-pattern", cmd = "ast-pattern", args = Nil, ctx = ctx(_.copy(extendsFilter = Some("UserService")))),
+      (label = "api", cmd = "api", args = List("com.example"), ctx = ctx()),
+      (label = "summary", cmd = "summary", args = List("com"), ctx = ctx()),
+      (label = "entrypoints", cmd = "entrypoints", args = Nil, ctx = ctx()),
+    )
+
+    cases.foreach { c =>
+      val out = captureOut { runCommand(c.cmd, c.args, c.ctx) }
+      assertValidJson(out, c.label)
+    }
+  }
+
+  test("graph --render --json output is valid JSON") {
+    val idx = WorkspaceIndex(workspace, needBlooms = false)
+    val ctx = CommandContext(idx = idx, workspace = workspace, jsonOutput = true)
+    val out = captureOut { render(cmdGraph(List("--render", "A->B,B->C"), ctx), ctx) }
+    assertValidJson(out, "graph-render")
+  }
+
+  // ── grep --json corrected-hint escaping (bug fix) ─────────────────────────
+
+  test("grep --json escapes auto-corrected pattern containing backslashes") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val ctx = CommandContext(idx = idx, workspace = workspace, jsonOutput = true)
+    // POSIX alternation triggers the auto-correct path; \d survives into the
+    // corrected pattern and must be escaped in the JSON hint
+    val out = captureOut { runCommand("grep", List("""findUser\|\d+"""), ctx) }
+    assertValidJson(out, "grep-corrected-backslash")
+    assert(out.contains(""""corrected":"findUser|\\d+""""), s"corrected hint should be JSON-escaped: $out")
+  }
+
+  test("grep --json escapes auto-corrected pattern containing quotes") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val ctx = CommandContext(idx = idx, workspace = workspace, jsonOutput = true)
+    val out = captureOut { runCommand("grep", List("""say "hi"\|findUser"""), ctx) }
+    assertValidJson(out, "grep-corrected-quote")
+  }
+
+  test("grep --count --json escapes auto-corrected pattern") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val ctx = CommandContext(idx = idx, workspace = workspace, jsonOutput = true, countOnly = true)
+    val out = captureOut { runCommand("grep", List("""findUser\|\d+"""), ctx) }
+    assertValidJson(out, "grep-count-corrected")
+  }
+
+  // ── Search ranking locks ──────────────────────────────────────────────────
+
+  test("search ranks exact matches before prefix matches") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val names = idx.search("UserService").map(_.name)
+    assert(names.nonEmpty, "search should find results")
+    assertEquals(names.head, "UserService")
+    val lastExact = names.lastIndexOf("UserService")
+    val firstPrefix = names.indexOf("UserServiceLive")
+    assert(firstPrefix > lastExact, s"prefix matches should come after exact: $names")
+  }
+
+  test("search camelCase fuzzy matches rank after substring matches") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val names = idx.search("usl").map(_.name)
+    assert(names.contains("UserServiceLive"), s"camelCase fuzzy should match UserServiceLive: $names")
+  }
+
+  test("searchFiles ranks exact filename match first") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val results = idx.searchFiles("UserService")
+    assert(results.nonEmpty)
+    assert(results.head.endsWith("UserService.scala"), s"exact filename should rank first: $results")
+  }
+
+  // ── Overview architecture deps lock (import source swap) ─────────────────
+
+  test("overview --architecture computes package deps from imports") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val ctx = CommandContext(idx = idx, workspace = workspace, jsonOutput = true, limit = 50, architecture = true)
+    val out = captureOut { runCommand("overview", Nil, ctx) }
+    // com.client files import com.example (explicit, wildcard, and renaming);
+    // no other cross-package imports exist in the fixture
+    assert(out.contains(""""packageDependencies":{"com.client":["com.example"]}"""),
+      s"package deps should be exactly com.client -> com.example: $out")
+  }
+
+  test("overview --focus-package filters dependency graph") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val ctx = CommandContext(idx = idx, workspace = workspace, limit = 50, focusPackage = Some("com.example"))
+    val out = captureOut { runCommand("overview", Nil, ctx) }
+    assert(out.contains("com.client"), s"dependents of com.example should include com.client: $out")
+  }
+
+  // ── Java extraction consistency lock ──────────────────────────────────────
+
+  test("java method signatures identical between file symbols and members") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val file = workspace.resolve("src/main/java/com/example/UserRepository.java")
+    val memberSigs = extractMembers(file, "UserRepository")
+      .filter(m => m.kind == SymbolKind.Def && m.name != "<init>").map(_.signature).toSet
+    val symbolSigs = idx.fileSymbols("src/main/java/com/example/UserRepository.java")
+      .filter(_.kind == SymbolKind.Def).map(_.signature).toSet
+    assertEquals(memberSigs, symbolSigs)
+    assert(memberSigs.contains("def findById(id: String): Optional<String>"), s"sigs: $memberSigs")
+  }
+
+  test("java field signatures identical between file symbols and members") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val file = workspace.resolve("src/main/java/com/example/GenericRepository.java")
+    val memberSigs = extractMembers(file, "GenericRepository")
+      .filter(m => m.kind == SymbolKind.Val || m.kind == SymbolKind.Var).map(_.signature).toSet
+    val symbolSigs = idx.fileSymbols("src/main/java/com/example/GenericRepository.java")
+      .filter(s => s.kind == SymbolKind.Val || s.kind == SymbolKind.Var).map(_.signature).toSet
+    assertEquals(memberSigs, symbolSigs)
+    assert(memberSigs.contains("val tableName: String"), s"sigs: $memberSigs")
+    assert(memberSigs.contains("var maxResults: int"), s"sigs: $memberSigs")
+  }
+
+  // ── Truncation footer lock ────────────────────────────────────────────────
+
+  test("search text output shows truncation footer when over limit") {
+    val idx = WorkspaceIndex(workspace)
+    idx.index()
+    val total = idx.search("User").size
+    assert(total > 2, "fixture should have more than 2 User matches")
+    val ctx = CommandContext(idx = idx, workspace = workspace, limit = 2)
+    val out = captureOut { runCommand("search", List("User"), ctx) }
+    assert(out.contains(s"... and ${total - 2} more"), s"should show footer: $out")
+  }
+
+  // ── Context-line rendering lock (content, not alignment) ─────────────────
+
+  test("refs -C output marks the matching line and shows neighbors") {
+    val ref = Reference(workspace.resolve("src/main/scala/com/example/UserService.scala"), 4, "def findUser(id: String): Option[User]")
+    val s = formatRefWithContext(ref, workspace, 1)
+    assert(s.contains("| trait UserService {"), s"should show line before: $s")
+    assert(s.contains("|   def findUser(id: String): Option[User]"), s"should show match line: $s")
+    val markedLines = s.linesIterator.filter(_.trim.startsWith("> ")).toList
+    assertEquals(markedLines.size, 1, s"exactly one marked line: $s")
+    assert(markedLines.head.contains("findUser"), s"marker on match line: $s")
+  }
+}


### PR DESCRIPTION
## Summary

Dedup pass over the whole CLI — every repeated computation/pattern identified in review is now a single reusable unit. Net **−37 lines of production code** (plus a new 354-line guard-test suite).

### Extracted units

- **JSON emission helpers** (`jStr`/`jArr`/`jStrArr`/`jOpt`, `jsonMemberFields`, `jsonBodyFields`) replace ~50 hand-rolled `jsonEscape` interpolation fragments across all renderers — every string value is escaped exactly once by construction
- **`DeadlineScan` chassis** behind `grepFiles`/`findReferences`/`findImports` (deadline, result queue, unreadable-file counter, parallel per-file/per-line scanning)
- **`pathPredicate`** shares the `--no-tests`/`--path`/`--exclude-path` chain across `filterSymbols`, `filterRefs`, `grepFiles`, `astPatternSearch`, `tests`
- **`nameMatchTier`** classifier (exact/prefix/contains/reverse-contains/camelCase) behind symbol search, file search, and owner-scoped suggestions; **`buildMultiIndex`** for the inverted lazy indexes
- **`requireArg`** replaces the 21 identical `args.headOption match … UsageError` command preambles; **`findTypeDefs`** names the repeated type-definition lookup
- **`overview --architecture/--concise`** reads imports recorded in the index instead of re-parsing every source file
- **Java extraction** shares `javaParams`/`javaMethodSig`/`javaFieldInfo`/`javaLine` between symbol, member, and body extraction — signatures can no longer drift apart
- format.scala text helpers: `renderShown` footers, `numberedLine` gutters, `contextWindow` (single file read), one recursive hierarchy printer, `SymbolKind.label`, `Confidence.label/explanation`, `refCategoryOrder`, `wildcardImportPkg`, `pkgSuffix`
- Policy/layering: `bench.scala` is `return`-free; the graph-command flag strip-list is derived from the flag registry; `coverage` computes its not-found hint in the command, not the renderer

### Bug fixes

- `grep --json` emitted **invalid JSON** when the auto-corrected pattern contained backslashes or quotes (unescaped `"corrected"` hint) — failing test written first, then fixed
- `graph --render … --limit 5` corrupted the edge-list args (hardcoded strip-list missed value-taking flags)
- `refs`/`imports` could report partial results without `timedOut: true` when the deadline expired mid-file on the last scanned file

### Behavior changes (documented in CHANGELOG)

- Line-number gutters uniformly left-aligned (`refs -C` previously right-aligned, `body` left-aligned)

### Tests

New `RefactorGuardSuite`: a dependency-free structural JSON validator swept over **every `--json` command variant** (50+ cases), plus locks on search ranking, overview package-dependency edges, Java signature consistency between `symbols`/`members`, truncation footers, and context-line rendering. **477/477 tests green, zero warnings, zero deprecations.**

### Benchmarks (scala3 corpus, 17.7k files, hyperfine, native image)

| Benchmark | Before | After | Change |
|---|---|---|---|
| Cold index | 3760ms | 3255ms | −13% |
| Warm index | 354ms | 313ms | −12% |
| `overview --concise` | 3676ms | 747ms | **−80% (4.9×)** |
| def / impl / search / hierarchy / explain | — | — | −8% to −18% |
| refs / imports / coverage | — | — | +7–15% (native only, see below) |
| Index size | 21.3MB | 21.3MB | unchanged |

The bloom-loading commands (`refs`/`imports`/`coverage`) regressed ~50–90ms **in the native image only**: the delta sits entirely in the untouched index-deserialization phase, JVM mode shows parity, a rebuild reproduces it exactly, and `-XX:+PrintGC` attributes it to GC pacing (3 extra collections, slower full GC) from the binary growing. Pinning the heap (`-Xms1g`) recovers most of it on both old and new binaries. Follow-up tracked separately: evaluate a build-time min-heap setting or lazy bloom deserialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)