### PR TITLE
feat(scalex): support Codex CLI and desktop plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "scalex-marketplace",
+  "interface": {
+    "displayName": "Scalex"
+  },
+  "plugins": [
+    {
+      "name": "scalex",
+      "source": {
+        "source": "local",
+        "path": "./plugins/scalex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ scala-cli test src/ tests/
 ./build-native.sh
 # Output: ./scalex (26MB standalone binary)
 
-# Validate Codex plugin structure
-Codex plugin validate plugins/scalex/
+# Validate shared skill frontmatter
+./scripts/check-skill-frontmatter.sh
 ```
 
 ## Architecture
@@ -112,7 +112,8 @@ git ls-files --stage → Scalameta parse → in-memory index → query
 ```
 plugins/
 └── scalex/                        # scalex plugin
-    ├── .Codex-plugin/plugin.json
+    ├── .claude-plugin/plugin.json # Claude Code manifest
+    ├── .codex-plugin/plugin.json  # Codex CLI/desktop manifest
     └── skills/scalex/
         ├── SKILL.md
         ├── references/
@@ -134,10 +135,10 @@ The bootstrap script `scalex-cli` contains `EXPECTED_VERSION` that must be bumpe
 ### Step 3: Plugin version bump
 5. Bump `EXPECTED_VERSION` in `plugins/scalex/skills/scalex/scripts/scalex-cli`
 6. Update `CHECKSUM_scalex_*` values in `scalex-cli` — get hashes from individual `.sha256` release assets (iterate: `gh release view vX.Y.Z --json assets --jq '.assets[] | select(.name | endswith(".sha256")) | .name'` then download each with `gh release download vX.Y.Z -p <name> -O -`)
-7. Bump `version` in `.Codex-plugin/marketplace.json` (plugin version is only managed here, not in `plugins/scalex/.Codex-plugin/plugin.json`)
+7. Bump `version` in `.claude-plugin/marketplace.json` and `plugins/scalex/.codex-plugin/plugin.json` alongside the bootstrap version
 8. Commit, create PR, merge to main (main is protected — cannot push directly)
 
-Note: `marketplace.json` is at the repo root (`.Codex-plugin/marketplace.json`), NOT inside `plugins/`.
+Marketplace catalogs: Claude Code uses `.claude-plugin/marketplace.json`; Codex uses `.agents/plugins/marketplace.json`. Both point to `plugins/scalex/` and share its skill and bootstrap. Codex's version is in its plugin manifest, not its marketplace catalog.
 
 ## Feature checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Codex CLI and desktop plugin packaging and repository marketplace, sharing the existing skill and binary bootstrap with Claude Code.
+
 ### Fixed
 - `graph --parse` no longer drops sibling nested boxes: a box containing two or more boxes side by side wrongly promoted all but one of them to top level (and leaked their border characters into the parent's text). Box containment is now resolved by linking each box to its smallest container
 - `grep --in <owner>`: an unreadable file no longer discards matches already found in other files defining the same owner; the file is skipped instead

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here's the architecture (generated with `scalex graph --render`):
 
 ## Quick Start
 
-### Claude Code (recommended)
+### Claude Code
 
 Installs the binary + skill (teaches Claude when and how to use scalex) in one step:
 
@@ -147,6 +147,23 @@ Installs the binary + skill (teaches Claude when and how to use scalex) in one s
 Then try:
 
 > *"use scalex to explore how authentication works in this codebase"*
+
+### Codex CLI and desktop
+
+Run these commands in your terminal:
+
+```bash
+codex plugin marketplace add nguyenyou/scalex
+codex plugin add scalex@scalex-marketplace
+```
+
+Start a new Codex CLI session or desktop task, then ask:
+
+> *"Use scalex to explore how this project works."*
+
+The plugin includes the same skill and bootstrap as the Claude Code plugin. The bootstrap downloads and verifies the native binary on first use; Codex may request permission for the download or cache write. Supported platforms: macOS arm64/x64 and Linux x64. The IDE extension is not part of this plugin support.
+
+Requires a Codex CLI with `codex plugin` commands. Installation is from this repository's marketplace; Scalex is not yet listed in OpenAI's public plugin directory.
 
 ### Other coding agents
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- [x] Codex CLI and desktop plugin packaging, marketplace installation, and shared skill validation (local install verified with Codex CLI 0.153.4)
+- [ ] Publish Codex marketplace changes and verify installation from GitHub; optionally submit to OpenAI's public plugin directory
 - [ ] Publish plugin to Claude Code marketplace
 
 ### Simplicity review: remove dead code and single-use abstractions (no behavior change except noted)

--- a/plugins/scalex/.codex-plugin/plugin.json
+++ b/plugins/scalex/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "scalex",
+  "version": "1.40.0",
+  "description": "Scala/Java code intelligence — find definitions, implementations, references, and explore code without a compiler or build server.",
+  "author": {
+    "name": "Tu Nguyen"
+  },
+  "homepage": "https://github.com/nguyenyou/scalex",
+  "repository": "https://github.com/nguyenyou/scalex",
+  "license": "MIT",
+  "keywords": ["scala", "java", "code-intelligence", "navigation"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Scalex",
+    "shortDescription": "Explore Scala and Java code without a build server",
+    "longDescription": "Navigate definitions, implementations, references, imports, and type hierarchies in Scala and Java projects. The bundled skill downloads and verifies the native CLI on first use.",
+    "developerName": "Tu Nguyen",
+    "category": "Developer Tools",
+    "capabilities": [],
+    "websiteURL": "https://github.com/nguyenyou/scalex",
+    "defaultPrompt": ["Use scalex to explore how this project works."]
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1424,19 +1424,17 @@
         </div>
         <div class="install-block reveal">
           <span class="comment"
-            ># Other coding agents — just copy the skill folder</span
+            ># Codex CLI and desktop — run in your terminal</span
           ><br />
           <span class="t-cmd"
-            >git clone --depth 1
-            https://github.com/nguyenyou/scalex.git /tmp/scalex</span
+            >codex plugin marketplace add nguyenyou/scalex</span
           ><br />
           <span class="t-cmd"
-            >cp -r /tmp/scalex/plugins/scalex/skills/scalex
-            /path/to/your/agent/skills/</span
+            >codex plugin add scalex@scalex-marketplace</span
           ><br />
           <br />
           <span class="comment"
-            ># Bootstrap script auto-downloads the binary on first run</span
+            ># Start a new task; the binary downloads on first use</span
           >
         </div>
       </div>


### PR DESCRIPTION
Adds installable Scalex plugin support for Codex CLI and desktop. Users can register this repository's marketplace and install `scalex@scalex-marketplace`, reusing the existing Claude Code skill, references, and native binary bootstrap.

Includes the Codex manifest and marketplace catalog, installation instructions in the README and website, and release guidance to keep plugin versions aligned. Public OpenAI directory submission remains a separate step.

Validation:
- Official plugin validator passed.
- Shared skill frontmatter and `git diff --check` passed.
- Local marketplace registration and installation verified with Codex CLI 0.153.4; plugin listed as installed and enabled.
- Installed bootstrap returned Scalex 1.40.0.
- Scala compilation is not required for these metadata/documentation changes; the unnecessary compile was stopped.

GitHub-source installation and fresh-task automatic skill selection have not yet been verified.
