### PR TITLE
refactor: simplicity pass — delete dead code, collapse single-impl abstractions, fix sibling-box parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- `graph --parse` no longer drops sibling nested boxes: a box containing two or more boxes side by side wrongly promoted all but one of them to top level (and leaked their border characters into the parent's text). Box containment is now resolved by linking each box to its smallest container
+- `grep --in <owner>`: an unreadable file no longer discards matches already found in other files defining the same owner; the file is skipped instead
+
 ### Changed
+- `ast-pattern --json` now emits the same symbol object as `search`/`def` (gains `parents`, `typeParamParents`, and `annotations` fields) — one JSON shape for all symbol-returning commands
 - When both `-w` and `--workspace` are passed, the last occurrence now wins (previously `--workspace` always took precedence regardless of position)
 - `refs --top` now uses the same timed-out suffix as every other command (`(timed out — partial results)` instead of `(timed out — results may be incomplete)`)
 - `overview --architecture/--concise/--focus-package` reads imports recorded in the index instead of re-parsing every source file — on the scala3 corpus (17.7k files) this drops `overview --concise` from ~3.7s to ~0.75s (4.9×)
@@ -38,6 +43,11 @@
 - Member extraction (`members`, `grep --each-method`) now shares one traversal; body extraction and the Scala 3 → 2.13 parse fallback are deduplicated
 - Removed all remaining `return` statements from production code (34) per the codebase-wide policy
 - Deduplicated command-layer logic into shared helpers: dotted-name splitting (`simpleNameOf`, `splitOwnerMember`), member decoration (`decorateMembers`), body-size gating (`bodyWithinLimit`), package resolve-or-not-found (`withResolvedPackage`), stdlib package detection/ranking (`isStdlibPackage`, `stdlibPkgRank`), timed-out suffix, and kind counting (`countByKind`); `grep` shares one owner-lookup and span-scan path, and `overview` computes its parent ranking once for both most-extended and hub types
+- Simplicity pass (−443 lines net, no behavior change beyond the items above). Benchmarked on the scala3 corpus (17.7k files): index size byte-identical, cold index −12%, warm index and all index-backed queries at parity. The bloom-loading commands (`refs`/`imports`) show another ~10% native-binary slowdown isolated to the untouched index-deserialization phase with exact JVM parity (cache-load 237 ms on both HEAD and this change) — the same GraalVM GC-pacing/codegen artifact documented above, this time from the binary shrinking 42→40 MB:
+  - graph module: deleted the unused library surface (`EdgeType`/`connections`, `CrossingCalculator`, `OccupancyGrid`, `GraphUtils.topologicalSort`/`hasCycle`, six unused `Graph` methods, `QuadTree.collisions`, assorted dead members) and collapsed single-implementation abstractions: the `Lens` machinery (replaced by a plain child-node list), `VertexRenderingStrategy` (with its `asInstanceOf` casts), and the `LayoutPrefs`/`RendererPrefs` trait tower (now one `LayoutPrefs` case class); `Direction` is a Scala 3 enum; the renderer's twelve per-character defs are three indexed glyph strings, and the swapped `lineHorizontalChar`/`lineVerticalChar` names are fixed
+  - `graph --parse` text collection no longer rebuilds the all-edge-labels point set once per scanned character (was O(edges × area) per box cell)
+  - deleted parallel types: `AstPatternMatch` (≡ `SymbolInfo`), dead `CategorizedRef`, `OverviewData.hubTypes` (same data as `mostExtended`), write-only `SymbolList.total`/`StringList.total`, write-only `TestCaseInfo.suiteName`/`suiteFile`; `HierarchyNode`'s four parallel `Option` fields are now one `Option[SymbolInfo]`; the `symbols --summary` "already printed" sentinel is an explicit `CmdResult.Silent`
+  - folded duplicated logic: `index()` cached/uncached parse branches are one path, `search`/`searchFiles` share one tier bucketer, `findImplementations`/`fixPosixRegex`/`cmdGrep` lost their copy-pasted branches, `grep --in` reads each file once per owner definition (was once per body block), categorized refs resolve confidence once per ref (was once per confidence level), and the overview/index-stats/entrypoints renderers share their repeated print blocks and JSON fragments (`jKindCounts`, `InheritedGroup` alias)
 
 ## [1.40.0] — 2026-06-01
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,17 @@
 
 - [ ] Publish plugin to Claude Code marketplace
 
+### Simplicity review: remove dead code and single-use abstractions (no behavior change except noted)
+
+- [x] graph module: delete dead library surface (`EdgeType`/`connections`, `CrossingCalculator`, `OccupancyGrid`, `GraphUtils.topologicalSort`/`hasCycle`, six unused `Graph` methods, `QuadTree.collisions`, `Utils.removeFirst`/`signum`, misc dead members)
+- [x] graph module: collapse single-implementation abstractions (`Lens` machinery, `VertexRenderingStrategy`, `LayoutPrefs`/`RendererPrefs` trait tower, redundant `renderGraph` overload); replace the twelve per-character renderer defs with three indexed glyph strings; fix swapped `lineHorizontalChar`/`lineVerticalChar` names; `Direction` as Scala 3 enum
+- [x] Bug fix: `Diagram` parsing drops sibling nested boxes (`boxContains` keyed `.toMap` by outer box keeps only the last pair); each box now links to its smallest container (regression test added)
+- [x] Perf fix: `collectText` rebuilds the all-edge-labels point set once per scanned character; hoisted to a parser-level lazy val
+- [x] src/: delete parallel types (`AstPatternMatch` → reuse `SymbolInfo`; dead `CategorizedRef`; `OverviewData.hubTypes` → derive from `mostExtended`; dead `SymbolList.total`/`StringList.total`; dead `TestCaseInfo.suiteName`/`suiteFile`; `HierarchyNode` holds `Option[SymbolInfo]` instead of four parallel `Option` fields; explicit `CmdResult.Silent` replaces the empty-`StringList` sentinel). Behavior change: `ast-pattern --json` gains `parents`/`typeParamParents`/`annotations` fields (now shares `jsonSymbol`)
+- [x] src/: fold duplicated logic (`index()` cached/uncached parse branches, tier-ranking behind `search`/`searchFiles`/owner-scoped suggestions, `findImplementations` branches, `cmdGrep` result-building arms, `grepInSymbol` per-body file re-read, `renderOverview` concise/full print blocks, `renderCategorizedRefs` triple confidence resolve, `extractRawSymbols` type-defn arms, `fixPosixRegex` fallback, `jKindCounts`/`InheritedGroup` shared fragments)
+- [x] Micro-cleanups: identical `if` branches (`requiredWidth`), identical `catch` arms, `var`→`val`, pass-through aliases/wrappers, hand-rolled stdlib equivalents
+- Net: −443 lines across 29 files; deferred as not worth the churn: `KinkRemover` mirror-case helper (delicate choreography), `gitShowFile`/`runGitLines` unification (semantic differences in a perf-tuned area), `TestCaseResult`/`TestSuiteResult` merge, `SymbolKind.id` vs `ordinal` (persisted-format decoupling is deliberate)
+
 ### Dedup refactor: extract reusable units across src/ (no behavior change except noted)
 
 - [x] JSON emission helpers (`jStr`/`jArr`/`jStrArr`/`jOpt`/`jsonMemberFields`/`jsonBodyFields`) replacing ~50 hand-rolled `jsonEscape` interpolation fragments in `format.scala`

--- a/graph/src/common.scala
+++ b/graph/src/common.scala
@@ -26,8 +26,6 @@ case class Point(row: Int, column: Int)
   def maxRowCol(that: Point): Point =
     Point(math.max(this.row, that.row), math.max(this.column, that.column))
 
-  type Self = Point
-
   def translate(down: Int = 0, right: Int = 0): Point =
     Point(row + down, column + right)
 
@@ -36,8 +34,6 @@ case class Point(row: Int, column: Int)
   def neighbours: List[Point] = List(up, right, down, left)
 
   def withRow(newRow: Int) = copy(row = newRow)
-
-  def withColumn(newColumn: Int) = copy(column = newColumn)
 
   def region: Region = Region(this, this)
 
@@ -111,36 +107,34 @@ case class Dimension(height: Int, width: Int) extends Transposable[Dimension]:
 
 // ── Direction ───────────────────────────────────────────────────────────────
 
-sealed trait Direction:
+enum Direction {
+  case Up, Down, Left, Right
   import Direction.*
 
-  val turnLeft: Direction
-  val turnRight: Direction
-  val opposite: Direction
+  def turnLeft: Direction = this match {
+    case Up => Left
+    case Down => Right
+    case Left => Down
+    case Right => Up
+  }
+
+  def turnRight: Direction = this match {
+    case Up => Right
+    case Down => Left
+    case Left => Up
+    case Right => Down
+  }
+
+  def opposite: Direction = this match {
+    case Up => Down
+    case Down => Up
+    case Left => Right
+    case Right => Left
+  }
 
   def isVertical = this == Up || this == Down
   def isHorizontal = !isVertical
-
-object Direction:
-  case object Up extends Direction:
-    val turnLeft = Left
-    val turnRight = Right
-    val opposite: Direction = Down
-
-  case object Down extends Direction:
-    val turnLeft = Right
-    val turnRight = Left
-    val opposite: Direction = Up
-
-  case object Left extends Direction:
-    val turnLeft = Down
-    val turnRight = Up
-    val opposite: Direction = Right
-
-  case object Right extends Direction:
-    val turnLeft = Up
-    val turnRight = Down
-    val opposite: Direction = Left
+}
 
 // ── Translatable ────────────────────────────────────────────────────────────
 

--- a/graph/src/diagram-model.scala
+++ b/graph/src/diagram-model.scala
@@ -13,54 +13,14 @@ trait DiagramContainer:
 trait DiagramBox extends DiagramContainer:
   def edges: List[DiagramEdge]
 
-  def connections(edgeType: EdgeType = EdgeType.All): List[(DiagramEdge, DiagramBox)] =
-    for
-      edge <- edges
-      if edgeType.includeEdge(edge, this)
-      otherBox = edge.otherBox(this)
-    yield edge -> otherBox
-
 // ── DiagramEdge ─────────────────────────────────────────────────────────────
 
 trait DiagramEdge:
-  def points: List[Point]
-  def parent: DiagramContainer
   val box1: DiagramBox
   val box2: DiagramBox
   def hasArrow1: Boolean
   def hasArrow2: Boolean
   def label: Option[String]
-
-  def otherBox(box: DiagramBox): DiagramBox =
-    if box == box1 then box2
-    else if box == box2 then box1
-    else throw IllegalArgumentException("Box not part of edge: " + box)
-
-  def hasArrow(box: DiagramBox): Boolean =
-    if box == box1 then hasArrow1
-    else if box == box2 then hasArrow2
-    else throw IllegalArgumentException("Box not part of edge: " + box)
-
-  def otherHasArrow(box: DiagramBox): Boolean = hasArrow(otherBox(box))
-
-// ── EdgeType ────────────────────────────────────────────────────────────────
-
-sealed trait EdgeType:
-  def includeEdge(edge: DiagramEdge, thisBox: DiagramBox): Boolean
-
-object EdgeType:
-  case object Out extends EdgeType:
-    def includeEdge(edge: DiagramEdge, fromBox: DiagramBox): Boolean = edge.otherHasArrow(fromBox)
-
-  case object In extends EdgeType:
-    def includeEdge(edge: DiagramEdge, fromBox: DiagramBox): Boolean = edge.hasArrow(fromBox)
-
-  case object Undirected extends EdgeType:
-    def includeEdge(edge: DiagramEdge, fromBox: DiagramBox): Boolean =
-      !edge.hasArrow1 && !edge.hasArrow2
-
-  case object All extends EdgeType:
-    def includeEdge(edge: DiagramEdge, fromBox: DiagramBox): Boolean = true
 
 // ── Diagram ─────────────────────────────────────────────────────────────────
 

--- a/graph/src/diagram-parser.scala
+++ b/graph/src/diagram-parser.scala
@@ -222,7 +222,7 @@ class DiagramParser(s: String):
 
   // ── DiagramImplementation ───────────────────────────────────────────────
 
-  protected class DiagramImpl(numberOfRows: Int, numberOfColumns: Int) extends ContainerImpl with Diagram:
+  protected class DiagramImpl extends ContainerImpl with Diagram:
     var allBoxes: List[BoxImpl] = Nil
     var allEdges: List[EdgeImpl] = Nil
     def boxAt(point: Point): Option[BoxImpl] = allBoxes.find(_.boundaryPoints.contains(point))
@@ -300,24 +300,23 @@ class DiagramParser(s: String):
   private val rows = rawRows.map(_.padTo(numberOfColumns, ' ')).toArray
   protected val numberOfRows = rows.length
   protected val diagramRegion = Region(Point(0, 0), Point(numberOfRows - 1, numberOfColumns - 1))
-  protected val diagram = new DiagramImpl(numberOfRows, numberOfColumns)
+  protected val diagram = new DiagramImpl
 
   diagram.allBoxes = findAllBoxes
 
-  private val boxContains: Map[BoxImpl, BoxImpl] =
+  // Each box's parent is its smallest containing box (or the diagram if none)
+  private val boxContainers: Map[BoxImpl, List[BoxImpl]] =
     (for
       outerBox <- diagram.allBoxes
       innerBox <- diagram.allBoxes
       if outerBox != innerBox
       if outerBox.region.contains(innerBox.region)
-    yield outerBox -> innerBox).toMap
+    yield (outer = outerBox, inner = innerBox)).groupMap(_.inner)(_.outer)
 
-  for (box, containingBoxMap) <- boxContains.groupBy(_._2) do
-    val containingBoxes = box :: containingBoxMap.keys.toList
-    val orderedBoxes = containingBoxes.sortBy(_.region.area)
-    for (childBox, parentBox) <- orderedBoxes.zip(orderedBoxes.drop(1)) do
-      childBox.parent = Some(parentBox)
-      parentBox.childBoxes ::= childBox
+  for (box, containingBoxes) <- boxContainers do
+    val parentBox = containingBoxes.minBy(_.region.area)
+    box.parent = Some(parentBox)
+    parentBox.childBoxes ::= box
 
   for
     box <- diagram.allBoxes
@@ -362,6 +361,9 @@ class DiagramParser(s: String):
     else if !isBoxDrawingCharacter(charAt(startPoint)) then followAsciiEdge(initialPoints, direction)
     else None
 
+  private lazy val allLabelPoints: Set[Point] =
+    diagram.allEdges.flatMap(_.label_.toList.flatMap(_.points)).toSet
+
   private def collectText(container: ContainerImpl): String =
     val childBoxPoints = container.childBoxes.flatMap(_.region.points).toSet
     val sb = new StringBuilder
@@ -372,7 +374,7 @@ class DiagramParser(s: String):
         point = Point(row, column)
         if !childBoxPoints.contains(point)
         if !allEdgePoints.contains(point)
-        if !(diagram.allEdges.flatMap(_.label_.toList.flatMap(_.points)).toSet.contains(point))
+        if !allLabelPoints.contains(point)
       do sb.append(charAt(point))
       sb.append("\n")
     if sb.nonEmpty then sb.deleteCharAt(sb.length - 1)

--- a/graph/src/graph-model.scala
+++ b/graph/src/graph-model.scala
@@ -22,24 +22,12 @@ case class Graph[V](vertices: Set[V], edges: List[(V, V)]):
   require(outMap.keys.forall(vertices.contains))
   require(inMap.keys.forall(vertices.contains))
 
-  def isEmpty = vertices.isEmpty
-  def inEdges(v: V): List[(V, V)] = edges.filter(_._2 == v)
-  def outEdges(v: V): List[(V, V)] = edges.filter(_._1 == v)
   def inVertices(v: V): List[V] = inMap.getOrElse(v, Nil)
   def outVertices(v: V): List[V] = outMap.getOrElse(v, Nil)
   def outDegree(v: V): Int = outVertices(v).size
   def inDegree(v: V): Int = inVertices(v).size
   def sources: List[V] = vertices.toList.filter(inDegree(_) == 0)
   def sinks: List[V] = vertices.toList.filter(outDegree(_) == 0)
-
-  def removeEdge(edge: (V, V)): Graph[V] =
-    copy(edges = removeFirst(edges, edge))
-
-  def removeVertex(v: V): Graph[V] =
-    Graph(vertices.filterNot(_ == v), edges.filterNot { case (v1, v2) => v1 == v || v2 == v })
-
-  def map[U](f: V => U): Graph[U] =
-    Graph(vertices.map(f), edges.map { case (v1, v2) => (f(v1), f(v2)) })
 
   override lazy val hashCode = vertices.## + edges.##
 
@@ -62,34 +50,10 @@ case class Graph[V](vertices: Set[V], edges: List[(V, V)]):
 
   override def toString =
     try
-      val layoutPrefs = LayoutPrefsImpl(unicode = true, explicitAsciiBends = false)
+      val layoutPrefs = LayoutPrefs(unicode = true, explicitAsciiBends = false)
       "\n" + GraphLayout.renderGraph(this, layoutPrefs = layoutPrefs) + "\n" + asVertexList
     catch
       case _: Throwable => asVertexList
-
-// ── GraphUtils ──────────────────────────────────────────────────────────────
-
-object GraphUtils:
-  def topologicalSort[V](g: Graph[V]): Option[List[V]] =
-    var sort: List[V] = Nil
-    var sources: List[V] = g.sources
-    var deletedEdges: Set[(V, V)] = Set()
-    while sources.nonEmpty do
-      val n = sources.head
-      sources = sources.tail
-      sort ::= n
-      for
-        m <- g.outVertices(n)
-        if !deletedEdges.contains((m, n))
-      do
-        deletedEdges += ((n, m))
-        if g.inEdges(m).filterNot(deletedEdges).isEmpty &&
-           !sources.contains(m)
-        then sources ::= m
-    if deletedEdges == g.edges.toSet then Some(sort.reverse)
-    else None
-
-  def hasCycle(g: Graph[?]): Boolean = topologicalSort(g).isEmpty
 
 // ── DiagramToGraphConvertor ─────────────────────────────────────────────────
 

--- a/graph/src/layout-coord.scala
+++ b/graph/src/layout-coord.scala
@@ -2,20 +2,15 @@ package asciiGraph
 
 import Utils.*
 
-// ── VertexRenderingStrategy ─────────────────────────────────────────────────
+// ── VertexRendering ─────────────────────────────────────────────────────────
 
-trait VertexRenderingStrategy[-V]:
-  def getPreferredSize(v: V): Dimension
-  def getText(v: V, allocatedSize: Dimension): List[String]
-
-// ── ToStringVertexRenderingStrategy ─────────────────────────────────────────
-
-object ToStringVertexRenderingStrategy extends VertexRenderingStrategy[Any]:
-  def getPreferredSize(v: Any): Dimension =
+/** Renders a vertex's contents (via toString) into box text lines. */
+object VertexRendering:
+  def preferredSize(v: Any): Dimension =
     val lines = splitLines(v.toString)
     Dimension(lines.size, if lines.isEmpty then 0 else lines.map(_.size).max)
 
-  def getText(v: Any, allocatedSize: Dimension): List[String] =
+  def text(v: Any, allocatedSize: Dimension): List[String] =
     val unpaddedLines = splitLines(v.toString).take(allocatedSize.height).map(line => centerLine(allocatedSize, line))
     val verticalDiscrepancy = Math.max(0, allocatedSize.height - unpaddedLines.size)
     val verticalPadding = List.fill(verticalDiscrepancy / 2)("")
@@ -44,7 +39,6 @@ case class EdgeInfo(
   def finishColumn = finishPort.column
   def requiresBend = !isStraight
   def isStraight = startColumn == finishColumn
-  def withFinishColumn(column: Int) = copy(finishPort = finishPort.withColumn(column))
 
 // ── VertexInfo ──────────────────────────────────────────────────────────────
 
@@ -64,8 +58,8 @@ case class VertexInfo(
     VertexInfo(
       boxRegion.translate(down, right),
       greaterRegion.translate(down, right),
-      transformValues(inEdgeToPortMap)(_.translate(down, right)),
-      transformValues(outEdgeToPortMap)(_.translate(down, right)),
+      inEdgeToPortMap.transform((_, p) => p.translate(down, right)),
+      outEdgeToPortMap.transform((_, p) => p.translate(down, right)),
       selfInPorts.map(_.translate(down, right)),
       selfOutPorts.map(_.translate(down, right))
     )
@@ -90,7 +84,7 @@ case class LayerInfo(vertexInfos: Map[LayeringVertex, VertexInfo])
   def topSelfEdgeBuffer: Int = vertexInfos.values.map(getSelfEdgeBuffer).fold(0)(_ max _)
 
   def translate(down: Int = 0, right: Int = 0) =
-    copy(vertexInfos = transformValues(vertexInfos)(_.translate(down, right)))
+    copy(vertexInfos = vertexInfos.transform((_, info) => info.translate(down, right)))
 
   def realVertexInfos: List[(RealVertex, VertexInfo)] =
     vertexInfos.toList.collect { case (vertex: RealVertex, info) => (vertex, info) }
@@ -101,7 +95,7 @@ class EdgeBendCalculator(edgeInfos: List[EdgeInfo], edgeZoneTopRow: Int, selfEdg
   private val edgeRows: Map[EdgeInfo, Int] = orderEdgeBends(edgeInfos)
   require(edgeInfos.forall(edge => edge.isStraight || edgeRows.contains(edge)))
 
-  private def bendRow(rowIndex: Int) = edgeZoneTopRow + rowIndex * 1 + 1
+  private def bendRow(rowIndex: Int) = edgeZoneTopRow + rowIndex + 1
 
   val edgeZoneBottomRow =
     (if edgeInfos.isEmpty then -1
@@ -112,9 +106,7 @@ class EdgeBendCalculator(edgeInfos: List[EdgeInfo], edgeZoneTopRow: Int, selfEdg
 
   private def orderEdgeBends(edgeInfos: List[EdgeInfo]): Map[EdgeInfo, Int] =
     def edgeRank(edgeInfo: EdgeInfo): Int =
-      val startColumn = edgeInfo.startColumn
-      val finishColumn = edgeInfo.finishColumn
-      signum(startColumn - finishColumn) * finishColumn
+      math.signum(edgeInfo.startColumn - edgeInfo.finishColumn) * edgeInfo.finishColumn
     val orderedEdges = edgeInfos.filter(_.requiresBend).sortBy(edgeRank)
     val edgeToRowMap: Map[EdgeInfo, Int] = orderedEdges.zipWithIndex.toMap
     reorderEdgesWithSameStartAndEndColumns(edgeToRowMap)
@@ -197,24 +189,19 @@ object PortNudger:
     vertexInfo.copy(inEdgeToPortMap = newInEdgeToPortMap, outEdgeToPortMap = newOutEdgeToPortMap)
 
   private def isStraight(edge: LayeringEdge, vertexInfo: VertexInfo, previousLayerInfoOpt: Option[LayerInfo]) =
-    val column1: Option[Int] =
+    val outColumn: Option[Int] =
       for
         previousLayerInfo <- previousLayerInfoOpt
         previousVertexInfo <- previousLayerInfo.vertexInfo(edge.startVertex)
-        outPort = previousVertexInfo.outEdgeToPortMap(edge)
-      yield outPort.column
-    val column2: Option[Int] = Some(vertexInfo.inEdgeToPortMap(edge).column)
-    column1 == column2
+      yield previousVertexInfo.outEdgeToPortMap(edge).column
+    outColumn.contains(vertexInfo.inEdgeToPortMap(edge).column)
 
 // ── Layouter ────────────────────────────────────────────────────────────────
 
 object Layouter:
   private val MINIMUM_VERTEX_HEIGHT = 3
 
-class Layouter(
-    vertexRenderingStrategy: VertexRenderingStrategy[?],
-    vertical: Boolean = true
-):
+class Layouter(vertical: Boolean = true):
   import Layouter.*
 
   case class LayoutState(
@@ -228,20 +215,17 @@ class Layouter(
 
   def layout(layering: Layering): Drawing =
     val layerInfos: Map[Layer, LayerInfo] = calculateLayerInfos(layering)
-    var layoutState = LayoutState(LayerInfo(Map()), Map(), Nil)
-    for layer <- layering.layers do
-      val layerResult = layoutLayer(
-        layoutState.previousLayerInfo, layerInfos(layer),
-        layering.edges, layoutState.incompleteEdges
+    val finalState = layering.layers.foldLeft(LayoutState(LayerInfo(Map()), Map(), Nil)) { (state, layer) =>
+      state.mergeLayerResult(
+        layoutLayer(state.previousLayerInfo, layerInfos(layer), layering.edges, state.incompleteEdges)
       )
-      layoutState = layoutState.mergeLayerResult(layerResult)
-    Drawing(layoutState.drawingElements)
+    }
+    Drawing(finalState.drawingElements)
 
   private def calculateLayerInfos(layering: Layering): Map[Layer, LayerInfo] =
-    var layerInfos: Map[Layer, LayerInfo] = Map()
-    for (previousLayerOpt, currentLayer, nextLayerOpt) <- withPreviousAndNext(layering.layers) do
-      val layerInfo = calculateLayerInfo(currentLayer, layering.edges, previousLayerOpt, nextLayerOpt)
-      layerInfos += currentLayer -> layerInfo
+    val layerInfos = withPreviousAndNext(layering.layers).map { (previousLayerOpt, currentLayer, nextLayerOpt) =>
+      currentLayer -> calculateLayerInfo(currentLayer, layering.edges, previousLayerOpt, nextLayerOpt)
+    }.toMap
     PortNudger.nudge(layering, spaceVertices(layerInfos))
 
   private def calculateLayerInfo(
@@ -276,8 +260,8 @@ class Layouter(
     vertex match
       case realVertex: RealVertex =>
         makeRealVertexInfo(realVertex, boxRegion, greaterRegion, inEdges, outEdges)
-      case dummyVertex: DummyVertex =>
-        makeDummyVertexInfo(dummyVertex, boxRegion, greaterRegion, inEdges, outEdges)
+      case _: DummyVertex =>
+        makeDummyVertexInfo(boxRegion, greaterRegion, inEdges, outEdges)
 
   private def makeRealVertexInfo(
       vertex: RealVertex, boxRegion: Region, greaterRegion: Region,
@@ -294,15 +278,11 @@ class Layouter(
     VertexInfo(boxRegion, greaterRegion, inEdgeToPortMap, outEdgeToPortMap, selfInPorts, selfOutPorts)
 
   private def makeDummyVertexInfo(
-      vertex: DummyVertex, boxRegion: Region, greaterRegion: Region,
+      boxRegion: Region, greaterRegion: Region,
       inEdges: List[LayeringEdge], outEdges: List[LayeringEdge]
   ): VertexInfo =
-    val inVertex = inEdges.head
-    val outVertex = outEdges.head
     val port = boxRegion.topLeft
-    val inEdgeToPortMap = Map(inVertex -> port)
-    val outEdgeToPortMap = Map(outVertex -> port)
-    VertexInfo(boxRegion, greaterRegion, inEdgeToPortMap, outEdgeToPortMap, Nil, Nil)
+    VertexInfo(boxRegion, greaterRegion, Map(inEdges.head -> port), Map(outEdges.head -> port), Nil, Nil)
 
   private def portOffsets(portCount: Int, vertexWidth: Int): List[Int] =
     val factor = vertexWidth / (portCount + 1)
@@ -310,14 +290,9 @@ class Layouter(
     0.until(portCount).toList.map(i => (i + 1) * factor + centraliser)
 
   private def calculateVertexDimension(v: RealVertex, inDegree: Int, outDegree: Int) =
-    val selfEdges = v.selfEdges
-    def requiredWidth(degree: Int) =
-      if vertical then (degree + selfEdges) * 2 + 1 + 2
-      else (degree + selfEdges) * 2 + 1 + 2
-    val requiredInputWidth = requiredWidth(inDegree)
-    val requiredOutputWidth = requiredWidth(outDegree)
-    val Dimension(preferredHeight, preferredWidth) = getPreferredSize(vertexRenderingStrategy, v)
-    val width = math.max(math.max(requiredInputWidth, requiredOutputWidth), preferredWidth + 2)
+    def requiredWidth(degree: Int) = (degree + v.selfEdges) * 2 + 1 + 2
+    val Dimension(preferredHeight, preferredWidth) = preferredSize(v)
+    val width = math.max(math.max(requiredWidth(inDegree), requiredWidth(outDegree)), preferredWidth + 2)
     val height = math.max(MINIMUM_VERTEX_HEIGHT, preferredHeight + 2)
     Dimension(height = height, width = width)
 
@@ -448,18 +423,11 @@ class Layouter(
 
   private def makeVertexElements(layerInfo: LayerInfo): List[VertexDrawingElement] =
     layerInfo.realVertexInfos.map { case (realVertex, info) =>
-      val text = getText(vertexRenderingStrategy, realVertex, info.contentRegion.dimension)
+      val allocatedSize = info.contentRegion.dimension
+      val text = VertexRendering.text(realVertex.contents, if vertical then allocatedSize else allocatedSize.transpose)
       VertexDrawingElement(info.boxRegion, text)
     }
 
-  private def getPreferredSize[V](vertexRenderingStrategy: VertexRenderingStrategy[V], realVertex: RealVertex): Dimension =
-    val preferredSize = vertexRenderingStrategy.getPreferredSize(realVertex.contents.asInstanceOf[V])
-    if vertical then preferredSize else preferredSize.transpose
-
-  private def getText[V](
-      vertexRenderingStrategy: VertexRenderingStrategy[V],
-      realVertex: RealVertex,
-      preferredSize: Dimension
-  ) =
-    val actualPreferredSize = if vertical then preferredSize else preferredSize.transpose
-    vertexRenderingStrategy.getText(realVertex.contents.asInstanceOf[V], actualPreferredSize)
+  private def preferredSize(realVertex: RealVertex): Dimension =
+    val size = VertexRendering.preferredSize(realVertex.contents)
+    if vertical then size else size.transpose

--- a/graph/src/layout-drawing.scala
+++ b/graph/src/layout-drawing.scala
@@ -12,7 +12,6 @@ sealed trait DrawingElement
     extends Translatable[DrawingElement]
     with Transposable[DrawingElement]:
   def translate(down: Int = 0, right: Int = 0): DrawingElement
-  def points: List[Point]
   def transpose: DrawingElement
 
 case class VertexDrawingElement(region: Region, textLines: List[String])
@@ -21,7 +20,6 @@ case class VertexDrawingElement(region: Region, textLines: List[String])
     with Transposable[VertexDrawingElement]
     with HasRegion:
   def translate(down: Int = 0, right: Int = 0) = copy(region = region.translate(down, right))
-  def points = region.points
   def transpose: VertexDrawingElement = copy(region = region.transpose)
 
 case class EdgeDrawingElement(
@@ -31,8 +29,6 @@ case class EdgeDrawingElement(
 ) extends DrawingElement
     with Translatable[EdgeDrawingElement]
     with Transposable[EdgeDrawingElement]:
-
-  lazy val points: List[Point] = segments.flatMap(_.points).distinct
 
   def translate(down: Int = 0, right: Int = 0) =
     copy(bendPoints = bendPoints.map(_.translate(down, right)))
@@ -59,17 +55,10 @@ case class EdgeDrawingElement(
     val newBendPoints = bendPoints.patch(oldIndex, List(newStart, newFinish), 2)
     copy(bendPoints = newBendPoints)
 
-  def startPoint = points.head
-  def finishPoint = points.last
+  def startPoint = bendPoints.head
+  def finishPoint = bendPoints.last
 
 case class EdgeSegment(start: Point, direction: Direction, finish: Point) extends HasRegion:
-  def points: List[Point] =
-    @tailrec
-    def scanForPoints(start: Point, direction: Direction, finish: Point, accum: List[Point]): List[Point] =
-      if start == finish then finish :: accum
-      else scanForPoints(start.go(direction), direction, finish, accum = start :: accum)
-    scanForPoints(start, direction, finish, accum = Nil).reverse
-
   def region =
     if start.column < finish.column || start.row < finish.row then Region(start, finish)
     else Region(finish, start)
@@ -118,7 +107,7 @@ case class Drawing(elements: List[DrawingElement]) extends Transposable[Drawing]
 
   def transpose: Drawing = Drawing(elements.map(_.transpose))
 
-  override def toString = Renderer.render(this, LayoutPrefsImpl())
+  override def toString = Renderer.render(this, LayoutPrefs())
 
 // ── Grid ────────────────────────────────────────────────────────────────────
 
@@ -143,23 +132,6 @@ class Grid(dimension: Dimension):
   private def region = Region(Point(0, 0), dimension)
   def contains(point: Point) = region.contains(point)
   override def toString = chars.map(new String(_)).mkString("\n")
-
-// ── OccupancyGrid ───────────────────────────────────────────────────────────
-
-class OccupancyGrid(drawing: Drawing):
-  private val grid: Array[Array[Int]] = Array.fill(drawing.dimension.height, drawing.dimension.width)(0)
-  drawing.elements.foreach(add)
-
-  def apply(point: Point): Boolean = grid(point.row)(point.column) > 0
-  def isOccupied(point: Point) = this(point)
-  private def add(element: DrawingElement) = adjust(element, 1)
-  private def remove(element: DrawingElement) = adjust(element, -1)
-  def replace(element1: DrawingElement, element2: DrawingElement): Unit =
-    remove(element1)
-    add(element2)
-  private def adjust(drawingElement: DrawingElement, delta: Int) =
-    for point <- drawingElement.points do
-      grid(point.row)(point.column) += delta
 
 // ── EdgeTracker ─────────────────────────────────────────────────────────────
 
@@ -324,7 +296,10 @@ object EdgeElevator:
     for
       segmentInfo <- segmentInfos.sortBy(_.row)
       updatedEdgeSegment <- elevate(segmentInfo, edgeTracker)
-    do segmentUpdates = addToMultimap(segmentUpdates, segmentInfo.edgeElement, segmentInfo.segment2 -> updatedEdgeSegment)
+    do
+      val edge = segmentInfo.edgeElement
+      val update = segmentInfo.segment2 -> updatedEdgeSegment
+      segmentUpdates += edge -> (update :: segmentUpdates.getOrElse(edge, Nil))
 
     for (edge, updates) <- segmentUpdates do
       currentDrawing = currentDrawing.replaceElement(edge, updateEdge(edge, updates))
@@ -388,10 +363,7 @@ object RedundantRowRemover:
     val upShift = toRow - fromRow + 1
     val newElements = drawing.elements.map {
       case ede: EdgeDrawingElement =>
-        val newBendPoints = conditionallyMap(ede.bendPoints) {
-          case p if p.row >= fromRow => p.up(upShift)
-        }
-        ede.copy(bendPoints = newBendPoints)
+        ede.copy(bendPoints = ede.bendPoints.map(p => if p.row >= fromRow then p.up(upShift) else p))
       case vde: VertexDrawingElement =>
         if vde.region.topRow < fromRow then vde
         else vde.up(upShift)
@@ -406,11 +378,11 @@ object BoxDrawingCharacters:
 // ── Renderer ────────────────────────────────────────────────────────────────
 
 object Renderer:
-  def render(drawing: Drawing, rendererPrefs: RendererPrefs) =
-    new Renderer(rendererPrefs).render(drawing)
+  def render(drawing: Drawing, prefs: LayoutPrefs) =
+    new Renderer(prefs).render(drawing)
 
-class Renderer(rendererPrefs: RendererPrefs):
-  import rendererPrefs.*
+class Renderer(prefs: LayoutPrefs):
+  import prefs.*
 
   def render(drawing: Drawing): String =
     val grid = new Grid(drawing.dimension)
@@ -421,11 +393,11 @@ class Renderer(rendererPrefs: RendererPrefs):
   @tailrec
   private def drawLine(grid: Grid, point1: Point, direction: Direction, point2: Point): Unit =
     val lineChar = direction match
-      case Up | Down => lineHorizontalChar
-      case Right | Left => lineVerticalChar
+      case Up | Down => verticalLineChar
+      case Right | Left => horizontalLineChar
     grid(point1) =
       if grid(point1) == backgroundChar then lineChar
-      else intersectionCharOpt.getOrElse(lineChar)
+      else intersectionChar
     if point1 != point2 then drawLine(grid, point1.go(direction), direction, point2)
 
   private def renderEdge(grid: Grid, element: EdgeDrawingElement, drawing: Drawing): Unit =
@@ -440,19 +412,19 @@ class Renderer(rendererPrefs: RendererPrefs):
           throw RuntimeException("Problem drawing segment " + segment + " in edge " + element, e)
 
       condOpt((previousSegmentOpt.map(_.direction), direction)) {
-        case (Some(Up), Right) | (Some(Left), Down) => grid(point1) = bendChar1
-        case (Some(Up), Left) | (Some(Right), Down) => grid(point1) = bendChar2
-        case (Some(Down), Right) | (Some(Left), Up) => grid(point1) = bendChar3
-        case (Some(Down), Left) | (Some(Right), Up) => grid(point1) = bendChar4
+        case (Some(Up), Right) | (Some(Left), Down) => grid(point1) = bendChars(0)
+        case (Some(Up), Left) | (Some(Right), Down) => grid(point1) = bendChars(1)
+        case (Some(Down), Right) | (Some(Left), Up) => grid(point1) = bendChars(2)
+        case (Some(Down), Left) | (Some(Right), Up) => grid(point1) = bendChars(3)
       }
 
     def drawBoxIntersection(intersectionPoint: Point, direction: Direction) =
       if unicode && drawing.vertexElementAt(intersectionPoint).isDefined && grid.contains(intersectionPoint) then
         grid(intersectionPoint) = direction match
-          case Up => joinChar1
-          case Down => joinChar2
-          case Right => joinChar3
-          case Left => joinChar4
+          case Up => joinChars(0)
+          case Down => joinChars(1)
+          case Right => joinChars(2)
+          case Left => joinChars(3)
 
     for EdgeSegment(point, direction, _) <- element.segments.headOption do
       if element.hasArrow1 then grid(point) = arrow(direction.opposite)
@@ -464,10 +436,10 @@ class Renderer(rendererPrefs: RendererPrefs):
 
   private def renderVertex(grid: Grid, element: VertexDrawingElement): Unit =
     val region = element.region
-    grid(region.topLeft) = topLeftChar
-    grid(region.topRight) = topRightChar
-    grid(region.bottomLeft) = bottomLeftChar
-    grid(region.bottomRight) = bottomRightChar
+    grid(region.topLeft) = cornerChars(0)
+    grid(region.topRight) = cornerChars(1)
+    grid(region.bottomLeft) = cornerChars(2)
+    grid(region.bottomRight) = cornerChars(3)
 
     for column <- (region.leftColumn + 1).to(region.rightColumn - 1) do
       grid(Point(region.topRow, column)) = boxHorizontalChar
@@ -479,66 +451,32 @@ class Renderer(rendererPrefs: RendererPrefs):
     for (line, index) <- element.textLines.zipWithIndex do
       grid(region.topLeft.right.down(index + 1)) = line
 
+    // Where an edge line meets a box side, replace the border with a junction
     if unicode then
-      for
-        row <- (element.region.topRow + 1).to(element.region.bottomRow - 1)
-        point = Point(row, element.region.leftColumn)
-        if grid(point.right) == '\u2500' // '─'
-      do grid(point) = if doubleVertices then '\u255f' else '\u251c' // '╟' or '├'
-      for
-        row <- (element.region.topRow + 1).to(element.region.bottomRow - 1)
-        point = Point(row, element.region.rightColumn)
-        if grid(point.left) == '\u2500' // '─'
-      do grid(point) = if doubleVertices then '\u2562' else '\u2524' // '╢' or '┤'
+      for row <- (region.topRow + 1).to(region.bottomRow - 1) do
+        val left = Point(row, region.leftColumn)
+        if grid(left.right) == '\u2500' then grid(left) = joinChars(3)
+        val right = Point(row, region.rightColumn)
+        if grid(right.left) == '\u2500' then grid(right) = joinChars(2)
 
-  private def lineHorizontalChar = if unicode then '\u2502' else '|' // '│'
-  private def lineVerticalChar = if unicode then '\u2500' else '-' // '─'
+  private def verticalLineChar = if unicode then '\u2502' else '|' // '│'
+  private def horizontalLineChar = if unicode then '\u2500' else '-' // '─'
+  private def intersectionChar = if unicode then '\u253c' else '-' // '┼'
 
-  private def bendChar1 =
-    if unicode then (if rounded then '\u256d' else '\u250c') // '╭' or '┌'
-    else if explicitAsciiBends then '/'
-    else '-'
-  private def bendChar2 =
-    if unicode then (if rounded then '\u256e' else '\u2510') // '╮' or '┐'
-    else if explicitAsciiBends then '\\'
-    else '-'
-  private def bendChar3 =
-    if unicode then (if rounded then '\u2570' else '\u2514') // '╰' or '└'
-    else if explicitAsciiBends then '\\'
-    else '-'
-  private def bendChar4 =
-    if unicode then (if rounded then '\u256f' else '\u2518') // '╯' or '┘'
-    else if explicitAsciiBends then '/'
-    else '-'
+  // Indexed glyph sets; call sites map junction kinds to indexes 0-3
+  private val bendChars: String = // up\u2192right/left\u2192down, up\u2192left/right\u2192down, down\u2192right/left\u2192up, down\u2192left/right\u2192up
+    if unicode then (if rounded then "\u256d\u256e\u2570\u256f" else "\u250c\u2510\u2514\u2518") // "╭╮╰╯" or "┌┐└┘"
+    else if explicitAsciiBends then "/\\\\/"
+    else "----"
 
-  private def intersectionCharOpt =
-    if unicode then Some('\u253c') // '┼'
-    else Some('-')
+  private val cornerChars: String = // top-left, top-right, bottom-left, bottom-right
+    if !unicode then "++++"
+    else if doubleVertices then "\u2554\u2557\u255a\u255d" // "╔╗╚╝"
+    else if rounded then "\u256d\u256e\u2570\u256f" // "╭╮╰╯"
+    else "\u250c\u2510\u2514\u2518" // "┌┐└┘"
 
-  private def topLeftChar =
-    if unicode then
-      if doubleVertices then '\u2554' // '╔'
-      else if rounded then '\u256d' // '╭'
-      else '\u250c' // '┌'
-    else '+'
-  private def topRightChar =
-    if unicode then
-      if doubleVertices then '\u2557' // '╗'
-      else if rounded then '\u256e' // '╮'
-      else '\u2510' // '┐'
-    else '+'
-  private def bottomLeftChar =
-    if unicode then
-      if doubleVertices then '\u255a' // '╚'
-      else if rounded then '\u2570' // '╰'
-      else '\u2514' // '└'
-    else '+'
-  private def bottomRightChar =
-    if unicode then
-      if doubleVertices then '\u255d' // '╝'
-      else if rounded then '\u256f' // '╯'
-      else '\u2518' // '┘'
-    else '+'
+  private val joinChars: String = // edge enters box: from above, below, right, left
+    if doubleVertices then "\u2564\u2567\u2562\u255f" else "\u252c\u2534\u2524\u251c" // "╤╧╢╟" or "┬┴┤├"
 
   private def boxHorizontalChar =
     if unicode then (if doubleVertices then '\u2550' else '\u2500') // '═' or '─'
@@ -546,11 +484,6 @@ class Renderer(rendererPrefs: RendererPrefs):
   private def boxVerticalChar =
     if unicode then (if doubleVertices then '\u2551' else '\u2502') // '║' or '│'
     else '|'
-
-  private def joinChar1 = if doubleVertices then '\u2564' else '\u252c' // '╤' or '┬'
-  private def joinChar2 = if doubleVertices then '\u2567' else '\u2534' // '╧' or '┴'
-  private def joinChar3 = if doubleVertices then '\u2562' else '\u2524' // '╢' or '┤'
-  private def joinChar4 = if doubleVertices then '\u255f' else '\u251c' // '╟' or '├'
 
   private def backgroundChar = ' '
 

--- a/graph/src/layout-layering.scala
+++ b/graph/src/layout-layering.scala
@@ -5,12 +5,9 @@ import scala.collection.mutable.ListBuffer
 
 // ── Layering ────────────────────────────────────────────────────────────────
 
-case class Layering(layers: List[Layer], edges: List[LayeringEdge]):
-  def edgesInto(layer: Layer): List[LayeringEdge] =
-    edges.filter(e => layer.contains(e.finishVertex))
+case class Layering(layers: List[Layer], edges: List[LayeringEdge])
 
 case class Layer(vertices: List[LayeringVertex]):
-  def contains(v: LayeringVertex) = vertices.contains(v)
   def positionOf(v: LayeringVertex) = vertices.indexOf(v)
 
 sealed abstract class LayeringVertex
@@ -30,7 +27,7 @@ object LayeringEdge:
 // ── LayeringCalculator ──────────────────────────────────────────────────────
 
 class LayeringCalculator[V]:
-  def assignLayers(cycleRemovalResult: CycleRemovalResult[V]): (Layering, Map[V, RealVertex]) =
+  def assignLayers(cycleRemovalResult: CycleRemovalResult[V]): Layering =
     val graph = cycleRemovalResult.dag
     val distancesToSink = LongestDistancesToSinkCalculator.longestDistancesToSink(cycleRemovalResult.dag)
     val maxLayerNum = if distancesToSink.isEmpty then -1 else distancesToSink.values.max
@@ -41,7 +38,7 @@ class LayeringCalculator[V]:
     for v <- graph.vertices do
       layeringBuilder.addVertex(layerNum(v), realVertices(v))
     addEdges(cycleRemovalResult, layerNum, layeringBuilder, realVertices)
-    (layeringBuilder.build, realVertices)
+    layeringBuilder.build
 
   private class LayeringBuilder(numberOfLayers: Int):
     val layers: Buffer[Buffer[LayeringVertex]] = ListBuffer.fill(numberOfLayers)(ListBuffer[LayeringVertex]())
@@ -125,26 +122,3 @@ object LongestDistancesToSinkCalculator:
           newBoundary += v1
       boundary = newBoundary
     distances
-
-// ── CrossingCalculator ──────────────────────────────────────────────────────
-
-class CrossingCalculator(layer1: Layer, layer2: Layer, edges: List[LayeringEdge]):
-  def crossingNumber(u: LayeringVertex, v: LayeringVertex): Int =
-    if u == v then 0
-    else
-      var count = 0
-      for
-        LayeringEdge(w, u2) <- edges
-        if u2 == u
-        LayeringEdge(z, v2) <- edges
-        if v2 == v
-        if layer1.positionOf(z) < layer1.positionOf(w)
-      do count += 1
-      count
-
-  def numberOfCrossings: Int =
-    (for
-      u <- layer2.vertices
-      v <- layer2.vertices
-      if layer2.positionOf(u) < layer2.positionOf(v)
-    yield crossingNumber(u, v)).sum

--- a/graph/src/layout-prefs.scala
+++ b/graph/src/layout-prefs.scala
@@ -1,24 +1,8 @@
 package asciiGraph
 
-// ── RendererPrefs ───────────────────────────────────────────────────────────
-
-trait RendererPrefs:
-  def unicode: Boolean
-  def doubleVertices: Boolean
-  def rounded: Boolean
-  def explicitAsciiBends: Boolean
-
 // ── LayoutPrefs ─────────────────────────────────────────────────────────────
 
-trait LayoutPrefs extends RendererPrefs:
-  def removeKinks: Boolean
-  def compactify: Boolean
-  def elevateEdges: Boolean
-  def vertical: Boolean
-
-// ── LayoutPrefsImpl ─────────────────────────────────────────────────────────
-
-case class LayoutPrefsImpl(
+case class LayoutPrefs(
     removeKinks: Boolean = true,
     compactify: Boolean = true,
     elevateEdges: Boolean = true,
@@ -27,4 +11,4 @@ case class LayoutPrefsImpl(
     doubleVertices: Boolean = false,
     rounded: Boolean = false,
     explicitAsciiBends: Boolean = false
-) extends LayoutPrefs
+)

--- a/graph/src/layout.scala
+++ b/graph/src/layout.scala
@@ -3,18 +3,11 @@ package asciiGraph
 // ── GraphLayout ─────────────────────────────────────────────────────────────
 
 object GraphLayout:
-  def renderGraph[V](graph: Graph[V]): String =
-    renderGraph(graph, ToStringVertexRenderingStrategy, LayoutPrefsImpl())
-
-  def renderGraph[V](
-      graph: Graph[V],
-      vertexRenderingStrategy: VertexRenderingStrategy[V] = ToStringVertexRenderingStrategy,
-      layoutPrefs: LayoutPrefs = LayoutPrefsImpl()
-  ): String =
+  def renderGraph[V](graph: Graph[V], layoutPrefs: LayoutPrefs = LayoutPrefs()): String =
     val cycleRemovalResult = CycleRemover.removeCycles(graph)
-    val (layering, _) = new LayeringCalculator[V].assignLayers(cycleRemovalResult)
+    val layering = new LayeringCalculator[V].assignLayers(cycleRemovalResult)
     val reorderedLayering = LayerOrderingCalculator.reorder(layering)
-    val layouter = new Layouter(vertexRenderingStrategy, layoutPrefs.vertical)
+    val layouter = new Layouter(layoutPrefs.vertical)
     var drawing = layouter.layout(reorderedLayering)
     if layoutPrefs.removeKinks then drawing = KinkRemover.removeKinks(drawing)
     if layoutPrefs.elevateEdges then drawing = EdgeElevator.elevateEdges(drawing)

--- a/graph/src/util.scala
+++ b/graph/src/util.scala
@@ -5,9 +5,6 @@ import scala.annotation.tailrec
 // ── Utils ───────────────────────────────────────────────────────────────────
 
 object Utils:
-  def transformValues[K, V, V2](map: Map[K, V])(f: V => V2): Map[K, V2] =
-    map.map { case (k, v) => (k, f(v)) }
-
   def withPrevious[T](iterable: Iterable[T]): List[(Option[T], T)] =
     withPreviousAndNext(iterable).map { case (a, b, _) => (a, b) }
 
@@ -42,27 +39,8 @@ object Utils:
   def mkMultiset[T](set1: List[T]): Map[T, Int] =
     set1.groupBy(identity).map { case (k, v) => k -> v.size }
 
-  def removeFirst[T](xs: List[T], x: T): List[T] =
-    xs match
-      case Nil => Nil
-      case h :: t =>
-        if h == x then t
-        else h :: removeFirst(t, x)
-
   def makeMap[T, U](s: Iterable[T], f: T => U): Map[T, U] =
     s.iterator.map(t => t -> f(t)).toMap
-
-  def signum(x: Int) =
-    x match
-      case _ if x < 0 => -1
-      case 0 => 0
-      case _ if x > 0 => +1
-
-  def conditionallyMap[T](xs: List[T])(fn: PartialFunction[T, T]): List[T] =
-    xs.map(t => if fn.isDefinedAt(t) then fn(t) else t)
-
-  def addToMultimap[K, V](m: Map[K, List[V]], k: K, v: V): Map[K, List[V]] =
-    m + (k -> (v :: m.getOrElse(k, Nil)))
 
 // ── QuadTree ────────────────────────────────────────────────────────────────
 
@@ -75,47 +53,32 @@ class QuadTree[T <: HasRegion](dimension: Dimension):
     def region: Region
     def items: Set[T]
     def contains(t: T) = region.contains(t.region)
-    def immediateItemsIntersecting(region: Region) = items.filter(i => i.region.intersects(region))
     def immediateItemIntersects(region: Region): Boolean = items.exists(i => i.region.intersects(region))
     def childNodes: List[Node]
     def addItem(t: T): Node
     def removeItem(t: T): Node
 
-  private case class QuadNode(
-      region: Region, items: Set[T],
-      topLeft: Node, topRight: Node, bottomLeft: Node, bottomRight: Node
-  ) extends Node:
-    override def childNodes: List[Node] = List(topLeft, topRight, bottomLeft, bottomRight)
+  private case class QuadNode(region: Region, items: Set[T], childNodes: List[Node]) extends Node:
     def addItem(t: T) = copy(items = items + t)
     def removeItem(t: T) = copy(items = items - t)
-
-  private object QuadNode:
-    private val topLeftL = Lens.lens[QuadNode, Node](_.topLeft, (n1, n2) => n1.copy(topLeft = n2))
-    private val topRightL = Lens.lens[QuadNode, Node](_.topRight, (n1, n2) => n1.copy(topRight = n2))
-    private val bottomLeftL = Lens.lens[QuadNode, Node](_.bottomLeft, (n1, n2) => n1.copy(bottomLeft = n2))
-    private val bottomRightL = Lens.lens[QuadNode, Node](_.bottomRight, (n1, n2) => n1.copy(bottomRight = n2))
-
-    object Lenses:
-      val topLeft = topLeftL
-      val topRight = topRightL
-      val bottomLeft = bottomLeftL
-      val bottomRight = bottomRightL
-      val childNodeLenses = List(topLeft, topRight, bottomLeft, bottomRight)
 
   private case class LeafNode(region: Region, items: Set[T]) extends Node:
     override def childNodes: List[Node] = Nil
     def addItem(t: T): LeafNode = copy(items = items + t)
     def removeItem(t: T): LeafNode = copy(items = items - t)
 
+  /** Update the child whose region contains `tRegion`, or apply `orElse` to the node itself. */
+  private def updateContainingChild(qn: QuadNode, tRegion: Region, rec: Node => Node, orElse: => Node): Node =
+    qn.childNodes.indexWhere(_.region.contains(tRegion)) match
+      case -1 => orElse
+      case i => qn.copy(childNodes = qn.childNodes.updated(i, rec(qn.childNodes(i))))
+
   def add(t: T): Unit =
     val tRegion = t.region
     def addRec(n: Node): Node =
       require(n.region.contains(tRegion))
       n match
-        case qn: QuadNode =>
-          QuadNode.Lenses.childNodeLenses.find(lens => lens(qn).region.contains(tRegion)) match
-            case Some(childLens) => childLens.update(qn, addRec)
-            case None => qn.addItem(t)
+        case qn: QuadNode => updateContainingChild(qn, tRegion, addRec, qn.addItem(t))
         case leaf: LeafNode =>
           val newLeaf = leaf.addItem(t)
           if newLeaf.items.size <= maxCapacity && newLeaf.region.width > 1 && newLeaf.region.height > 1
@@ -128,26 +91,16 @@ class QuadTree[T <: HasRegion](dimension: Dimension):
     def removeRec(n: Node): Node =
       require(n.region.contains(tRegion))
       n match
-        case qn: QuadNode =>
-          QuadNode.Lenses.childNodeLenses.find(lens => lens(qn).region.contains(tRegion)) match
-            case Some(childLens) => childLens.update(qn, removeRec)
-            case None => n.removeItem(t)
-        case _: LeafNode =>
-          n.removeItem(t)
+        case qn: QuadNode => updateContainingChild(qn, tRegion, removeRec, qn.removeItem(t))
+        case _: LeafNode => n.removeItem(t)
     rootNode = removeRec(rootNode)
 
   private def quadrate(leaf: LeafNode): QuadNode =
     val (tl, tr, bl, br) = quadrateRegion(leaf.region)
     def makeLeaf(quadrant: Region) = LeafNode(quadrant, leaf.items.filter(i => quadrant.contains(i.region)))
-    val topLeftNode = makeLeaf(tl)
-    val topRightNode = makeLeaf(tr)
-    val bottomLeftNode = makeLeaf(bl)
-    val bottomRightNode = makeLeaf(br)
-    val newItems = leaf.items.filterNot(i =>
-      topLeftNode.contains(i) || topRightNode.contains(i) ||
-      bottomLeftNode.contains(i) || bottomRightNode.contains(i)
-    )
-    QuadNode(leaf.region, newItems, topLeftNode, topRightNode, bottomLeftNode, bottomRightNode)
+    val childNodes = List(makeLeaf(tl), makeLeaf(tr), makeLeaf(bl), makeLeaf(br))
+    val newItems = leaf.items.filterNot(i => childNodes.exists(_.contains(i)))
+    QuadNode(leaf.region, newItems, childNodes)
 
   private def quadrateRegion(region: Region): (Region, Region, Region, Region) =
     val middleTop = region.topLeft.right(region.width / 2)
@@ -167,25 +120,3 @@ class QuadTree[T <: HasRegion](dimension: Dimension):
     region.intersects(node.region) &&
       (node.immediateItemIntersects(region) ||
         node.childNodes.exists(collides(region, _)))
-
-  def collisions(t: T): Set[T] = collectCollisions(t.region, rootNode)
-
-  private def collectCollisions(region: Region, node: Node): Set[T] =
-    if region.intersects(node.region) then
-      node.immediateItemsIntersecting(region) ++
-        node.childNodes.flatMap(collectCollisions(region, _))
-    else Set()
-
-// ── Lens ────────────────────────────────────────────────────────────────────
-
-object Lens:
-  def lens[T, X](getter: T => X, setter: (T, X) => T): Lens[T, X] =
-    new Lens[T, X]:
-      def get(t: T) = getter(t)
-      def set(t: T, x: X) = setter(t, x)
-
-trait Lens[T, X]:
-  def apply(t: T): X = get(t)
-  def get(t: T): X
-  def set(t: T, x: X): T
-  def update(t: T, f: X => X): T = set(t, f(get(t)))

--- a/src/analysis.scala
+++ b/src/analysis.scala
@@ -16,12 +16,10 @@ def buildHierarchy(idx: WorkspaceIndex, symbolName: String, goUp: Boolean, goDow
         s.parents.map { parentName =>
           idx.findDefinition(parentName).headOption match {
             case None =>
-              val extNode = HierarchyNode(parentName, None, None, None, "", isExternal = true)
-              HierarchyTree(extNode, Nil, Nil)
+              HierarchyTree(HierarchyNode(parentName, None), Nil, Nil)
             case Some(pd) =>
-              val pNode = HierarchyNode(pd.name, Some(pd.kind), Some(pd.file), Some(pd.line), pd.packageName, isExternal = false)
               val grandParents = walkUp(pd.name, newVisited, depth + 1)
-              HierarchyTree(pNode, grandParents, Nil)
+              HierarchyTree(HierarchyNode(pd.name, Some(pd)), grandParents, Nil)
           }
         }
       }
@@ -33,7 +31,7 @@ def buildHierarchy(idx: WorkspaceIndex, symbolName: String, goUp: Boolean, goDow
     else {
       val newVisited = visited + name.toLowerCase
       idx.findImplementations(name).map { s =>
-        val node = HierarchyNode(s.name, Some(s.kind), Some(s.file), Some(s.line), s.packageName, isExternal = false)
+        val node = HierarchyNode(s.name, Some(s))
         if depth + 1 >= maxDepth then {
           val truncated = idx.findImplementations(s.name).size
           HierarchyTree(node, Nil, Nil, truncatedChildren = truncated)
@@ -46,10 +44,9 @@ def buildHierarchy(idx: WorkspaceIndex, symbolName: String, goUp: Boolean, goDow
   }
 
   idx.findDefinition(symbolName).headOption.map { sym =>
-    val rootNode = HierarchyNode(sym.name, Some(sym.kind), Some(sym.file), Some(sym.line), sym.packageName, isExternal = false)
     val parents = if goUp then walkUp(sym.name, Set.empty, 0) else Nil
     val children = if goDown then walkDown(sym.name, Set.empty, 0) else Nil
-    HierarchyTree(rootNode, parents, children)
+    HierarchyTree(HierarchyNode(sym.name, Some(sym)), parents, children)
   }
 }
 
@@ -198,39 +195,21 @@ def astPatternSearch(idx: WorkspaceIndex, workspace: Path,
                      hasMethod: Option[String], extendsTrait: Option[String],
                      bodyContains: Option[String], noTests: Boolean,
                      pathFilter: Option[String], excludePath: Option[String] = None,
-                     limit: Int): List[AstPatternMatch] = {
+                     limit: Int): List[SymbolInfo] = {
   val keep = pathPredicate(noTests, pathFilter, excludePath, workspace)
-  var candidates = idx.symbols.filter(s => typeKinds.contains(s.kind) && keep(s.file))
-
-  // Filter by extends
-  extendsTrait.foreach { traitName =>
-    candidates = candidates.filter(_.parents.exists(_.equalsIgnoreCase(traitName)))
+  val candidates = idx.symbols.filter { s =>
+    typeKinds.contains(s.kind) && keep(s.file) &&
+    extendsTrait.forall(t => s.parents.exists(_.equalsIgnoreCase(t)))
   }
 
-  val buf = mutable.ListBuffer.empty[AstPatternMatch]
-
+  val buf = mutable.ListBuffer.empty[SymbolInfo]
   val iter = candidates.iterator
   while iter.hasNext && buf.size < limit do {
     val s = iter.next()
-    var matches = true
-
-    // Filter by has-method
-    hasMethod.foreach { methodName =>
-      val members = extractMembers(s.file, s.name)
-      if !members.exists(_.name == methodName) then matches = false
-    }
-
-    // Filter by body-contains
-    bodyContains.foreach { pattern =>
-      if matches then {
-        val bodies = extractBody(s.file, s.name, None)
-        if !bodies.exists(_.sourceText.contains(pattern)) then matches = false
-      }
-    }
-
-    if matches then {
-      buf += AstPatternMatch(s.name, s.kind, s.file, s.line, s.packageName, s.signature)
-    }
+    // The expensive per-file parses run only for candidates that pass the cheap filters
+    val ok = hasMethod.forall(m => extractMembers(s.file, s.name).exists(_.name == m)) &&
+      bodyContains.forall(p => extractBody(s.file, s.name, None).exists(_.sourceText.contains(p)))
+    if ok then buf += s
   }
   buf.toList
 }

--- a/src/command-helpers.scala
+++ b/src/command-helpers.scala
@@ -1,4 +1,5 @@
 import java.nio.file.Path
+import java.util.regex.{Pattern, PatternSyntaxException}
 import scala.collection.mutable
 
 // ── Command helpers ─────────────────────────────────────────────────────────
@@ -31,21 +32,14 @@ def splitOwnerMember(s: String): Option[(owner: String, member: String)] = {
 def fixPosixRegex(pattern: String): (pattern: String, wasFixed: Boolean) =
   // Only \| needs unconditional conversion: POSIX alternation vs Java literal pipe.
   // \( and \) mean "literal paren" in both POSIX and Java — leave them alone.
-  if hasRegexHint(pattern) then
-    val fixed = pattern.replace("\\|", "|")
-    try
-      java.util.regex.Pattern.compile(fixed)
-      (pattern = fixed, wasFixed = true)
-    catch
-      case _: java.util.regex.PatternSyntaxException =>
-        (pattern = java.util.regex.Pattern.quote(fixed), wasFixed = true)
-  else
-    try
-      java.util.regex.Pattern.compile(pattern)
-      (pattern = pattern, wasFixed = false)
-    catch
-      case _: java.util.regex.PatternSyntaxException =>
-        (pattern = java.util.regex.Pattern.quote(pattern), wasFixed = true)
+  val candidate = if hasRegexHint(pattern) then pattern.replace("\\|", "|") else pattern
+  try {
+    Pattern.compile(candidate)
+    (pattern = candidate, wasFixed = candidate != pattern)
+  } catch {
+    case _: PatternSyntaxException =>
+      (pattern = Pattern.quote(candidate), wasFixed = true)
+  }
 
 // ── Suggestions for not-found ────────────────────────────────────────────────
 
@@ -53,7 +47,7 @@ def mkNotFoundWithSuggestions(symbol: String, ctx: CommandContext, cmd: String):
   var results = ctx.idx.search(symbol)
   if ctx.noTests then results = results.filter(s => !isTestFile(s.file, ctx.workspace))
   val suggestions = results.take(5).map { s =>
-    s"${s.kind.toString.toLowerCase} ${s.name} (${s.packageName})"
+    s"${s.kind.label} ${s.name} (${s.packageName})"
   }
   NotFoundHint(symbol, ctx.idx.fileCount, ctx.idx.parseFailures, cmd, ctx.batchMode,
     symbol.contains("/") || symbol.startsWith("."), suggestions)
@@ -62,23 +56,15 @@ def mkNotFoundWithSuggestions(symbol: String, ctx: CommandContext, cmd: String):
 def mkOwnerScopedSuggestions(symbol: String, owner: String, ctx: CommandContext): List[String] =
   val ownerDefs = filterSymbols(findTypeDefs(owner, ctx), ctx.copy(kindFilter = None))
   val members = ownerDefs.headOption.toList.flatMap(s => extractMembers(s.file, s.name, Some(s.kind)))
-  // Rank by similarity: exact > prefix > contains > rest
+  // Rank by similarity: exact > prefix > contains > rest (sortBy is stable)
   val lower = symbol.toLowerCase
-  val exact = mutable.ListBuffer.empty[MemberInfo]
-  val prefix = mutable.ListBuffer.empty[MemberInfo]
-  val contains = mutable.ListBuffer.empty[MemberInfo]
-  val rest = mutable.ListBuffer.empty[MemberInfo]
-  members.foreach { m =>
-    nameMatchTier(lower, m.name) match {
-      case Some(MatchTier.Exact)    => exact += m
-      case Some(MatchTier.Prefix)   => prefix += m
-      case Some(MatchTier.Contains) => contains += m
-      case _                        => rest += m
-    }
+  def tier(m: MemberInfo): Int = nameMatchTier(lower, m.name) match {
+    case Some(MatchTier.Exact)    => 0
+    case Some(MatchTier.Prefix)   => 1
+    case Some(MatchTier.Contains) => 2
+    case _                        => 3
   }
-  (exact.toList ++ prefix.toList ++ contains.toList ++ rest.toList).take(5).map { m =>
-    s"${m.kind.label} ${m.name} in $owner"
-  }
+  members.sortBy(tier).take(5).map(m => s"${m.kind.label} ${m.name} in $owner")
 
 // ── Package resolution (shared by package, api, summary) ────────────────────
 
@@ -181,41 +167,36 @@ def countByKind(symbols: List[SymbolInfo]): List[(kind: SymbolKind, count: Int)]
 // ── Inherited member collection (shared by members + explain) ──────────────
 
 def collectInheritedMembers(sym: SymbolInfo, ctx: CommandContext): (
-  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
+  inherited: List[InheritedGroup],
   parentMemberKeys: Set[(name: String, kind: SymbolKind)]
 ) = {
   if !ctx.inherited then (inherited = Nil, parentMemberKeys = Set.empty)
-  else collectInheritedMembersImpl(sym, ctx)
-}
+  else {
+    val visited = mutable.HashSet.empty[String]
+    visited += sym.name.toLowerCase
+    val ownMembers = extractMembers(sym.file, sym.name, Some(sym.kind)).map(m => (name = m.name, kind = m.kind)).toSet
+    val result = mutable.ListBuffer.empty[InheritedGroup]
+    val allParentKeys = mutable.HashSet.empty[(name: String, kind: SymbolKind)]
 
-private def collectInheritedMembersImpl(sym: SymbolInfo, ctx: CommandContext): (
-  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
-  parentMemberKeys: Set[(name: String, kind: SymbolKind)]
-) = {
-  val visited = mutable.HashSet.empty[String]
-  visited += sym.name.toLowerCase
-  val ownMembers = extractMembers(sym.file, sym.name, Some(sym.kind)).map(m => (name = m.name, kind = m.kind)).toSet
-  val result = mutable.ListBuffer.empty[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])]
-  val allParentKeys = mutable.HashSet.empty[(name: String, kind: SymbolKind)]
-
-  def walk(parentNames: List[String]): Unit = {
-    parentNames.foreach { pName =>
-      if !visited.contains(pName.toLowerCase) then {
-        visited += pName.toLowerCase
-        val parentDefs = findTypeDefs(pName, ctx)
-        parentDefs.headOption.foreach { pd =>
-          val parentMembers = extractMembers(pd.file, pd.name, Some(pd.kind))
-          parentMembers.foreach(m => allParentKeys += ((name = m.name, kind = m.kind)))
-          val filtered = parentMembers.filterNot(m => ownMembers.contains((name = m.name, kind = m.kind)))
-          if filtered.nonEmpty then result += ((parentName = pd.name, parentFile = Some(pd.file), parentPackage = pd.packageName, members = filtered))
-          walk(pd.parents)
+    def walk(parentNames: List[String]): Unit = {
+      parentNames.foreach { pName =>
+        if !visited.contains(pName.toLowerCase) then {
+          visited += pName.toLowerCase
+          val parentDefs = findTypeDefs(pName, ctx)
+          parentDefs.headOption.foreach { pd =>
+            val parentMembers = extractMembers(pd.file, pd.name, Some(pd.kind))
+            parentMembers.foreach(m => allParentKeys += ((name = m.name, kind = m.kind)))
+            val filtered = parentMembers.filterNot(m => ownMembers.contains((name = m.name, kind = m.kind)))
+            if filtered.nonEmpty then result += ((parentName = pd.name, parentFile = Some(pd.file), parentPackage = pd.packageName, members = filtered))
+            walk(pd.parents)
+          }
         }
       }
     }
-  }
 
-  walk(sym.parents)
-  (inherited = result.toList, parentMemberKeys = allParentKeys.toSet)
+    walk(sym.parents)
+    (inherited = result.toList, parentMemberKeys = allParentKeys.toSet)
+  }
 }
 
 // ── Body enrichment (shared by members, overrides, explain) ─────────────────
@@ -316,15 +297,8 @@ def extractRelatedTypes(members: List[MemberInfo], sym: SymbolInfo, idx: Workspa
   // Cross-reference with index — skip names that are only defined in stdlib packages
   typeNames.foreach { name =>
     val lower = name.toLowerCase
-    if !seen.contains(lower) then
-      seen += lower
-      if !isStdlibType(lower, idx.symbolsByName) then
-        idx.symbolsByName.get(lower) match
-          case Some(syms) =>
-            syms.find(s => typeKinds.contains(s.kind)).foreach { s =>
-              result += s
-            }
-          case None => ()
+    if seen.add(lower) && !isStdlibType(lower, idx.symbolsByName) then
+      idx.symbolsByName.getOrElse(lower, Nil).find(s => typeKinds.contains(s.kind)).foreach(result += _)
   }
   result.toList.sortBy(_.name).take(10)
 

--- a/src/commands/annotated.scala
+++ b/src/commands/annotated.scala
@@ -5,6 +5,5 @@ def cmdAnnotated(args: List[String], ctx: CommandContext): CmdResult =
       CmdResult.SymbolList(
         header = s"Symbols annotated with @$annot — ${results.size} found:",
         symbols = results,
-        total = results.size,
         emptyMessage = s"No symbols with @$annot annotation found")
   }

--- a/src/commands/definition.scala
+++ b/src/commands/definition.scala
@@ -8,8 +8,7 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
           case Some(memberResults) =>
             CmdResult.SymbolList(
               header = s"""Definition of "$symbol":""",
-              symbols = memberResults,
-              total = memberResults.size)
+              symbols = memberResults)
           case None =>
             CmdResult.NotFound(
               s"""Definition of "$symbol": not found""",
@@ -21,8 +20,7 @@ def cmdDef(args: List[String], ctx: CommandContext): CmdResult =
       else
         CmdResult.SymbolList(
           header = s"""Definition of "$symbol":""",
-          symbols = results,
-          total = results.size)
+          symbols = results)
   }
 
 /** Resolve Owner.member syntax: if Owner is a type, extract its members and filter to the member name */

--- a/src/commands/explain.scala
+++ b/src/commands/explain.scala
@@ -66,7 +66,7 @@ def cmdExplain(args: List[String], ctx: CommandContext): CmdResult = boundary {
         else Nil
         // Members (for types)
         val inheritResult = if typeKinds.contains(sym.kind) then collectInheritedMembers(sym, ctx)
-          else (inherited = Nil: List[(parentName: String, parentFile: Option[java.nio.file.Path], parentPackage: String, members: List[MemberInfo])], parentMemberKeys = Set.empty[(name: String, kind: SymbolKind)])
+          else (inherited = Nil: List[InheritedGroup], parentMemberKeys = Set.empty[(name: String, kind: SymbolKind)])
         val inherited = inheritResult.inherited
         val parentKeys = inheritResult.parentMemberKeys
         val members = decorateMembers(rawMembers, parentKeys, sym.file, simpleName, ctx)

--- a/src/commands/file.scala
+++ b/src/commands/file.scala
@@ -4,6 +4,5 @@ def cmdFile(args: List[String], ctx: CommandContext): CmdResult =
       CmdResult.StringList(
         header = s"""Found ${results.size} files matching "$query":""",
         items = results,
-        total = results.size,
         emptyMessage = s"""Found 0 files matching "$query"\n  Hint: scalex indexes ${ctx.idx.fileCount} git-tracked .scala files.""")
   }

--- a/src/commands/graph.scala
+++ b/src/commands/graph.scala
@@ -33,26 +33,24 @@ private case class ParsedGraphEdges(vertices: Set[String], edges: List[(String, 
 
 private def parseGraphFlags(args: List[String]): (flags: GraphCmdFlags, remaining: List[String]) =
   var flags = GraphCmdFlags()
-  val remaining = scala.collection.mutable.ListBuffer[String]()
-  var i = 0
-  while i < args.size do
-    args(i) match
-      case "--unicode" => flags = flags.copy(unicode = true)
-      case "--no-unicode" => flags = flags.copy(unicode = false)
-      case "--vertical" => flags = flags.copy(vertical = true)
-      case "--horizontal" => flags = flags.copy(vertical = false)
-      case "--rounded" => flags = flags.copy(rounded = true)
-      case "--double" => flags = flags.copy(double = true)
-      case "--json" => flags = flags.copy(json = true)
-      case other => remaining += other
-    i += 1
-  (flags = flags, remaining = remaining.toList)
+  val remaining = List.newBuilder[String]
+  args.foreach {
+    case "--unicode" => flags = flags.copy(unicode = true)
+    case "--no-unicode" => flags = flags.copy(unicode = false)
+    case "--vertical" => flags = flags.copy(vertical = true)
+    case "--horizontal" => flags = flags.copy(vertical = false)
+    case "--rounded" => flags = flags.copy(rounded = true)
+    case "--double" => flags = flags.copy(double = true)
+    case "--json" => flags = flags.copy(json = true)
+    case other => remaining += other
+  }
+  (flags = flags, remaining = remaining.result())
 
 private def renderGraphCmd(edgeListStr: String, flags: GraphCmdFlags): CmdResult =
   try
     val parsed = parseGraphEdgeList(edgeListStr)
     val graph = asciiGraph.Graph(parsed.vertices, parsed.edges)
-    val prefs = asciiGraph.LayoutPrefsImpl(
+    val prefs = asciiGraph.LayoutPrefs(
       unicode = flags.unicode,
       vertical = flags.vertical,
       rounded = flags.rounded,
@@ -93,8 +91,6 @@ private def parseGraphCmd(input: String, flags: GraphCmdFlags): CmdResult =
         sb.append(s"\n  ${edge.box1.text.trim}$arrow${edge.box2.text.trim}$labelStr")
       CmdResult.GraphOutput(sb.toString)
   catch
-    case e: asciiGraph.DiagramParserException =>
-      CmdResult.UsageError(s"Error parsing diagram: ${e.getMessage}")
     case e: Exception =>
       CmdResult.UsageError(s"Error parsing diagram: ${e.getMessage}")
 

--- a/src/commands/grep.scala
+++ b/src/commands/grep.scala
@@ -12,8 +12,7 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
     case Some(rawPattern) =>
       val (pattern, wasFixed) = fixPosixRegex(rawPattern)
       val isLiteralQuoted = wasFixed && pattern.startsWith("\\Q")
-      // Use rawPattern in display strings so users never see \Q...\E internals
-      val displayPattern = rawPattern
+      // Display strings use rawPattern so users never see \Q...\E internals
       val stderrHint =
         if isLiteralQuoted then Some(s"""  Note: invalid regex, treating as literal search: "$rawPattern"""")
         else if wasFixed then Some(s"""  Note: auto-corrected POSIX regex to Java regex: "$rawPattern" → "$pattern"""")
@@ -22,36 +21,23 @@ def cmdGrep(args: List[String], ctx: CommandContext): CmdResult =
       ctx.inOwner match
         case Some(owner) if ctx.eachMethod =>
           // Per-method grep: iterate members, grep each body, report which methods matched
-          grepEachMethod(pattern, displayPattern, owner, ctx, hint, stderrHint)
-        case Some(owner) =>
-          // Scoped grep: restrict to a specific symbol's body span
-          val (scopedResults, scopedTimedOut) = grepInSymbol(pattern, owner, ctx)
+          grepEachMethod(pattern, rawPattern, owner, ctx, hint, stderrHint)
+        case ownerOpt =>
+          val (results, timedOut) = ownerOpt match
+            // Scoped grep: restrict to a specific symbol's body span
+            case Some(owner) => grepInSymbol(pattern, owner, ctx)
+            case None => ctx.idx.grepFiles(pattern, ctx.noTests, ctx.pathFilter, ctx.excludePath)
           if ctx.countOnly then
-            val fileCount = scopedResults.map(_.file).distinct.size
-            CmdResult.GrepCount(scopedResults.size, fileCount, scopedTimedOut, hint, stderrHint)
+            CmdResult.GrepCount(results.size, results.map(_.file).distinct.size, timedOut, hint, stderrHint)
           else
-            val suffix = timedOutSuffix(scopedTimedOut)
-            val inStr = s""" in $owner"""
+            val suffix = timedOutSuffix(timedOut)
+            val inStr = ownerOpt.map(o => s" in $o").getOrElse("")
             CmdResult.RefList(
-              header = s"""Matches for "$displayPattern"$inStr — ${scopedResults.size} found:$suffix""",
-              refs = scopedResults,
-              timedOut = scopedTimedOut,
-              hint = hint,
-              emptyMessage = s"""No matches for "$displayPattern"$inStr$suffix""",
-              stderrHint = stderrHint)
-        case None =>
-          val (results, grepTimedOut) = ctx.idx.grepFiles(pattern, ctx.noTests, ctx.pathFilter, ctx.excludePath)
-          if ctx.countOnly then
-            val fileCount = results.map(_.file).distinct.size
-            CmdResult.GrepCount(results.size, fileCount, grepTimedOut, hint, stderrHint)
-          else
-            val suffix = timedOutSuffix(grepTimedOut)
-            CmdResult.RefList(
-              header = s"""Matches for "$displayPattern" — ${results.size} found:$suffix""",
+              header = s"""Matches for "$rawPattern"$inStr — ${results.size} found:$suffix""",
               refs = results,
-              timedOut = grepTimedOut,
+              timedOut = timedOut,
               hint = hint,
-              emptyMessage = s"""No matches for "$displayPattern"$suffix""",
+              emptyMessage = s"""No matches for "$rawPattern"$inStr$suffix""",
               stderrHint = stderrHint)
 
 /** Find a symbol's definitions for scoped grep, falling back to an exact-name
@@ -77,7 +63,7 @@ private def grepSpan(lines: collection.Seq[String], startLine: Int, endLine: Int
   matched.toList
 }
 
-private def grepInSymbol(pattern: String, owner: String, ctx: CommandContext): (results: List[Reference], timedOut: Boolean) = boundary {
+private def grepInSymbol(pattern: String, owner: String, ctx: CommandContext): (results: List[Reference], timedOut: Boolean) = {
   val regex = java.util.regex.Pattern.compile(pattern) // pattern is pre-validated by fixPosixRegex
 
   // Split Owner.member if present
@@ -86,26 +72,23 @@ private def grepInSymbol(pattern: String, owner: String, ctx: CommandContext): (
     case None => (owner, None)
   }
 
-  // Find the owner's files
   val ownerDefs = findOwnerDefs(ownerName, ctx, typesOnly = false)
-  if ownerDefs.isEmpty then break((Nil, false))
-
-  val results = scala.collection.mutable.ListBuffer.empty[Reference]
-  ownerDefs.foreach { sym =>
-    // Get the body span(s) for the owner (and optionally a member within it)
+  val results = ownerDefs.flatMap { sym =>
+    // Body span(s) for the owner (or a member within it); read the file once per definition
     val bodies = memberName match
       case Some(mName) => extractBody(sym.file, mName, Some(ownerName))
       case None => extractBody(sym.file, ownerName, None)
-
-    bodies.foreach { b =>
-      val lines = try java.nio.file.Files.readAllLines(sym.file).asScala catch
-        case _: java.io.IOException => break((Nil, false))
-      grepSpan(lines, b.startLine, b.endLine, regex).foreach { m =>
-        results += Reference(sym.file, m.lineNum, m.text)
+    if bodies.isEmpty then Nil
+    else {
+      val lines = try java.nio.file.Files.readAllLines(sym.file).asScala catch {
+        case _: java.io.IOException => Seq.empty
+      }
+      bodies.flatMap { b =>
+        grepSpan(lines, b.startLine, b.endLine, regex).map(m => Reference(sym.file, m.lineNum, m.text))
       }
     }
   }
-  (results.toList, false)
+  (results, false)
 }
 
 private val eachMethodTimeoutMs = 20_000L

--- a/src/commands/impl.scala
+++ b/src/commands/impl.scala
@@ -8,6 +8,5 @@ def cmdImpl(args: List[String], ctx: CommandContext): CmdResult =
       else
         CmdResult.SymbolList(
           header = s"""Implementations of "$symbol" — ${results.size} found:""",
-          symbols = results,
-          total = results.size)
+          symbols = results)
   }

--- a/src/commands/overview.scala
+++ b/src/commands/overview.scala
@@ -35,14 +35,15 @@ private def recoverSignature(lower: String, symbolsByName: Map[String, List[Symb
   recoverSymbol(lower, symbolsByName).map(_.signature).getOrElse("")
 
 def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
-  var allSymbols = filterSymbols(ctx.idx.symbols, ctx)
+  val allSymbols = filterSymbols(ctx.idx.symbols, ctx)
 
   val symbolsByKind = countByKind(allSymbols)
   val topPackages: List[(pkg: String, syms: List[SymbolInfo])] = allSymbols.groupBy(_.packageName)
     .filter(_._1.nonEmpty).toList.sortBy(-_._2.size).take(ctx.limit)
     .map((p, s) => (pkg = p, syms = s))
 
-  // Most-extended non-stdlib parents, ranked — feeds both mostExtended and hubTypes
+  // Most-extended non-stdlib parents, ranked — rendered as "most extended" or
+  // as "hub types" depending on the architecture flag
   val mostExtended = ctx.idx.parentIndex.toList
     .filter((name, _) => ctx.idx.symbolsByName.contains(name) && !isStdlibParent(name) && !isStdlibPackageOnly(name, ctx.idx.symbolsByName))
     .filter((name, _) => recoverName(name, ctx.idx.symbolsByName).length > 1) // exclude single-char names
@@ -87,15 +88,6 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
         .map((pkg, deps) => pkg -> deps.filter(relevant.contains))
     case None => archPkgDeps
 
-  // Architecture: hub types — same ranking as mostExtended, different projection
-  val hubTypes: List[(name: String, score: Int, signature: String)] = if effectiveArch then {
-    mostExtended.map(t => (
-      name = recoverName(t.name, ctx.idx.symbolsByName),
-      score = t.impls.size,
-      signature = recoverSignature(t.name, ctx.idx.symbolsByName)
-    ))
-  } else Nil
-
   CmdResult.Overview(OverviewData(
     fileCount = allSymbols.map(_.file).distinct.size,
     symbolCount = allSymbols.size,
@@ -108,7 +100,6 @@ def cmdOverview(args: List[String], ctx: CommandContext): CmdResult =
       signature = recoverSignature(t.name, ctx.idx.symbolsByName)
     )),
     pkgDeps = filteredPkgDeps,
-    hubTypes = hubTypes,
     hasArchitecture = effectiveArch,
     focusPackage = ctx.focusPackage
   ))

--- a/src/commands/search.scala
+++ b/src/commands/search.scala
@@ -43,6 +43,5 @@ def cmdSearch(args: List[String], ctx: CommandContext): CmdResult =
       else
         CmdResult.SymbolList(
           header = s"""Found ${results.size} symbols matching "$query":""",
-          symbols = results,
-          total = results.size)
+          symbols = results)
   }

--- a/src/commands/symbols.scala
+++ b/src/commands/symbols.scala
@@ -4,19 +4,17 @@ def cmdSymbols(args: List[String], ctx: CommandContext): CmdResult =
       if ctx.summaryMode then
         val grouped = countByKind(results)
         if ctx.jsonOutput then
-          val byKind = grouped.map((k, count) => s""""${k.label}":$count""").mkString(",")
           // Consistent with overview/index-stats symbolsByKind format
-          println(s"""{"file":${jStr(file)},"symbolsByKind":{$byKind},"total":${results.size}}""")
-          CmdResult.StringList(header = "", items = Nil, total = 0) // already printed
+          println(s"""{"file":${jStr(file)},"symbolsByKind":${jKindCounts(grouped)},"total":${results.size}}""")
+          CmdResult.Silent
         else
           val counts = grouped.map((k, count) => s"$count ${k.label}${if count > 1 then "s" else ""}").mkString(", ")
           val summary = if counts.nonEmpty then s"$file: $counts (${results.size} total)" else s"$file: no symbols"
-          CmdResult.StringList(header = "", items = Nil, total = 0, emptyMessage = summary)
+          CmdResult.StringList(header = "", items = Nil, emptyMessage = summary)
       else
         CmdResult.SymbolList(
           header = s"Symbols in $file:",
           symbols = results,
-          total = results.size,
           emptyMessage = s"No symbols found in $file",
           truncate = false)
   }

--- a/src/extraction.scala
+++ b/src/extraction.scala
@@ -174,34 +174,24 @@ def extractRawSymbols(tree: Tree): (symbols: List[RawSymbol], packageName: Strin
   val pkg = tree.children.collectFirst { case p: Pkg => p.ref.toString() }.getOrElse("")
   val buf = mutable.ListBuffer.empty[RawSymbol]
 
+  // One path for every template-carrying definition (class/trait/object/enum)
+  def addTypeDefn(t: Tree, name: String, kind: SymbolKind, keyword: String, templ: Template,
+                  tparams: List[String], mods: List[Mod]): Unit =
+    val (parents, tpParents) = extractParents(templ)
+    val sig = buildSignature(name, keyword, parents, tparams)
+    buf += RawSymbol(name, kind, t.pos.startLine + 1, parents, tpParents, sig, extractAnnotations(mods))
+
   def visit(t: Tree): Unit = t match
     case d: Defn.Class =>
-      val (parents, tpParents) = extractParents(d.templ)
-      val tparams = d.tparamClause.values.map(_.name.value)
-      val sig = buildSignature(d.name.value, "class", parents, tparams)
-      val annots = extractAnnotations(d.mods)
-      buf += RawSymbol(d.name.value, SymbolKind.Class, d.pos.startLine + 1, parents, tpParents, sig, annots)
+      addTypeDefn(d, d.name.value, SymbolKind.Class, "class", d.templ, d.tparamClause.values.map(_.name.value).toList, d.mods)
     case d: Defn.Trait =>
-      val (parents, tpParents) = extractParents(d.templ)
-      val tparams = d.tparamClause.values.map(_.name.value)
-      val sig = buildSignature(d.name.value, "trait", parents, tparams)
-      val annots = extractAnnotations(d.mods)
-      buf += RawSymbol(d.name.value, SymbolKind.Trait, d.pos.startLine + 1, parents, tpParents, sig, annots)
+      addTypeDefn(d, d.name.value, SymbolKind.Trait, "trait", d.templ, d.tparamClause.values.map(_.name.value).toList, d.mods)
     case d: Defn.Object =>
-      val (parents, tpParents) = extractParents(d.templ)
-      val sig = buildSignature(d.name.value, "object", parents)
-      val annots = extractAnnotations(d.mods)
-      buf += RawSymbol(d.name.value, SymbolKind.Object, d.pos.startLine + 1, parents, tpParents, sig, annots)
+      addTypeDefn(d, d.name.value, SymbolKind.Object, "object", d.templ, Nil, d.mods)
     case d: Pkg.Object =>
-      val (parents, tpParents) = extractParents(d.templ)
-      val sig = buildSignature(d.name.value, "object", parents)
-      buf += RawSymbol(d.name.value, SymbolKind.Object, d.pos.startLine + 1, parents, tpParents, sig)
+      addTypeDefn(d, d.name.value, SymbolKind.Object, "object", d.templ, Nil, Nil)
     case d: Defn.Enum =>
-      val (parents, tpParents) = extractParents(d.templ)
-      val tparams = d.tparamClause.values.map(_.name.value)
-      val sig = buildSignature(d.name.value, "enum", parents, tparams)
-      val annots = extractAnnotations(d.mods)
-      buf += RawSymbol(d.name.value, SymbolKind.Enum, d.pos.startLine + 1, parents, tpParents, sig, annots)
+      addTypeDefn(d, d.name.value, SymbolKind.Enum, "enum", d.templ, d.tparamClause.values.map(_.name.value).toList, d.mods)
     case d: Defn.Given =>
       if d.name.value.nonEmpty then
         val annots = extractAnnotations(d.mods)
@@ -433,13 +423,13 @@ def extractTests(file: Path): List[TestSuiteInfo] = {
     case Some(tree) =>
       val suites = mutable.ListBuffer.empty[TestSuiteInfo]
 
-      def collectTests(stats: List[Tree], suiteName: String): (tests: List[TestCaseInfo], dynamicSites: Int) = {
+      def collectTests(stats: List[Tree]): (tests: List[TestCaseInfo], dynamicSites: Int) = {
         val tests = mutable.ListBuffer.empty[TestCaseInfo]
         var dynamicCount = 0
         def visit(t: Tree): Unit = {
           classifyTestCall(t) match
             case TestCallMatch.Literal(name, line) =>
-              tests += TestCaseInfo(name, line, suiteName, file)
+              tests += TestCaseInfo(name, line)
               // Don't recurse into matched test node — avoids double-counting
               // when inner Term.Apply also matches (e.g. test("name")(body))
             case TestCallMatch.Dynamic(_) =>
@@ -455,11 +445,11 @@ def extractTests(file: Path): List[TestSuiteInfo] = {
       def findSuites(t: Tree): Unit = {
         t match
           case d: Defn.Class =>
-            val (tests, dynSites) = collectTests(d.templ.body.stats, d.name.value)
+            val (tests, dynSites) = collectTests(d.templ.body.stats)
             if tests.nonEmpty || dynSites > 0 then
               suites += TestSuiteInfo(d.name.value, file, d.pos.startLine + 1, tests, dynSites)
           case d: Defn.Object =>
-            val (tests, dynSites) = collectTests(d.templ.body.stats, d.name.value)
+            val (tests, dynSites) = collectTests(d.templ.body.stats)
             if tests.nonEmpty || dynSites > 0 then
               suites += TestSuiteInfo(d.name.value, file, d.pos.startLine + 1, tests, dynSites)
           case _ =>
@@ -592,9 +582,6 @@ private def parseJavaSource(source: String, path: Path): Option[JavaCU] =
 private def parseJavaFile(path: Path): Option[JavaCU] =
   readSource(path).flatMap(source => parseJavaSource(source, path))
 
-private def javaTypeToString(tpe: com.github.javaparser.ast.`type`.Type): String =
-  tpe.asString()
-
 /** 1-based start line of a JavaParser node (0 when unknown). */
 private def javaLine(node: JavaNode): Int =
   node.getBegin.map(_.line).orElse(0)
@@ -602,19 +589,19 @@ private def javaLine(node: JavaNode): Int =
 /** "name: Type, name: Type" rendering of a Java parameter list. */
 private def javaParams(params: NodeList[Parameter]): String =
   val buf = mutable.ListBuffer.empty[String]
-  params.forEach(p => buf += s"${p.getNameAsString}: ${javaTypeToString(p.getType)}")
+  params.forEach(p => buf += s"${p.getNameAsString}: ${p.getType.asString()}")
   buf.mkString(", ")
 
 /** Scala-style `def` signature for a Java method — the one shape used by both
   * file-symbol extraction and member extraction. */
 private def javaMethodSig(m: MethodDeclaration): String =
-  s"def ${m.getNameAsString}(${javaParams(m.getParameters)}): ${javaTypeToString(m.getType)}"
+  s"def ${m.getNameAsString}(${javaParams(m.getParameters)}): ${m.getType.asString()}"
 
 /** Kind + Scala-style signature for one declarator of a Java field. */
 private def javaFieldInfo(f: FieldDeclaration, v: VariableDeclarator): (kind: SymbolKind, sig: String) =
   val prefix = if f.isFinal then "val" else "var"
   val kind = if f.isFinal then SymbolKind.Val else SymbolKind.Var
-  (kind = kind, sig = s"$prefix ${v.getNameAsString}: ${javaTypeToString(f.getCommonType)}")
+  (kind = kind, sig = s"$prefix ${v.getNameAsString}: ${f.getCommonType.asString()}")
 
 private def javaParentsFromType(td: TypeDeclaration[?]): List[String] =
   val buf = mutable.ListBuffer.empty[String]

--- a/src/format.scala
+++ b/src/format.scala
@@ -136,6 +136,7 @@ def render(result: CmdResult, ctx: CommandContext): Unit = {
     case r: GraphOutput      => println(r.text)
     case r: NotFound         => renderNotFound(r, ctx)
     case r: UsageError       => println(r.message)
+    case Silent              => ()
   }
 }
 
@@ -204,18 +205,20 @@ private def renderCategorizedRefs(r: CmdResult.CategorizedRefs, ctx: CommandCont
     val total = r.grouped.values.map(_.size).sum
     val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — $total found:$suffix""")
+    // Resolve each ref's confidence once, then group per confidence level
+    val annotated = r.grouped.toList.flatMap { (cat, refs) =>
+      refs.map(ref => (cat = cat, ref = ref, conf = ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
+    }
     Confidence.values.foreach { conf =>
-      val catRefs = r.grouped.flatMap { (cat, refs) =>
-        refs.map(ref => (cat, ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
-      }.filter(_._3 == conf).toList
-      if catRefs.nonEmpty then {
+      val confRefs = annotated.filter(_.conf == conf)
+      if confRefs.nonEmpty then {
         println(s"\n  ${conf.label} (${conf.explanation}):")
-        val byCat = catRefs.groupBy(_._1)
+        val byCat = confRefs.groupBy(_.cat)
         refCategoryOrder.foreach { cat =>
           byCat.get(cat).filter(_.nonEmpty).foreach { entries =>
-            val sorted = entries.sortBy((_, ref, _) => (path = ctx.workspace.relativize(ref.file).toString, line = ref.line))
+            val sorted = entries.sortBy(e => (path = ctx.workspace.relativize(e.ref.file).toString, line = e.ref.line))
             println(s"\n    ${cat.toString}:")
-            renderShown(sorted, ctx.limit, "      ")((_, ref, _) => println(s"    ${ctx.fmtRef(ref)}"))
+            renderShown(sorted, ctx.limit, "      ")(e => println(s"    ${ctx.fmtRef(e.ref)}"))
           }
         }
       }
@@ -229,19 +232,15 @@ private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
   } else {
     val suffix = timedOutSuffix(r.timedOut)
     println(s"""References to "${r.symbol}" — ${r.refs.size} found:$suffix""")
-    val annotated = r.refs.map(ref => (ref, ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
-    val sorted = annotated.sortBy { case (ref, c) => (confidence = c.ordinal, path = ctx.workspace.relativize(ref.file).toString, line = ref.line) }
+    val annotated = r.refs.map(ref => (ref = ref, conf = ctx.idx.resolveConfidence(ref, r.symbol, r.targetPkgs)))
+    val sorted = annotated.sortBy(e => (confidence = e.conf.ordinal, path = ctx.workspace.relativize(e.ref.file).toString, line = e.ref.line))
     var lastConf: Option[Confidence] = None
-    var shown = 0
-    sorted.foreach { case (ref, conf) =>
-      if shown < ctx.limit then {
-        if !lastConf.contains(conf) then {
-          println(s"\n  [${conf.label}]")
-          lastConf = Some(conf)
-        }
-        println(ctx.fmtRef(ref))
-        shown += 1
+    sorted.take(ctx.limit).foreach { (ref, conf) =>
+      if !lastConf.contains(conf) then {
+        println(s"\n  [${conf.label}]")
+        lastConf = Some(conf)
       }
+      println(ctx.fmtRef(ref))
     }
     if r.refs.size > ctx.limit then println(s"  ... and ${r.refs.size - ctx.limit} more")
   }
@@ -249,9 +248,7 @@ private def renderFlatRefs(r: CmdResult.FlatRefs, ctx: CommandContext): Unit = {
 
 private def renderStringList(r: CmdResult.StringList, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    // Skip only when output was already printed (empty items + empty header + empty emptyMessage)
-    if r.items.nonEmpty || r.header.nonEmpty || r.emptyMessage.nonEmpty then
-      println(jStrArr(r.items.take(ctx.limit)))
+    println(jStrArr(r.items.take(ctx.limit)))
   } else {
     if r.items.isEmpty then {
       if r.emptyMessage.nonEmpty then println(r.emptyMessage)
@@ -264,8 +261,7 @@ private def renderStringList(r: CmdResult.StringList, ctx: CommandContext): Unit
 
 private def renderIndexStats(r: CmdResult.IndexStats, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val byKind = r.symbolsByKind.map((k, c) => s""""${k.label}":$c""").mkString(",")
-    println(s"""{"fileCount":${r.fileCount},"symbolCount":${r.symbolCount},"packageCount":${r.packageCount},"symbolsByKind":{$byKind},"indexTimeMs":${r.indexTimeMs},"cachedLoad":${r.cachedLoad},"parsedCount":${r.parsedCount},"skippedCount":${r.skippedCount},"parseFailures":${r.parseFailures}}""")
+    println(s"""{"fileCount":${r.fileCount},"symbolCount":${r.symbolCount},"packageCount":${r.packageCount},"symbolsByKind":${jKindCounts(r.symbolsByKind)},"indexTimeMs":${r.indexTimeMs},"cachedLoad":${r.cachedLoad},"parsedCount":${r.parsedCount},"skippedCount":${r.skippedCount},"parseFailures":${r.parseFailures}}""")
   } else {
     if r.cachedLoad then
       println(s"Indexed ${r.fileCount} files (${r.skippedCount} cached, ${r.parsedCount} parsed) in ${r.indexTimeMs}ms")
@@ -412,10 +408,26 @@ private def renderDocEntries(r: CmdResult.DocEntries, ctx: CommandContext): Unit
   }
 }
 
+/** `{"class":12,"def":3,...}` JSON object from kind counts — shared by overview,
+  * index stats, and the symbols --summary command. */
+def jKindCounts(counts: List[(kind: SymbolKind, count: Int)]): String =
+  counts.map((k, c) => s""""${k.label}":$c""").mkString("{", ",", "}")
+
+/** "  pkg.padded  count" rows shared by the overview modes. */
+private def printPackageRows(rows: List[(pkg: String, count: Int)]): Unit =
+  rows.foreach((pkg, count) => println(s"  ${pkg.padTo(50, ' ')} $count"))
+
+/** "  Name.padded  N <label>  sig" rows shared by hub-types / most-extended output. */
+private def printRankedTypeRows(rows: List[(name: String, count: Int, signature: String)], countLabel: String): Unit =
+  rows.foreach { (name, count, sig) =>
+    val sigHint = if sig.nonEmpty then s"  $sig" else ""
+    println(s"  ${name.padTo(30, ' ')} $count $countLabel$sigHint")
+  }
+
 private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
   val d = r.data
   if ctx.jsonOutput then {
-    val kindJson = d.symbolsByKind.map((k, c) => s""""${k.label}":$c""").mkString("{", ",", "}")
+    val kindJson = jKindCounts(d.symbolsByKind)
     val pkgJson = jArr(d.topPackages.map((p, c) => s"""{"package":${jStr(p)},"count":$c}"""))
     if d.hasArchitecture then {
       val depsJson = if ctx.concise then {
@@ -429,7 +441,7 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
           s"""${jStr(pkg)}:${jStrArr(deps)}"""
         }.mkString("{", ",", "}")
       }
-      val hubJson = jArr(d.hubTypes.map((n, c, sig) => s"""{"name":${jStr(n)},"score":$c,"signature":${jStr(sig)}}"""))
+      val hubJson = jArr(d.mostExtended.map((n, c, sig) => s"""{"name":${jStr(n)},"score":$c,"signature":${jStr(sig)}}"""))
       val focusPkgJson = d.focusPackage.map(p => s""","focusPackage":${jStr(p)}""").getOrElse("")
       val conciseJson = if ctx.concise then {
         val totalEdges = d.pkgDeps.values.map(_.size).sum
@@ -453,9 +465,7 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
     // Top packages — capped at conciseLimit
     val shownPkgs = d.topPackages.take(conciseLimit)
     println(s"Top packages:")
-    shownPkgs.foreach { (pkg, count) =>
-      println(s"  ${pkg.padTo(50, ' ')} $count")
-    }
+    printPackageRows(shownPkgs)
     val remainingPkgs = d.packageCount - shownPkgs.size
     if remainingPkgs > 0 then
       println(s"  ... and $remainingPkgs more (use overview --limit N to show more)")
@@ -473,13 +483,10 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
     }
 
     // Hub types — capped at conciseLimit
-    val shownHubs = d.hubTypes.take(conciseLimit)
+    val shownHubs = d.mostExtended.take(conciseLimit)
     if shownHubs.nonEmpty then {
       println(s"\nHub types (top ${shownHubs.size}):")
-      shownHubs.foreach { (name, count, sig) =>
-        val sigHint = if sig.nonEmpty then s"  $sig" else ""
-        println(s"  ${name.padTo(30, ' ')} $count references$sigHint")
-      }
+      printRankedTypeRows(shownHubs, "references")
     }
 
     println(s"\nDrill down: overview --architecture, overview --focus-package PKG, entrypoints")
@@ -490,15 +497,10 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
       println(s"  ${kind.toString.padTo(10, ' ')} $count")
     }
     println(s"\nTop packages (by symbol count):")
-    d.topPackages.foreach { (pkg, count) =>
-      println(s"  ${pkg.padTo(50, ' ')} $count")
-    }
+    printPackageRows(d.topPackages)
     if !d.hasArchitecture then {
       println(s"\nMost extended (by package spread, then implementation count):")
-      d.mostExtended.foreach { (name, count, sig) =>
-        val sigHint = if sig.nonEmpty then s"  $sig" else ""
-        println(s"  ${name.padTo(30, ' ')} $count impl$sigHint")
-      }
+      printRankedTypeRows(d.mostExtended, "impl")
     }
     if d.hasArchitecture then {
       d.focusPackage match {
@@ -520,11 +522,8 @@ private def renderOverview(r: CmdResult.Overview, ctx: CommandContext): Unit = {
           }
       }
       println(s"\nHub types (by package spread, then extension count):")
-      if d.hubTypes.isEmpty then println("  (none)")
-      else d.hubTypes.foreach { (name, count, sig) =>
-        val sigHint = if sig.nonEmpty then s"  $sig" else ""
-        println(s"  ${name.padTo(30, ' ')} $count references$sigHint")
-      }
+      if d.mostExtended.isEmpty then println("  (none)")
+      else printRankedTypeRows(d.mostExtended, "references")
     }
   }
 }
@@ -578,10 +577,7 @@ private def renderSourceBlocks(r: CmdResult.SourceBlocks, ctx: CommandContext): 
       val (before, after) = windowFor(file, b)
       before.foreach((i, text) => println(s"  ${numberedLine(i, text)}"))
       if before.nonEmpty then println("  ---")
-      val bodyLines = b.sourceText.split("\n")
-      bodyLines.zipWithIndex.foreach { case (line, i) =>
-        println(s"  ${numberedLine(b.startLine + i, line)}")
-      }
+      renderInlineBody(Some(b), "  ")
       if after.nonEmpty then println("  ---")
       after.foreach((i, text) => println(s"  ${numberedLine(i, text)}"))
       println()
@@ -663,9 +659,9 @@ private def renderCoverageReport(r: CmdResult.CoverageReport, ctx: CommandContex
 private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandContext): Unit = {
   val tree = r.tree
   def nodeJson(n: HierarchyNode): String = {
-    val file = jOpt(n.file.map(f => ctx.workspace.relativize(f).toString))
-    val kind = jOpt(n.kind.map(_.label))
-    val line = n.line.map(_.toString).getOrElse("null")
+    val file = jOpt(n.sym.map(s => ctx.workspace.relativize(s.file).toString))
+    val kind = jOpt(n.sym.map(_.kind.label))
+    val line = n.sym.map(_.line.toString).getOrElse("null")
     s"""{"name":${jStr(n.name)},"kind":$kind,"file":$file,"line":$line,"package":${jStr(n.packageName)},"isExternal":${n.isExternal}}"""
   }
   def treeJson(t: HierarchyTree): String = {
@@ -682,9 +678,9 @@ private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandCont
       val prefix = if isLast then s"$indent└── " else s"$indent├── "
       val nextIndent = if isLast then s"$indent    " else s"$indent│   "
       val n = t.root
-      val nkind = n.kind.map(_.label + " ").getOrElse("")
+      val nkind = n.sym.map(_.kind.label + " ").getOrElse("")
       val nloc = if !down && n.isExternal then " [external]"
-                 else n.file.map(f => s" — ${ctx.workspace.relativize(f)}:${n.line.getOrElse(0)}").getOrElse("")
+                 else n.sym.map(s => s" — ${ctx.workspace.relativize(s.file)}:${s.line}").getOrElse("")
       println(s"$prefix$nkind${n.name}${pkgSuffix(n.packageName)}$nloc")
       printLevel(if down then t.children else t.parents, nextIndent, down)
       if down && t.truncatedChildren > 0 then
@@ -695,8 +691,8 @@ private def renderHierarchyResult(r: CmdResult.HierarchyResult, ctx: CommandCont
     println(treeJson(tree))
   } else {
     val rootNode = tree.root
-    val kind = rootNode.kind.map(_.label).getOrElse("unknown")
-    val loc = rootNode.file.map(f => s" — ${ctx.workspace.relativize(f)}:${rootNode.line.getOrElse(0)}").getOrElse("")
+    val kind = rootNode.sym.map(_.kind.label).getOrElse("unknown")
+    val loc = rootNode.sym.map(s => s" — ${ctx.workspace.relativize(s.file)}:${s.line}").getOrElse("")
     println(s"Hierarchy of $kind ${rootNode.name}${pkgSuffix(rootNode.packageName)}$loc:")
     if ctx.goUp then {
       println("  Parents:")
@@ -732,16 +728,18 @@ private def renderOverrideList(r: CmdResult.OverrideList, ctx: CommandContext): 
 private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Unit = {
   val sym = r.sym
   val rel = ctx.workspace.relativize(sym.file)
+  // Companion members identical to primary members are deduplicated in both modes
+  val primaryKeys = r.members.map(m => (name = m.name, kind = m.kind)).toSet
+  def uniqueCompanionMembers(compMembers: List[MemberInfo]): List[MemberInfo] =
+    compMembers.filter(m => !primaryKeys.contains((name = m.name, kind = m.kind)))
   if ctx.jsonOutput then {
     val membersJson = jArr(r.members.map { m =>
       val overrideJson = if m.isOverride then ""","isOverride":true""" else ""
       s"""{${jsonMemberFields(m)}$overrideJson${jsonBodyFields(m.body)}}"""
     })
     val implsJson = jArr(r.impls.map(s => jsonSymbol(s, ctx.workspace)))
-    val primaryKeys = r.members.map(m => (name = m.name, kind = m.kind)).toSet
     val companionJson = r.companion.map { (compSym, compMembers) =>
-      val uniqueCompMembers = compMembers.filter(m => !primaryKeys.contains((name = m.name, kind = m.kind)))
-      val cMembers = jArr(uniqueCompMembers.map(m => s"{${jsonMemberFields(m)}}"))
+      val cMembers = jArr(uniqueCompanionMembers(compMembers).map(m => s"{${jsonMemberFields(m)}}"))
       s"""{"definition":${jsonSymbol(compSym, ctx.workspace)},"members":$cMembers}"""
     }.getOrElse("null")
     def explainedImplJson(ei: ExplainedImpl): String = {
@@ -802,9 +800,7 @@ private def renderExplanation(r: CmdResult.Explanation, ctx: CommandContext): Un
       val compRel = ctx.workspace.relativize(compSym.file)
       println(s"  Companion ${compSym.kind.label} ${compSym.name} — $compRel:${compSym.line}")
       if compMembers.nonEmpty then
-        // Deduplicate: skip companion members that are identical to primary members
-        val primaryKeys = r.members.map(m => (name = m.name, kind = m.kind)).toSet
-        val uniqueCompMembers = compMembers.filter(m => !primaryKeys.contains((name = m.name, kind = m.kind)))
+        val uniqueCompMembers = uniqueCompanionMembers(compMembers)
         val dupeCount = compMembers.size - uniqueCompMembers.size
         if uniqueCompMembers.nonEmpty then
           uniqueCompMembers.foreach(m => println(s"    ${explainMemberLine(m, ctx.verbose)}"))
@@ -935,20 +931,13 @@ private def renderSymbolDiff(r: CmdResult.SymbolDiff, ctx: CommandContext): Unit
 
 private def renderAstMatches(r: CmdResult.AstMatches, ctx: CommandContext): Unit = {
   if ctx.jsonOutput then {
-    val arr = r.results.map { m =>
-      val rel = ctx.workspace.relativize(m.file).toString
-      s"""{"name":${jStr(m.name)},"kind":${jStr(m.kind.label)},"file":${jStr(rel)},"line":${m.line},"package":${jStr(m.packageName)},"signature":${jStr(m.signature)}}"""
-    }
-    println(jArr(arr))
+    println(jArr(r.results.map(s => jsonSymbol(s, ctx.workspace))))
   } else {
     if r.results.isEmpty then
       println(s"No types matching AST pattern (${r.filters})")
     else {
       println(s"Types matching AST pattern (${r.filters}) — ${r.results.size} found:")
-      r.results.foreach { m =>
-        val rel = ctx.workspace.relativize(m.file)
-        println(s"  ${m.kind.label.padTo(9, ' ')} ${m.name}${pkgSuffix(m.packageName)} — $rel:${m.line}")
-      }
+      r.results.foreach(s => println(formatSymbol(s, ctx.workspace)))
     }
   }
 }
@@ -1158,28 +1147,22 @@ private def renderRefsSummary(r: CmdResult.RefsSummary, ctx: CommandContext): Un
 private def renderEntrypoints(r: CmdResult.Entrypoints, ctx: CommandContext): Unit = {
   import EntrypointCategory.*
   val byCategory = r.entries.groupBy(_.category)
-  val categoryOrder = List(MainAnnotation, MainMethod, ExtendsApp, TestSuite)
-  val categoryLabels = Map(
-    MainAnnotation -> "@main annotated",
-    MainMethod -> "def main(...) methods",
-    ExtendsApp -> "extends App",
-    TestSuite -> "Test suites"
-  )
-  val categoryJsonKeys = Map(
-    MainAnnotation -> "mainAnnotated",
-    MainMethod -> "mainMethods",
-    ExtendsApp -> "extendsApp",
-    TestSuite -> "testSuites"
+  // Display order, text label, and JSON key per category — one table
+  val categories = List(
+    (cat = MainAnnotation, label = "@main annotated", jsonKey = "mainAnnotated"),
+    (cat = MainMethod, label = "def main(...) methods", jsonKey = "mainMethods"),
+    (cat = ExtendsApp, label = "extends App", jsonKey = "extendsApp"),
+    (cat = TestSuite, label = "Test suites", jsonKey = "testSuites"),
   )
   if ctx.jsonOutput then {
-    val groups = categoryOrder.map { cat =>
-      val entries = byCategory.getOrElse(cat, Nil).take(ctx.limit)
+    val groups = categories.map { c =>
+      val entries = byCategory.getOrElse(c.cat, Nil).take(ctx.limit)
       val arr = jArr(entries.map { e =>
         val rel = ctx.workspace.relativize(e.sym.file).toString
         val line = e.memberLine.getOrElse(e.sym.line)
         s"""{"name":${jStr(e.sym.name)},"kind":${jStr(e.sym.kind.label)},"file":${jStr(rel)},"line":$line,"package":${jStr(e.sym.packageName)}}"""
       })
-      s""""${categoryJsonKeys(cat)}":$arr"""
+      s""""${c.jsonKey}":$arr"""
     }.mkString(",")
     println(s"""{"entrypoints":{$groups},"total":${r.total}}""")
   } else {
@@ -1187,10 +1170,10 @@ private def renderEntrypoints(r: CmdResult.Entrypoints, ctx: CommandContext): Un
       println("No entrypoints found")
     else {
       println(s"Entrypoints — ${r.total} found:\n")
-      categoryOrder.foreach { cat =>
-        val entries = byCategory.getOrElse(cat, Nil)
+      categories.foreach { c =>
+        val entries = byCategory.getOrElse(c.cat, Nil)
         if entries.nonEmpty then {
-          println(s"  ${categoryLabels(cat)} (${entries.size}):")
+          println(s"  ${c.label} (${entries.size}):")
           renderShown(entries, ctx.limit, "    ") { e =>
             val rel = ctx.workspace.relativize(e.sym.file)
             val line = e.memberLine.getOrElse(e.sym.line)
@@ -1211,10 +1194,9 @@ private def renderNotFound(r: CmdResult.NotFound, ctx: CommandContext): Unit = {
         // hierarchy never emits JSON for not-found case (matches original behavior)
         println(r.message)
         renderHint(r.hint)
-      case "explain" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
+      case "explain" | "package" | "api" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
       case "imports" => println(s"""{"results":[],"timedOut":${r.hint.timedOut},"suggestions":$suggestionsJson}""")
       case "deps" => println(s"""{"imports":[],"bodyReferences":[],"suggestions":$suggestionsJson}""")
-      case "package" | "api" => println(s"""{"error":"not found","suggestions":$suggestionsJson}""")
       case _ => println(s"""{"results":[],"suggestions":$suggestionsJson}""")
     }
   } else {

--- a/src/index.scala
+++ b/src/index.scala
@@ -312,6 +312,13 @@ def nameMatchTier(lowerQuery: String, name: String): Option[MatchTier] = {
   else None
 }
 
+/** Bucket items by their name-match tier against `lowerQuery`, preserving
+  * encounter order within each tier. Items that match no tier are dropped.
+  * One bucketer behind symbol search and file search. */
+private def bucketByTier[A](items: List[A], lowerQuery: String)(nameOf: A => String): Map[MatchTier, List[A]] =
+  items.flatMap(a => nameMatchTier(lowerQuery, nameOf(a)).map(t => (tier = t, item = a)))
+    .groupMap(_.tier)(_.item)
+
 /** Inverted index: group items under each (already-normalized) key produced by `keys`. */
 private def buildMultiIndex[A, K](items: List[A])(keys: A => IterableOnce[K]): Map[K, List[A]] = {
   val idx = mutable.HashMap.empty[K, mutable.ListBuffer[A]]
@@ -433,47 +440,34 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     fileCount = gitFiles.size
 
     val cached = Timings.phase("cache-load") { IndexPersistence.load(workspace, needBlooms) }
+    cachedLoad = cached.isDefined
+    // No cache = empty map: every file misses the OID compare and gets parsed
+    val cachedMap = cached.getOrElse(Map.empty)
     val result = mutable.ListBuffer.empty[IndexedFile]
+    val toParse = mutable.ListBuffer.empty[GitFile]
 
-    cached match
-      case Some(cachedMap) =>
-        cachedLoad = true
-        val toParseQueue = ConcurrentLinkedQueue[IndexedFile]()
-        val toParse = mutable.ListBuffer.empty[GitFile]
+    Timings.phase("oid-compare") {
+      gitFiles.foreach { gf =>
+        val rel = workspace.relativize(gf.path).toString
+        cachedMap.get(rel) match
+          case Some(cf) if cf.oid == gf.oid =>
+            result += cf
+            skippedCount += 1
+          case _ =>
+            toParse += gf
+      }
+    }
 
-        Timings.phase("oid-compare") {
-          gitFiles.foreach { gf =>
-            val rel = workspace.relativize(gf.path).toString
-            cachedMap.get(rel) match
-              case Some(cf) if cf.oid == gf.oid =>
-                result += cf
-                skippedCount += 1
-              case _ =>
-                toParse += gf
-          }
-        }
-
-        Timings.phase("parse") {
-          toParse.asJava.parallelStream().forEach { gf =>
-            val rel = workspace.relativize(gf.path).toString
-            val (syms, bloom, imports, aliases, failed) = extractSymbols(gf.path)
-            toParseQueue.add(IndexedFile(rel, gf.oid, syms, bloom, imports, aliases, failed))
-          }
-        }
-        result ++= toParseQueue.asScala
-        parsedCount = toParse.size
-
-      case None =>
-        val queue = ConcurrentLinkedQueue[IndexedFile]()
-        Timings.phase("parse") {
-          gitFiles.asJava.parallelStream().forEach { gf =>
-            val rel = workspace.relativize(gf.path).toString
-            val (syms, bloom, imports, aliases, failed) = extractSymbols(gf.path)
-            queue.add(IndexedFile(rel, gf.oid, syms, bloom, imports, aliases, failed))
-          }
-        }
-        result ++= queue.asScala
-        parsedCount = gitFiles.size
+    val parsedQueue = ConcurrentLinkedQueue[IndexedFile]()
+    Timings.phase("parse") {
+      toParse.asJava.parallelStream().forEach { gf =>
+        val rel = workspace.relativize(gf.path).toString
+        val (syms, bloom, imports, aliases, failed) = extractSymbols(gf.path)
+        parsedQueue.add(IndexedFile(rel, gf.oid, syms, bloom, imports, aliases, failed))
+      }
+    }
+    result ++= parsedQueue.asScala
+    parsedCount = toParse.size
 
     indexedFiles = result.toList
     parseFailedFiles = indexedFiles.collect {
@@ -525,20 +519,12 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
   }
 
   def findImplementations(name: String): List[SymbolInfo] = {
-    if name.contains(".") then {
-      val resolved = findDefinition(name)
-      if resolved.isEmpty then Nil
-      else {
-        val simpleName = name.substring(name.lastIndexOf('.') + 1)
-        val direct = parentIndex.getOrElse(simpleName.toLowerCase, Nil)
-        val viaTp = typeParamParentIndex.getOrElse(simpleName.toLowerCase, Nil)
-        (direct ++ viaTp).distinctBy(s => (name = s.name, file = s.file, line = s.line))
-      }
-    }
+    // A qualified name must resolve before its simple name is looked up
+    if name.contains(".") && findDefinition(name).isEmpty then Nil
     else {
-      val direct = parentIndex.getOrElse(name.toLowerCase, Nil)
-      val viaTp = typeParamParentIndex.getOrElse(name.toLowerCase, Nil)
-      (direct ++ viaTp).distinctBy(s => (name = s.name, file = s.file, line = s.line))
+      val simpleName = name.substring(name.lastIndexOf('.') + 1).toLowerCase
+      (parentIndex.getOrElse(simpleName, Nil) ++ typeParamParentIndex.getOrElse(simpleName, Nil))
+        .distinctBy(s => (name = s.name, file = s.file, line = s.line))
     }
   }
 
@@ -571,22 +557,8 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
         None
 
   def search(query: String): List[SymbolInfo] =
-    val lower = query.toLowerCase
-    val exact = mutable.ListBuffer.empty[SymbolInfo]
-    val prefix = mutable.ListBuffer.empty[SymbolInfo]
-    val contains = mutable.ListBuffer.empty[SymbolInfo]
-    val reverseContains = mutable.ListBuffer.empty[SymbolInfo]
-    val fuzzy = mutable.ListBuffer.empty[SymbolInfo]
-
-    distinctSymbols.foreach { s =>
-      nameMatchTier(lower, s.name).foreach {
-        case MatchTier.Exact           => exact += s
-        case MatchTier.Prefix          => prefix += s
-        case MatchTier.Contains        => contains += s
-        case MatchTier.ReverseContains => reverseContains += s
-        case MatchTier.CamelCase       => fuzzy += s
-      }
-    }
+    val byTier = bucketByTier(distinctSymbols, query.toLowerCase)(_.name)
+    def tier(t: MatchTier) = byTier.getOrElse(t, Nil)
     def searchRank(s: SymbolInfo): (kindRank: Int, testRank: Int, stdlibRank: Int, importRank: Int, pathLen: Int) =
       val kindRank = s.kind match
         case SymbolKind.Class | SymbolKind.Trait | SymbolKind.Enum => 0
@@ -599,7 +571,8 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
       val importRank = -symbolImportRank.getOrElse(s.name.toLowerCase, 0)
       val pathLen = s.file.toString.length
       (kindRank, testRank, stdlibRank, importRank, pathLen)
-    exact.toList.sortBy(searchRank) ++ prefix.toList.sortBy(searchRank) ++ contains.toList.sortBy(searchRank) ++ reverseContains.toList.sortBy(searchRank) ++ fuzzy.sortBy(_.name.length).toList
+    List(MatchTier.Exact, MatchTier.Prefix, MatchTier.Contains, MatchTier.ReverseContains)
+      .flatMap(t => tier(t).sortBy(searchRank)) ++ tier(MatchTier.CamelCase).sortBy(_.name.length)
 
   def fileSymbols(path: String): List[SymbolInfo] =
     val resolved = if Path.of(path).isAbsolute then Path.of(path)
@@ -607,38 +580,27 @@ class WorkspaceIndex(val workspace: Path, val needBlooms: Boolean = true):
     filesByPath.getOrElse(resolved, Nil)
 
   def searchFiles(query: String): List[String] =
-    val lower = query.toLowerCase
-    val exact = mutable.ListBuffer.empty[String]
-    val prefix = mutable.ListBuffer.empty[String]
-    val contains = mutable.ListBuffer.empty[String]
-    val fuzzy = mutable.ListBuffer.empty[String]
-
-    indexedFiles.foreach { f =>
-      val fileName = f.relativePath.substring(f.relativePath.lastIndexOf('/') + 1).stripSuffix(".scala").stripSuffix(".java")
-      nameMatchTier(lower, fileName).foreach {
-        case MatchTier.Exact     => exact += f.relativePath
-        case MatchTier.Prefix    => prefix += f.relativePath
-        case MatchTier.Contains  => contains += f.relativePath
-        case MatchTier.CamelCase => fuzzy += f.relativePath
-        case MatchTier.ReverseContains => () // not a useful tier for filenames
-      }
-    }
-    exact.toList ++ prefix.toList ++ contains.toList ++ fuzzy.sortBy(_.length).toList
+    def fileName(f: IndexedFile): String =
+      f.relativePath.substring(f.relativePath.lastIndexOf('/') + 1).stripSuffix(".scala").stripSuffix(".java")
+    val byTier = bucketByTier(indexedFiles, query.toLowerCase)(fileName)
+    def tier(t: MatchTier) = byTier.getOrElse(t, Nil).map(_.relativePath)
+    // ReverseContains is not a useful tier for filenames
+    tier(MatchTier.Exact) ++ tier(MatchTier.Prefix) ++ tier(MatchTier.Contains) ++
+      tier(MatchTier.CamelCase).sortBy(_.length)
 
   private val defaultTimeoutMs = 20_000L
 
   def findReferences(name: String, timeoutMs: Long = defaultTimeoutMs, strict: Boolean = false): (results: List[Reference], timedOut: Boolean) =
     val wordMatch: (String, String) => Boolean = if strict then containsWordStrict else containsWord
-    val (candidates, allCandidates, fileAliasMap) = Timings.phase("bloom-screen") {
+    val (allCandidates, fileAliasMap) = Timings.phase("bloom-screen") {
       val candidates = indexedFiles.filter(f => f.identifierBloom.forall(_.mightContain(name)))
       val aliasFiles = aliasIndex.getOrElse(name, Nil)
       val candidateSet = candidates.map(_.relativePath).toSet
       val extraFiles = aliasFiles.collect {
         case (f, _) if !candidateSet.contains(f.relativePath) => f
       }
-      val allCandidates = candidates ++ extraFiles
       val fileAliasMap = aliasFiles.map((f, alias) => f.relativePath -> alias).toMap
-      (candidates, allCandidates, fileAliasMap)
+      (allCandidates = candidates ++ extraFiles, fileAliasMap = fileAliasMap)
     }
 
     val scan = DeadlineScan(timeoutMs)

--- a/src/model.scala
+++ b/src/model.scala
@@ -58,16 +58,10 @@ val refCategoryOrder: List[RefCategory] = List(
   RefCategory.Definition, RefCategory.ExtendedBy, RefCategory.ImportedBy,
   RefCategory.UsedAsType, RefCategory.Usage, RefCategory.Comment)
 
-case class CategorizedRef(ref: Reference, category: RefCategory)
-
 enum Confidence:
   case High, Medium, Low
 
-  def label: String = this match {
-    case Confidence.High   => "High confidence"
-    case Confidence.Medium => "Medium confidence"
-    case Confidence.Low    => "Low confidence"
-  }
+  def label: String = s"$this confidence"
 
   /** Parenthetical shown next to the label in categorized refs output. */
   def explanation: String = this match {
@@ -80,9 +74,17 @@ enum Confidence:
 
 case class MemberInfo(name: String, kind: SymbolKind, line: Int, signature: String = "", annotations: List[String] = Nil, isOverride: Boolean = false, body: Option[BodyInfo] = None)
 
+/** Members grouped under the parent type they are inherited from. */
+type InheritedGroup = (parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])
+
 case class BodyInfo(ownerName: String, symbolName: String, sourceText: String, startLine: Int, endLine: Int, isAbstract: Boolean = false)
 
-case class HierarchyNode(name: String, kind: Option[SymbolKind], file: Option[Path], line: Option[Int], packageName: String, isExternal: Boolean)
+/** A node in a hierarchy tree: the resolved symbol, or just a name when the
+  * type is defined outside the workspace (`sym` empty = external). */
+case class HierarchyNode(name: String, sym: Option[SymbolInfo]) {
+  def isExternal: Boolean = sym.isEmpty
+  def packageName: String = sym.map(_.packageName).getOrElse("")
+}
 case class HierarchyTree(root: HierarchyNode, parents: List[HierarchyTree], children: List[HierarchyTree], truncatedChildren: Int = 0)
 
 case class OverrideInfo(file: Path, line: Int, enclosingClass: String, enclosingKind: SymbolKind, signature: String, packageName: String, body: Option[BodyInfo] = None)
@@ -91,16 +93,12 @@ case class ScopeInfo(name: String, kind: String, line: Int)
 
 case class DiffSymbol(name: String, kind: SymbolKind, file: String, line: Int, packageName: String, signature: String)
 
-case class TestCaseInfo(name: String, line: Int, suiteName: String, suiteFile: Path)
+case class TestCaseInfo(name: String, line: Int)
 case class TestSuiteInfo(name: String, file: Path, line: Int, tests: List[TestCaseInfo], dynamicSites: Int = 0)
 
 // ── Dependency extraction types ─────────────────────────────────────────────
 
 case class DepInfo(name: String, kind: String, file: Option[Path], line: Option[Int], packageName: String, depth: Int = 0)
-
-// ── AST pattern matching types ──────────────────────────────────────────────
-
-case class AstPatternMatch(name: String, kind: SymbolKind, file: Path, line: Int, packageName: String, signature: String)
 
 case class MethodGrepMatch(member: MemberInfo, file: Path, matchCount: Int, matchLines: List[(lineNum: Int, text: String)] = Nil)
 
@@ -165,7 +163,7 @@ case class NotFoundHint(symbol: String, fileCount: Int, parseFailures: Int, cmd:
 case class MemberSectionData(
   file: Path, ownerKind: SymbolKind, packageName: String, line: Int,
   ownMembers: List[MemberInfo],
-  inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])],
+  inherited: List[InheritedGroup],
   companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] = None
 )
 
@@ -177,7 +175,6 @@ case class OverviewData(
   topPackages: List[(pkg: String, count: Int)],
   mostExtended: List[(name: String, count: Int, signature: String)],
   pkgDeps: Map[String, Set[String]],
-  hubTypes: List[(name: String, score: Int, signature: String)],
   hasArchitecture: Boolean,
   focusPackage: Option[String] = None
 )
@@ -186,11 +183,11 @@ case class TestCaseResult(name: String, line: Int, body: Option[BodyInfo])
 case class TestSuiteResult(name: String, file: Path, line: Int, tests: List[TestCaseResult])
 
 enum CmdResult:
-  case SymbolList(header: String, symbols: List[SymbolInfo], total: Int, emptyMessage: String = "", truncate: Boolean = true)
+  case SymbolList(header: String, symbols: List[SymbolInfo], emptyMessage: String = "", truncate: Boolean = true)
   case RefList(header: String, refs: List[Reference], timedOut: Boolean, hint: Option[String] = None, useContext: Boolean = true, emptyMessage: String = "", stderrHint: Option[String] = None)
   case CategorizedRefs(symbol: String, grouped: Map[RefCategory, List[Reference]], targetPkgs: Set[String], timedOut: Boolean, stderrHint: Option[String] = None)
   case FlatRefs(symbol: String, refs: List[Reference], targetPkgs: Set[String], timedOut: Boolean)
-  case StringList(header: String, items: List[String], total: Int, emptyMessage: String = "")
+  case StringList(header: String, items: List[String], emptyMessage: String = "")
   case IndexStats(fileCount: Int, symbolCount: Int, packageCount: Int, symbolsByKind: List[(kind: SymbolKind, count: Int)], indexTimeMs: Long, cachedLoad: Boolean, parsedCount: Int, skippedCount: Int, parseFailures: Int, parseFailedFiles: List[String])
   case MemberSections(symbol: String, sections: List[MemberSectionData])
   case DocEntries(symbol: String, entries: List[DocEntryData])
@@ -205,12 +202,12 @@ enum CmdResult:
     companion: Option[(sym: SymbolInfo, members: List[MemberInfo])] = None,
     expandedImpls: List[ExplainedImpl] = Nil,
     otherMatches: List[String] = Nil, totalImpls: Int = 0,
-    inherited: List[(parentName: String, parentFile: Option[Path], parentPackage: String, members: List[MemberInfo])] = Nil,
+    inherited: List[InheritedGroup] = Nil,
     relatedTypes: List[SymbolInfo] = Nil)
   case Dependencies(symbol: String, importDeps: List[DepInfo], bodyDeps: List[DepInfo])
   case Scopes(file: Path, line: Int, scopes: List[ScopeInfo])
   case SymbolDiff(ref: String, filesChanged: Int, added: List[DiffSymbol], removed: List[DiffSymbol], modified: List[(before: DiffSymbol, after: DiffSymbol)])
-  case AstMatches(filters: String, results: List[AstPatternMatch])
+  case AstMatches(filters: String, results: List[SymbolInfo])
   case GrepCount(matches: Int, files: Int, timedOut: Boolean, hint: Option[String] = None, stderrHint: Option[String] = None)
   case GrepByMethod(pattern: String, owner: String, methods: List[MethodGrepMatch], hint: Option[String] = None, stderrHint: Option[String] = None, timedOut: Boolean = false)
   case Packages(packages: List[String])
@@ -224,3 +221,5 @@ enum CmdResult:
   case GraphOutput(text: String)
   case NotFound(message: String, hint: NotFoundHint)
   case UsageError(message: String)
+  /** The command printed its own output; the renderer does nothing. */
+  case Silent

--- a/tests/analysis.test.scala
+++ b/tests/analysis.test.scala
@@ -14,9 +14,8 @@ class AnalysisSuite extends ScalexTestBase:
     val tree = result.get
     assertEquals(tree.root.name, "UserServiceLive")
     assert(!tree.root.isExternal, "Root should not be external")
-    assert(tree.root.kind.contains(SymbolKind.Class), s"Should be a class: ${tree.root.kind}")
-    assert(tree.root.file.isDefined, "Root should have a file")
-    assert(tree.root.line.isDefined, "Root should have a line")
+    assert(tree.root.sym.map(_.kind).contains(SymbolKind.Class), s"Should be a class: ${tree.root.sym.map(_.kind)}")
+    assert(tree.root.sym.isDefined, "Root should have a resolved symbol")
   }
 
   test("buildHierarchy returns root for UserService trait") {

--- a/tests/graph.test.scala
+++ b/tests/graph.test.scala
@@ -17,32 +17,32 @@ class GraphSuite extends munit.FunSuite:
 
   test("render with ASCII mode"):
     val graph = asciiGraph.Graph(Set("X", "Y"), List(("X", "Y")))
-    val prefs = asciiGraph.LayoutPrefsImpl(unicode = false)
+    val prefs = asciiGraph.LayoutPrefs(unicode = false)
     val result = asciiGraph.GraphLayout.renderGraph(graph, layoutPrefs = prefs)
     assert(result.contains("+"))
     assert(!result.contains("┌"))
 
   test("render with unicode mode"):
     val graph = asciiGraph.Graph(Set("X", "Y"), List(("X", "Y")))
-    val prefs = asciiGraph.LayoutPrefsImpl(unicode = true)
+    val prefs = asciiGraph.LayoutPrefs(unicode = true)
     val result = asciiGraph.GraphLayout.renderGraph(graph, layoutPrefs = prefs)
     assert(result.contains("┌") || result.contains("╭"))
 
   test("render with rounded corners"):
     val graph = asciiGraph.Graph(Set("X", "Y"), List(("X", "Y")))
-    val prefs = asciiGraph.LayoutPrefsImpl(unicode = true, rounded = true)
+    val prefs = asciiGraph.LayoutPrefs(unicode = true, rounded = true)
     val result = asciiGraph.GraphLayout.renderGraph(graph, layoutPrefs = prefs)
     assert(result.contains("╭"))
 
   test("render with double borders"):
     val graph = asciiGraph.Graph(Set("X", "Y"), List(("X", "Y")))
-    val prefs = asciiGraph.LayoutPrefsImpl(unicode = true, doubleVertices = true)
+    val prefs = asciiGraph.LayoutPrefs(unicode = true, doubleVertices = true)
     val result = asciiGraph.GraphLayout.renderGraph(graph, layoutPrefs = prefs)
     assert(result.contains("╔"))
 
   test("render horizontal layout"):
     val graph = asciiGraph.Graph(Set("A", "B"), List(("A", "B")))
-    val prefs = asciiGraph.LayoutPrefsImpl(vertical = false)
+    val prefs = asciiGraph.LayoutPrefs(vertical = false)
     val result = asciiGraph.GraphLayout.renderGraph(graph, layoutPrefs = prefs)
     assert(result.contains("A"))
     assert(result.contains(">"))
@@ -98,6 +98,18 @@ class GraphSuite extends munit.FunSuite:
     val diagram = asciiGraph.Diagram(input)
     assert(diagram.allBoxes.head.text.trim.contains("Hello"))
 
+  test("parse box containing two sibling boxes"):
+    val input =
+      """┌─────────────────┐
+        |│ ┌───┐  ┌───┐    │
+        |│ │ A │  │ B │    │
+        |│ └───┘  └───┘    │
+        |└─────────────────┘""".stripMargin
+    val diagram = asciiGraph.Diagram(input)
+    assertEquals(diagram.allBoxes.size, 3)
+    assertEquals(diagram.childBoxes.size, 1, "only the outer box is a direct child of the diagram")
+    assertEquals(diagram.childBoxes.head.childBoxes.map(_.text.trim).toSet, Set("A", "B"))
+
   // ── Round-trip tests ──────────────────────────────────────────────────────
 
   test("render then parse round-trip"):
@@ -149,18 +161,6 @@ class GraphSuite extends munit.FunSuite:
     val g = asciiGraph.Graph(Set(1, 2, 3), List((1, 2), (2, 3)))
     assertEquals(g.sources, List(1))
     assertEquals(g.sinks, List(3))
-
-  test("Graph cycle detection"):
-    val acyclic = asciiGraph.Graph(Set(1, 2), List((1, 2)))
-    assert(!asciiGraph.GraphUtils.hasCycle(acyclic))
-    val cyclic = asciiGraph.Graph(Set(1, 2), List((1, 2), (2, 1)))
-    assert(asciiGraph.GraphUtils.hasCycle(cyclic))
-
-  test("topological sort"):
-    val g = asciiGraph.Graph(Set(1, 2, 3), List((1, 2), (2, 3)))
-    val sorted = asciiGraph.GraphUtils.topologicalSort(g)
-    assert(sorted.isDefined)
-    assertEquals(sorted.get, List(1, 2, 3))
 
   test("render graph with cycle"):
     val graph = asciiGraph.Graph(Set("A", "B"), List(("A", "B"), ("B", "A")))


### PR DESCRIPTION
## Summary

A simplicity-focused review pass over the whole codebase: **−453 lines net** with no behavior change beyond the items below. Hard-dead code is deleted, single-implementation abstractions are collapsed, parallel types are folded into the ones they duplicated — and the review surfaced two real bugs in the diagram parser, fixed test-first.

## Bug fixes

- **`Diagram` parsing dropped sibling nested boxes**: containment pairs went through a `.toMap` keyed by the outer box, so a box containing two boxes kept only the last pair — the other box was wrongly promoted to a top-level child and its border characters leaked into the parent's text. Each box now links to its smallest container. Regression test added (failing first, per the bug-fix workflow).
- **`collectText` was accidentally quadratic**: it rebuilt the all-edge-labels point set once per scanned character (O(edges × area) per box cell). Hoisted to a lazy val.

## graph module (−301 lines)

- Deleted with zero callers (verified by grep across all source dirs): `EdgeType` + `connections`/`otherBox`/`hasArrow`/`otherHasArrow`, `CrossingCalculator`, `OccupancyGrid`, `GraphUtils.topologicalSort`/`hasCycle` (which carried a reversed-tuple bug — further evidence it was unexercised), six unused `Graph` methods, the `QuadTree.collisions` chain, and a set of single-use or stdlib-equivalent `Utils` helpers.
- Collapsed single-implementation abstractions: the `Lens` machinery (existed only to update one of four `QuadNode` children) → a plain child list with `indexWhere`/`updated`; `VertexRenderingStrategy` (one implementation ever, forced two `asInstanceOf` casts) → a plain object; the `LayoutPrefs`/`RendererPrefs`/`LayoutPrefsImpl` trait tower → one case class.
- Renderer: twelve near-identical per-character defs → three indexed glyph strings; fixed the swapped `lineHorizontalChar`/`lineVerticalChar` names; `Direction` is now a Scala 3 enum.

## src/ (−152 lines)

- Parallel types deleted: `AstPatternMatch` (field-for-field clone of `SymbolInfo`), dead `CategorizedRef`, `OverviewData.hubTypes` (identical projection of `mostExtended`), write-only `SymbolList.total`/`StringList.total` and `TestCaseInfo.suiteName`/`suiteFile`. `HierarchyNode`'s four convention-coupled `Option` fields are one `Option[SymbolInfo]`; the `symbols --summary` magic-empty sentinel is an explicit `CmdResult.Silent`.
- Logic folds: `index()`'s cached/uncached parse branches are one path; `search`/`searchFiles` share one tier-bucketing helper; `findImplementations`, `fixPosixRegex`, and `cmdGrep` lost copy-pasted branches; `grepInSymbol` reads each file once per owner and no longer discards results on an unreadable file; `renderCategorizedRefs` resolves confidence once per ref instead of once per confidence level; overview/index-stats/entrypoints renderers share their duplicated print blocks.

## Behavior changes (intentional, per the no-backwards-compat policy)

- `ast-pattern --json` now shares `jsonSymbol` and gains `parents`/`typeParamParents`/`annotations` fields.
- `graph --parse` reports correct box nesting for sibling boxes (the bug fix).

## Benchmarks (scala3 corpus, 17.7k files)

- Index size: **byte-identical** (22,424,472 B)
- Cold index: 3.16 s → 2.79 s (−12%); warm index and all index-backed queries at parity (±1%)
- `refs`/`imports` show ~10% native-binary slowdown isolated to the **untouched** index-deserialization phase, with exact JVM parity (cache-load 237 ms on both sides, verified against a HEAD worktree) — the same GraalVM GC-pacing artifact documented in the changelog previously, this time from the binary shrinking 42→40 MB.

## Test plan

- New regression test for sibling nested boxes (verified failing before the fix)
- Full suite green: 432 tests across 6 suites
- Zero compiler warnings, zero deprecations
- Commit 1 verified to compile and pass standalone against the previous src/ (bisect-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)